### PR TITLE
Use tree-sitter for python AST

### DIFF
--- a/tests/json-ast/x/py/append_builtin.py.json
+++ b/tests/json-ast/x/py/append_builtin.py.json
@@ -1,120 +1,104 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 119,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "a",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 6
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 10
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 10
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "a",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 103,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 103,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "List",
-                "elts": [
+              {
+                "kind": "list",
+                "start": 97,
+                "end": 103,
+                "children": [
                   {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 11,
-                    "end_col_offset": 12
+                    "kind": "integer",
+                    "start": 98,
+                    "end": 99
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
                   }
-                ],
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 10,
-                "end_col_offset": 13
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 104,
+        "end": 118,
+        "children": [
+          {
+            "kind": "call",
+            "start": 104,
+            "end": 118,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 104,
+                "end": 109
               },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 13
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 14
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 14
+              {
+                "kind": "argument_list",
+                "start": 109,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 110,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 110,
+                        "end": 111
+                      },
+                      {
+                        "kind": "list",
+                        "start": 114,
+                        "end": 117,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 115,
+                            "end": 116
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/avg_builtin.py.json
+++ b/tests/json-ast/x/py/avg_builtin.py.json
@@ -1,218 +1,174 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 156,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "List",
-                "elts": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 155,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 155,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
+              },
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 155,
+                "children": [
                   {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 43,
-                    "end_col_offset": 44
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 46,
-                    "end_col_offset": 47
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 49,
-                    "end_col_offset": 50
+                    "kind": "parenthesized_expression",
+                    "start": 99,
+                    "end": 154,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 100,
+                        "end": 153,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 100,
+                            "end": 131,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 100,
+                                "end": 114,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 100,
+                                    "end": 103
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 103,
+                                    "end": 114,
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "start": 104,
+                                        "end": 113,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 105,
+                                            "end": 106
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 108,
+                                            "end": 109
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 111,
+                                            "end": 112
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 117,
+                                "end": 131,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 117,
+                                    "end": 120
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 120,
+                                    "end": 131,
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "start": 121,
+                                        "end": 130,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 122,
+                                            "end": 123
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 125,
+                                            "end": 126
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 128,
+                                            "end": 129
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "list",
+                            "start": 135,
+                            "end": 144,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 136,
+                                "end": 137
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 139,
+                                "end": 140
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 142,
+                                "end": 143
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "float",
+                            "start": 150,
+                            "end": 153
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 42,
-                "end_col_offset": 51
-              },
-              "body": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "sum",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 7,
-                    "end_col_offset": 10
-                  },
-                  "args": [
-                    {
-                      "_type": "List",
-                      "elts": [
-                        {
-                          "_type": "Constant",
-                          "value": 1,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 12,
-                          "end_col_offset": 13
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": 2,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 15,
-                          "end_col_offset": 16
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": 3,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 18,
-                          "end_col_offset": 19
-                        }
-                      ],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 20
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 7,
-                  "end_col_offset": 21
-                },
-                "op": {
-                  "_type": "Div"
-                },
-                "right": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "len",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 24,
-                    "end_col_offset": 27
-                  },
-                  "args": [
-                    {
-                      "_type": "List",
-                      "elts": [
-                        {
-                          "_type": "Constant",
-                          "value": 1,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 29,
-                          "end_col_offset": 30
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": 2,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 32,
-                          "end_col_offset": 33
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": 3,
-                          "kind": null,
-                          "lineno": 3,
-                          "end_lineno": 3,
-                          "col_offset": 35,
-                          "end_col_offset": 36
-                        }
-                      ],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 28,
-                      "end_col_offset": 37
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 24,
-                  "end_col_offset": 38
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 7,
-                "end_col_offset": 38
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0.0,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 57,
-                "end_col_offset": 60
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 7,
-              "end_col_offset": 60
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 62
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 62
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/basic_compare.py.json
+++ b/tests/json-ast/x/py/basic_compare.py.json
@@ -1,302 +1,255 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 178,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 103,
+        "children": [
           {
-            "_type": "Name",
-            "id": "a",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 103,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "binary_operator",
+                "start": 97,
+                "end": 103,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 97,
+                    "end": 99
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 102,
+                    "end": 103
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "Constant",
-            "value": 10,
-            "kind": null,
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 4,
-            "end_col_offset": 6
-          },
-          "op": {
-            "_type": "Sub"
-          },
-          "right": {
-            "_type": "Constant",
-            "value": 3,
-            "kind": null,
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 9,
-            "end_col_offset": 10
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 10
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 10
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 104,
+        "end": 113,
+        "children": [
           {
-            "_type": "Name",
-            "id": "b",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 104,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 104,
+                "end": 105
+              },
+              {
+                "kind": "binary_operator",
+                "start": 108,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 108,
+                    "end": 109
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 112,
+                    "end": 113
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "Constant",
-            "value": 2,
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 5
-          },
-          "op": {
-            "_type": "Add"
-          },
-          "right": {
-            "_type": "Constant",
-            "value": 2,
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 8,
-            "end_col_offset": 9
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 9
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "a",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 122,
+        "children": [
+          {
+            "kind": "call",
+            "start": 114,
+            "end": 122,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 119
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 7
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 8
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 8
+              {
+                "kind": "argument_list",
+                "start": 119,
+                "end": 122,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 120,
+                    "end": 121
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "a",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 123,
+        "end": 150,
+        "children": [
+          {
+            "kind": "call",
+            "start": 123,
+            "end": 150,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 123,
+                "end": 128
+              },
+              {
+                "kind": "argument_list",
+                "start": 128,
+                "end": 150,
+                "children": [
                   {
-                    "_type": "Eq"
+                    "kind": "parenthesized_expression",
+                    "start": 129,
+                    "end": 149,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 130,
+                        "end": 148,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 130,
+                            "end": 131
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 135,
+                            "end": 141,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 135,
+                                "end": 136
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 140,
+                                "end": 141
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 147,
+                            "end": 148
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 7,
-                    "kind": null,
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  }
-                ],
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 18
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 24,
-                "end_col_offset": 25
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 27
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 27
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "b",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 151,
+        "end": 177,
+        "children": [
+          {
+            "kind": "call",
+            "start": 151,
+            "end": 177,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 151,
+                "end": 156
+              },
+              {
+                "kind": "argument_list",
+                "start": 156,
+                "end": 177,
+                "children": [
                   {
-                    "_type": "Lt"
+                    "kind": "parenthesized_expression",
+                    "start": 157,
+                    "end": 176,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 158,
+                        "end": 175,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 158,
+                            "end": 159
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 163,
+                            "end": 168,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 163,
+                                "end": 164
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 167,
+                                "end": 168
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 174,
+                            "end": 175
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 5,
-                    "kind": null,
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 16,
-                    "end_col_offset": 17
-                  }
-                ],
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 12,
-                "end_col_offset": 17
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 23,
-                "end_col_offset": 24
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 24
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 26
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 26
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/bench_block.py.json
+++ b/tests/json-ast/x/py/bench_block.py.json
@@ -1,932 +1,1041 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 742,
+    "children": [
       {
-        "_type": "Import",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Import",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 9
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Import",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "Import",
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "sys",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 0,
-              "end_col_offset": 3
-            },
-            "attr": "set_int_max_str_digits",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 0,
-            "end_col_offset": 26
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 0,
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 27,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "_now_seed",
-            "lineno": 11,
-            "end_lineno": 11,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 0,
-          "kind": null,
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 12,
-          "end_col_offset": 13
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_now_seeded",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 11
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": false,
-          "kind": null,
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 14,
-          "end_col_offset": 19
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "os",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "attr": "getenv",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "MOCHI_NOW_SEED",
-              "kind": null,
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 14,
-              "end_col_offset": 30
-            }
-          ],
-          "keywords": [],
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 4,
-          "end_col_offset": 31
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 31
-      },
-      {
-        "_type": "If",
-        "body": [
-          {
-            "_type": "Try",
-            "body": [
+            "kind": "dotted_name",
+            "start": 100,
+            "end": 104,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Name",
-                    "id": "_now_seed",
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 8,
-                    "end_col_offset": 17
-                  }
-                ],
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "int",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 20,
-                    "end_col_offset": 23
-                  },
-                  "args": [
-                    {
-                      "_type": "Name",
-                      "id": "s",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 16,
-                      "end_lineno": 16,
-                      "col_offset": 24,
-                      "end_col_offset": 25
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 20,
-                  "end_col_offset": 26
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 8,
-                "end_col_offset": 26
-              },
-              {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Name",
-                    "id": "_now_seeded",
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 8,
-                    "end_col_offset": 19
-                  }
-                ],
-                "value": {
-                  "_type": "Constant",
-                  "value": true,
-                  "kind": null,
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 22,
-                  "end_col_offset": 26
-                },
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 8,
-                "end_col_offset": 26
+                "kind": "identifier",
+                "start": 100,
+                "end": 104
               }
-            ],
-            "lineno": 15,
-            "end_lineno": 19,
-            "col_offset": 4,
-            "end_col_offset": 12
+            ]
           }
-        ],
-        "test": {
-          "_type": "BoolOp",
-          "op": {
-            "_type": "And"
-          },
-          "values": [
-            {
-              "_type": "Name",
-              "id": "s",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 3,
-              "end_col_offset": 4
-            },
-            {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "s",
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 9,
-                "end_col_offset": 10
-              },
-              "ops": [
-                {
-                  "_type": "NotEq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": "",
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 14,
-                  "end_col_offset": 16
-                }
-              ],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 9,
-              "end_col_offset": 16
-            }
-          ],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 3,
-          "end_col_offset": 16
-        },
-        "lineno": 14,
-        "end_lineno": 19,
-        "end_col_offset": 12
+        ]
       },
       {
-        "_type": "FunctionDef",
-        "name": "_now",
-        "body": [
+        "kind": "import_statement",
+        "start": 105,
+        "end": 114,
+        "children": [
           {
-            "_type": "Global",
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "If",
-            "body": [
+            "kind": "dotted_name",
+            "start": 112,
+            "end": 114,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
+                "kind": "identifier",
+                "start": 112,
+                "end": 114
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 115,
+        "end": 126,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 122,
+            "end": 126,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 122,
+                "end": 126
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 128,
+        "end": 138,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 135,
+            "end": 138,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 135,
+                "end": 138
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 139,
+        "end": 168,
+        "children": [
+          {
+            "kind": "call",
+            "start": 139,
+            "end": 168,
+            "children": [
+              {
+                "kind": "attribute",
+                "start": 139,
+                "end": 165,
+                "children": [
                   {
-                    "_type": "Name",
-                    "id": "_now_seed",
-                    "lineno": 24,
-                    "end_lineno": 24,
-                    "col_offset": 8,
-                    "end_col_offset": 17
+                    "kind": "identifier",
+                    "start": 139,
+                    "end": 142
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 143,
+                    "end": 165
                   }
-                ],
-                "value": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "BinOp",
-                    "left": {
-                      "_type": "BinOp",
-                      "left": {
-                        "_type": "Name",
-                        "id": "_now_seed",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 24,
-                        "end_lineno": 24,
-                        "col_offset": 21,
-                        "end_col_offset": 30
-                      },
-                      "op": {
-                        "_type": "Mult"
-                      },
-                      "right": {
-                        "_type": "Constant",
-                        "value": 1664525,
-                        "kind": null,
-                        "lineno": 24,
-                        "end_lineno": 24,
-                        "col_offset": 33,
-                        "end_col_offset": 40
-                      },
-                      "lineno": 24,
-                      "end_lineno": 24,
-                      "col_offset": 21,
-                      "end_col_offset": 40
-                    },
-                    "op": {
-                      "_type": "Add"
-                    },
-                    "right": {
-                      "_type": "Constant",
-                      "value": 1013904223,
-                      "kind": null,
-                      "lineno": 24,
-                      "end_lineno": 24,
-                      "col_offset": 43,
-                      "end_col_offset": 53
-                    },
-                    "lineno": 24,
-                    "end_lineno": 24,
-                    "col_offset": 21,
-                    "end_col_offset": 53
-                  },
-                  "op": {
-                    "_type": "Mod"
-                  },
-                  "right": {
-                    "_type": "Constant",
-                    "value": 2147483647,
-                    "kind": null,
-                    "lineno": 24,
-                    "end_lineno": 24,
-                    "col_offset": 57,
-                    "end_col_offset": 67
-                  },
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 20,
-                  "end_col_offset": 67
-                },
-                "lineno": 24,
-                "end_lineno": 24,
-                "col_offset": 8,
-                "end_col_offset": 67
+                ]
               },
               {
-                "_type": "Return",
-                "value": {
-                  "_type": "Name",
-                  "id": "_now_seed",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 15,
-                  "end_col_offset": 24
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 8,
-                "end_col_offset": 24
+                "kind": "argument_list",
+                "start": 165,
+                "end": 168,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 166,
+                    "end": 167
+                  }
+                ]
               }
-            ],
-            "test": {
-              "_type": "Name",
-              "id": "_now_seeded",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 7,
-              "end_col_offset": 18
-            },
-            "lineno": 23,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 24
-          },
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "int",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 11,
-                "end_col_offset": 14
-              },
-              "args": [
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "time",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 26,
-                      "end_lineno": 26,
-                      "col_offset": 15,
-                      "end_col_offset": 19
-                    },
-                    "attr": "time_ns",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 26,
-                    "end_lineno": 26,
-                    "col_offset": 15,
-                    "end_col_offset": 27
-                  },
-                  "args": [],
-                  "keywords": [],
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 15,
-                  "end_col_offset": 29
-                }
-              ],
-              "keywords": [],
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 11,
-              "end_col_offset": 30
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 30
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 21,
-        "end_lineno": 26,
-        "end_col_offset": 30
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 171,
+        "end": 184,
+        "children": [
           {
-            "_type": "Name",
-            "id": "_bench_start",
-            "lineno": 28,
-            "end_lineno": 28,
-            "end_col_offset": 12
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "_now",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 15,
-            "end_col_offset": 19
-          },
-          "args": [],
-          "keywords": [],
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 15,
-          "end_col_offset": 21
-        },
-        "lineno": 28,
-        "end_lineno": 28,
-        "end_col_offset": 21
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "n",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 1000,
-          "kind": null,
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 4,
-          "end_col_offset": 8
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 8
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 30,
-            "end_lineno": 30,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 0,
-          "kind": null,
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 5
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "assignment",
+            "start": 171,
+            "end": 184,
+            "children": [
               {
-                "_type": "Name",
-                "id": "s",
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 4,
-                "end_col_offset": 5
+                "kind": "identifier",
+                "start": 171,
+                "end": 180
+              },
+              {
+                "kind": "integer",
+                "start": 183,
+                "end": 184
               }
-            ],
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "s",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 8,
-                "end_col_offset": 9
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 12,
-                "end_col_offset": 13
-              },
-              "lineno": 32,
-              "end_lineno": 32,
-              "col_offset": 8,
-              "end_col_offset": 13
-            },
-            "lineno": 32,
-            "end_lineno": 32,
-            "col_offset": 4,
-            "end_col_offset": 13
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "i",
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "range",
-            "lineno": 31,
-            "end_lineno": 31,
-            "col_offset": 9,
-            "end_col_offset": 14
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 15,
-              "end_col_offset": 16
-            },
-            {
-              "_type": "Name",
-              "id": "n",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 9,
-          "end_col_offset": 20
-        },
-        "lineno": 31,
-        "end_lineno": 32,
-        "end_col_offset": 13
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 185,
+        "end": 204,
+        "children": [
           {
-            "_type": "Name",
-            "id": "_bench_end",
-            "lineno": 33,
-            "end_lineno": 33,
-            "end_col_offset": 10
+            "kind": "assignment",
+            "start": 185,
+            "end": 204,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 185,
+                "end": 196
+              },
+              {
+                "kind": "false",
+                "start": 199,
+                "end": 204
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "_now",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 33,
-            "end_lineno": 33,
-            "col_offset": 13,
-            "end_col_offset": 17
-          },
-          "args": [],
-          "keywords": [],
-          "lineno": 33,
-          "end_lineno": 33,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 33,
-        "end_lineno": 33,
-        "end_col_offset": 19
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "json",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "attr": "dumps",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 34,
-                "end_lineno": 34,
-                "col_offset": 6,
-                "end_col_offset": 16
+        "kind": "expression_statement",
+        "start": 205,
+        "end": 236,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 205,
+            "end": 236,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 205,
+                "end": 206
               },
-              "args": [
-                {
-                  "_type": "Dict",
-                  "keys": [
-                    {
-                      "_type": "Constant",
-                      "value": "duration_us",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 18,
-                      "end_col_offset": 31
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "memory_bytes",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 68,
-                      "end_col_offset": 82
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "name",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 87,
-                      "end_col_offset": 93
-                    }
-                  ],
-                  "values": [
-                    {
-                      "_type": "BinOp",
-                      "left": {
-                        "_type": "BinOp",
-                        "left": {
-                          "_type": "Name",
-                          "id": "_bench_end",
-                          "ctx": {
-                            "_type": "Load"
+              {
+                "kind": "call",
+                "start": 209,
+                "end": 236,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 209,
+                    "end": 218,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 209,
+                        "end": 211
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 212,
+                        "end": 218
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 218,
+                    "end": 236,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 219,
+                        "end": 235,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 219,
+                            "end": 220
                           },
-                          "lineno": 34,
-                          "end_lineno": 34,
-                          "col_offset": 34,
-                          "end_col_offset": 44
-                        },
-                        "op": {
-                          "_type": "Sub"
-                        },
-                        "right": {
-                          "_type": "Name",
-                          "id": "_bench_start",
-                          "ctx": {
-                            "_type": "Load"
+                          {
+                            "kind": "string_content",
+                            "start": 220,
+                            "end": 234
                           },
-                          "lineno": 34,
-                          "end_lineno": 34,
-                          "col_offset": 47,
-                          "end_col_offset": 59
-                        },
-                        "lineno": 34,
-                        "end_lineno": 34,
-                        "col_offset": 34,
-                        "end_col_offset": 59
-                      },
-                      "op": {
-                        "_type": "FloorDiv"
-                      },
-                      "right": {
-                        "_type": "Constant",
-                        "value": 1000,
-                        "kind": null,
-                        "lineno": 34,
-                        "end_lineno": 34,
-                        "col_offset": 62,
-                        "end_col_offset": 66
-                      },
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 33,
-                      "end_col_offset": 66
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 0,
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 84,
-                      "end_col_offset": 85
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "simple",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 95,
-                      "end_col_offset": 103
-                    }
-                  ],
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 17,
-                  "end_col_offset": 104
-                }
-              ],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "indent",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 34,
-                    "end_lineno": 34,
-                    "col_offset": 113,
-                    "end_col_offset": 114
+                          {
+                            "kind": "string_end",
+                            "start": 234,
+                            "end": 235
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "if_statement",
+        "start": 237,
+        "end": 352,
+        "children": [
+          {
+            "kind": "boolean_operator",
+            "start": 240,
+            "end": 253,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 240,
+                "end": 241
+              },
+              {
+                "kind": "comparison_operator",
+                "start": 246,
+                "end": 253,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 246,
+                    "end": 247
                   },
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 106,
-                  "end_col_offset": 114
-                }
-              ],
-              "lineno": 34,
-              "end_lineno": 34,
-              "col_offset": 6,
-              "end_col_offset": 115
-            }
-          ],
-          "keywords": [],
-          "lineno": 34,
-          "end_lineno": 34,
-          "col_offset": 0,
-          "end_col_offset": 116
-        },
-        "lineno": 34,
-        "end_lineno": 34,
-        "end_col_offset": 116
+                  {
+                    "kind": "string",
+                    "start": 251,
+                    "end": 253,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 251,
+                        "end": 252
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 252,
+                        "end": 253
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 259,
+            "end": 352,
+            "children": [
+              {
+                "kind": "try_statement",
+                "start": 259,
+                "end": 352,
+                "children": [
+                  {
+                    "kind": "block",
+                    "start": 272,
+                    "end": 317,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 272,
+                        "end": 290,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 272,
+                            "end": 290,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 272,
+                                "end": 281
+                              },
+                              {
+                                "kind": "call",
+                                "start": 284,
+                                "end": 290,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 284,
+                                    "end": 287
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 287,
+                                    "end": 290,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 288,
+                                        "end": 289
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 299,
+                        "end": 317,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 299,
+                            "end": 317,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 299,
+                                "end": 310
+                              },
+                              {
+                                "kind": "true",
+                                "start": 313,
+                                "end": 317
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "except_clause",
+                    "start": 322,
+                    "end": 352,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 329,
+                        "end": 338
+                      },
+                      {
+                        "kind": "block",
+                        "start": 348,
+                        "end": 352,
+                        "children": [
+                          {
+                            "kind": "pass_statement",
+                            "start": 348,
+                            "end": 352
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_definition",
+        "start": 354,
+        "end": 530,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 358,
+            "end": 362
+          },
+          {
+            "kind": "parameters",
+            "start": 362,
+            "end": 364
+          },
+          {
+            "kind": "block",
+            "start": 370,
+            "end": 530,
+            "children": [
+              {
+                "kind": "global_statement",
+                "start": 370,
+                "end": 386,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 377,
+                    "end": 386
+                  }
+                ]
+              },
+              {
+                "kind": "if_statement",
+                "start": 391,
+                "end": 499,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 394,
+                    "end": 405
+                  },
+                  {
+                    "kind": "block",
+                    "start": 415,
+                    "end": 499,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 415,
+                        "end": 474,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 415,
+                            "end": 474,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 415,
+                                "end": 424
+                              },
+                              {
+                                "kind": "binary_operator",
+                                "start": 427,
+                                "end": 474,
+                                "children": [
+                                  {
+                                    "kind": "parenthesized_expression",
+                                    "start": 427,
+                                    "end": 461,
+                                    "children": [
+                                      {
+                                        "kind": "binary_operator",
+                                        "start": 428,
+                                        "end": 460,
+                                        "children": [
+                                          {
+                                            "kind": "binary_operator",
+                                            "start": 428,
+                                            "end": 447,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 428,
+                                                "end": 437
+                                              },
+                                              {
+                                                "kind": "integer",
+                                                "start": 440,
+                                                "end": 447
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 450,
+                                            "end": 460
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 464,
+                                    "end": 474
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "return_statement",
+                        "start": 483,
+                        "end": 499,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 490,
+                            "end": 499
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "return_statement",
+                "start": 504,
+                "end": 530,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 511,
+                    "end": 530,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 511,
+                        "end": 514
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 514,
+                        "end": 530,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 515,
+                            "end": 529,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 515,
+                                "end": 527,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 515,
+                                    "end": 519
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 520,
+                                    "end": 527
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 527,
+                                "end": 529
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 532,
+        "end": 553,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 532,
+            "end": 553,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 532,
+                "end": 544
+              },
+              {
+                "kind": "call",
+                "start": 547,
+                "end": 553,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 547,
+                    "end": 551
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 551,
+                    "end": 553
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 554,
+        "end": 562,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 554,
+            "end": 562,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 554,
+                "end": 555
+              },
+              {
+                "kind": "integer",
+                "start": 558,
+                "end": 562
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 563,
+        "end": 568,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 563,
+            "end": 568,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 563,
+                "end": 564
+              },
+              {
+                "kind": "integer",
+                "start": 567,
+                "end": 568
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 569,
+        "end": 604,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 573,
+            "end": 574
+          },
+          {
+            "kind": "call",
+            "start": 578,
+            "end": 589,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 578,
+                "end": 583
+              },
+              {
+                "kind": "argument_list",
+                "start": 583,
+                "end": 589,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 584,
+                    "end": 585
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 587,
+                    "end": 588
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 595,
+            "end": 604,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 595,
+                "end": 604,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 595,
+                    "end": 604,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 595,
+                        "end": 596
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 599,
+                        "end": 604,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 599,
+                            "end": 600
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 603,
+                            "end": 604
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 605,
+        "end": 624,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 605,
+            "end": 624,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 605,
+                "end": 615
+              },
+              {
+                "kind": "call",
+                "start": 618,
+                "end": 624,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 618,
+                    "end": 622
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 622,
+                    "end": 624
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 625,
+        "end": 741,
+        "children": [
+          {
+            "kind": "call",
+            "start": 625,
+            "end": 741,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 625,
+                "end": 630
+              },
+              {
+                "kind": "argument_list",
+                "start": 630,
+                "end": 741,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 631,
+                    "end": 740,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 631,
+                        "end": 641,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 631,
+                            "end": 635
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 636,
+                            "end": 641
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 641,
+                        "end": 740,
+                        "children": [
+                          {
+                            "kind": "dictionary",
+                            "start": 642,
+                            "end": 729,
+                            "children": [
+                              {
+                                "kind": "pair",
+                                "start": 643,
+                                "end": 691,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 643,
+                                    "end": 656,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 643,
+                                        "end": 644
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 644,
+                                        "end": 655
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 655,
+                                        "end": 656
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "binary_operator",
+                                    "start": 658,
+                                    "end": 691,
+                                    "children": [
+                                      {
+                                        "kind": "parenthesized_expression",
+                                        "start": 658,
+                                        "end": 685,
+                                        "children": [
+                                          {
+                                            "kind": "binary_operator",
+                                            "start": 659,
+                                            "end": 684,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 659,
+                                                "end": 669
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 672,
+                                                "end": 684
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 687,
+                                        "end": 691
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "pair",
+                                "start": 693,
+                                "end": 710,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 693,
+                                    "end": 707,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 693,
+                                        "end": 694
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 694,
+                                        "end": 706
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 706,
+                                        "end": 707
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 709,
+                                    "end": 710
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "pair",
+                                "start": 712,
+                                "end": 728,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 712,
+                                    "end": 718,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 712,
+                                        "end": 713
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 713,
+                                        "end": 717
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 717,
+                                        "end": 718
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 720,
+                                    "end": 728,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 720,
+                                        "end": 721
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 721,
+                                        "end": 727
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 727,
+                                        "end": 728
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 731,
+                            "end": 739,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 731,
+                                "end": 737
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 738,
+                                "end": 739
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/binary_precedence.py.json
+++ b/tests/json-ast/x/py/binary_precedence.py.json
@@ -1,302 +1,252 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 165,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 7
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                },
-                "op": {
-                  "_type": "Mult"
-                },
-                "right": {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 7,
-                  "end_col_offset": 8
-                },
-                "op": {
-                  "_type": "Add"
-                },
-                "right": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 12
-              },
-              "op": {
-                "_type": "Mult"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 3,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 16,
-                "end_col_offset": 17
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 18
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 6,
-                  "end_col_offset": 7
-                },
-                "op": {
-                  "_type": "Mult"
-                },
-                "right": {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 11
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 109,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 99,
+                    "end": 108,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 99,
+                        "end": 100
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 103,
+                        "end": 108,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 103,
+                            "end": 104
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 107,
+                            "end": 108
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 2,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "expression_statement",
+        "start": 110,
+        "end": 128,
+        "children": [
+          {
+            "kind": "call",
+            "start": 110,
+            "end": 128,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 110,
+                "end": 115
               },
-              "op": {
-                "_type": "Mult"
+              {
+                "kind": "argument_list",
+                "start": 115,
+                "end": 128,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 116,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 116,
+                        "end": 123,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 117,
+                            "end": 122,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 117,
+                                "end": 118
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 121,
+                                "end": 122
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 126,
+                        "end": 127
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 129,
+        "end": 145,
+        "children": [
+          {
+            "kind": "call",
+            "start": 129,
+            "end": 145,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 129,
+                "end": 134
               },
-              "right": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "op": {
-                  "_type": "Add"
-                },
-                "right": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 11,
-                "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 134,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 135,
+                    "end": 144,
+                    "children": [
+                      {
+                        "kind": "binary_operator",
+                        "start": 135,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 135,
+                            "end": 136
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 139,
+                            "end": 140
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 143,
+                        "end": 144
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 146,
+        "end": 164,
+        "children": [
+          {
+            "kind": "call",
+            "start": 146,
+            "end": 164,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 146,
+                "end": 151
               },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
+              {
+                "kind": "argument_list",
+                "start": 151,
+                "end": 164,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 152,
+                    "end": 163,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 152,
+                        "end": 153
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 156,
+                        "end": 163,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 157,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 157,
+                                "end": 158
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 161,
+                                "end": 162
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/bool_chain.py.json
+++ b/tests/json-ast/x/py/bool_chain.py.json
@@ -1,566 +1,471 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 292,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "boom",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 138,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "boom",
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 4,
-              "end_col_offset": 17
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 17
+            "kind": "identifier",
+            "start": 97,
+            "end": 101
           },
           {
-            "_type": "Return",
-            "value": {
-              "_type": "Constant",
-              "value": true,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 15
+            "kind": "parameters",
+            "start": 101,
+            "end": 103
+          },
+          {
+            "kind": "block",
+            "start": 109,
+            "end": 138,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 109,
+                "end": 122,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 109,
+                    "end": 122,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 109,
+                        "end": 114
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 114,
+                        "end": 122,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 115,
+                            "end": 121,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 115,
+                                "end": 116
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 116,
+                                "end": 120
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 120,
+                                "end": 121
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "return_statement",
+                "start": 127,
+                "end": 138,
+                "children": [
+                  {
+                    "kind": "true",
+                    "start": 134,
+                    "end": 138
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 5,
-        "end_col_offset": 15
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "And"
-                },
-                "values": [
+        "kind": "expression_statement",
+        "start": 139,
+        "end": 185,
+        "children": [
+          {
+            "kind": "call",
+            "start": 139,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 139,
+                "end": 144
+              },
+              {
+                "kind": "argument_list",
+                "start": 144,
+                "end": 185,
+                "children": [
                   {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 12,
-                      "end_col_offset": 13
-                    },
-                    "ops": [
+                    "kind": "parenthesized_expression",
+                    "start": 145,
+                    "end": 184,
+                    "children": [
                       {
-                        "_type": "Lt"
+                        "kind": "conditional_expression",
+                        "start": 146,
+                        "end": 183,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 146,
+                            "end": 147
+                          },
+                          {
+                            "kind": "boolean_operator",
+                            "start": 151,
+                            "end": 176,
+                            "children": [
+                              {
+                                "kind": "boolean_operator",
+                                "start": 151,
+                                "end": 166,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 151,
+                                    "end": 156,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 151,
+                                        "end": 152
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 155,
+                                        "end": 156
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 161,
+                                    "end": 166,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 161,
+                                        "end": 162
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 165,
+                                        "end": 166
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 171,
+                                "end": 176,
+                                "children": [
+                                  {
+                                    "kind": "integer",
+                                    "start": 171,
+                                    "end": 172
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 175,
+                                    "end": 176
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 182,
+                            "end": 183
+                          }
+                        ]
                       }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 16,
-                        "end_col_offset": 17
-                      }
-                    ],
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 12,
-                    "end_col_offset": 17
-                  },
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 22,
-                      "end_col_offset": 23
-                    },
-                    "ops": [
-                      {
-                        "_type": "Lt"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 26,
-                        "end_col_offset": 27
-                      }
-                    ],
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 22,
-                    "end_col_offset": 27
-                  },
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 3,
-                      "kind": null,
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 32,
-                      "end_col_offset": 33
-                    },
-                    "ops": [
-                      {
-                        "_type": "Lt"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 4,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 36,
-                        "end_col_offset": 37
-                      }
-                    ],
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 32,
-                    "end_col_offset": 37
+                    ]
                   }
-                ],
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 37
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 43,
-                "end_col_offset": 44
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 44
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 46
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 46
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "And"
-                },
-                "values": [
+        "kind": "expression_statement",
+        "start": 186,
+        "end": 233,
+        "children": [
+          {
+            "kind": "call",
+            "start": 186,
+            "end": 233,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 186,
+                "end": 191
+              },
+              {
+                "kind": "argument_list",
+                "start": 191,
+                "end": 233,
+                "children": [
                   {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 12,
-                      "end_col_offset": 13
-                    },
-                    "ops": [
+                    "kind": "parenthesized_expression",
+                    "start": 192,
+                    "end": 232,
+                    "children": [
                       {
-                        "_type": "Lt"
+                        "kind": "conditional_expression",
+                        "start": 193,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 193,
+                            "end": 194
+                          },
+                          {
+                            "kind": "boolean_operator",
+                            "start": 198,
+                            "end": 224,
+                            "children": [
+                              {
+                                "kind": "boolean_operator",
+                                "start": 198,
+                                "end": 213,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 198,
+                                    "end": 203,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 198,
+                                        "end": 199
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 202,
+                                        "end": 203
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 208,
+                                    "end": 213,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 208,
+                                        "end": 209
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 212,
+                                        "end": 213
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 218,
+                                "end": 224,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 218,
+                                    "end": 222
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 222,
+                                    "end": 224
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 230,
+                            "end": 231
+                          }
+                        ]
                       }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 16,
-                        "end_col_offset": 17
-                      }
-                    ],
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 12,
-                    "end_col_offset": 17
-                  },
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 22,
-                      "end_col_offset": 23
-                    },
-                    "ops": [
-                      {
-                        "_type": "Gt"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 26,
-                        "end_col_offset": 27
-                      }
-                    ],
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 22,
-                    "end_col_offset": 27
-                  },
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "boom",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 32,
-                      "end_col_offset": 36
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 32,
-                    "end_col_offset": 38
+                    ]
                   }
-                ],
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 12,
-                "end_col_offset": 38
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 44,
-                "end_col_offset": 45
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 45
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 47
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 47
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "And"
-                },
-                "values": [
+        "kind": "expression_statement",
+        "start": 234,
+        "end": 291,
+        "children": [
+          {
+            "kind": "call",
+            "start": 234,
+            "end": 291,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 234,
+                "end": 239
+              },
+              {
+                "kind": "argument_list",
+                "start": 239,
+                "end": 291,
+                "children": [
                   {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 8,
-                      "end_lineno": 8,
-                      "col_offset": 12,
-                      "end_col_offset": 13
-                    },
-                    "ops": [
+                    "kind": "parenthesized_expression",
+                    "start": 240,
+                    "end": 290,
+                    "children": [
                       {
-                        "_type": "Lt"
+                        "kind": "conditional_expression",
+                        "start": 241,
+                        "end": 289,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 241,
+                            "end": 242
+                          },
+                          {
+                            "kind": "boolean_operator",
+                            "start": 246,
+                            "end": 282,
+                            "children": [
+                              {
+                                "kind": "boolean_operator",
+                                "start": 246,
+                                "end": 271,
+                                "children": [
+                                  {
+                                    "kind": "boolean_operator",
+                                    "start": 246,
+                                    "end": 261,
+                                    "children": [
+                                      {
+                                        "kind": "comparison_operator",
+                                        "start": 246,
+                                        "end": 251,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 246,
+                                            "end": 247
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 250,
+                                            "end": 251
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "comparison_operator",
+                                        "start": 256,
+                                        "end": 261,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 256,
+                                            "end": 257
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 260,
+                                            "end": 261
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 266,
+                                    "end": 271,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 266,
+                                        "end": 267
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 270,
+                                        "end": 271
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 276,
+                                "end": 282,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 276,
+                                    "end": 280
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 280,
+                                    "end": 282
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 288,
+                            "end": 289
+                          }
+                        ]
                       }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 8,
-                        "end_lineno": 8,
-                        "col_offset": 16,
-                        "end_col_offset": 17
-                      }
-                    ],
-                    "lineno": 8,
-                    "end_lineno": 8,
-                    "col_offset": 12,
-                    "end_col_offset": 17
-                  },
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 8,
-                      "end_lineno": 8,
-                      "col_offset": 22,
-                      "end_col_offset": 23
-                    },
-                    "ops": [
-                      {
-                        "_type": "Lt"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 8,
-                        "end_lineno": 8,
-                        "col_offset": 26,
-                        "end_col_offset": 27
-                      }
-                    ],
-                    "lineno": 8,
-                    "end_lineno": 8,
-                    "col_offset": 22,
-                    "end_col_offset": 27
-                  },
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Constant",
-                      "value": 3,
-                      "kind": null,
-                      "lineno": 8,
-                      "end_lineno": 8,
-                      "col_offset": 32,
-                      "end_col_offset": 33
-                    },
-                    "ops": [
-                      {
-                        "_type": "Gt"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Constant",
-                        "value": 4,
-                        "kind": null,
-                        "lineno": 8,
-                        "end_lineno": 8,
-                        "col_offset": 36,
-                        "end_col_offset": 37
-                      }
-                    ],
-                    "lineno": 8,
-                    "end_lineno": 8,
-                    "col_offset": 32,
-                    "end_col_offset": 37
-                  },
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "boom",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 8,
-                      "end_lineno": 8,
-                      "col_offset": 42,
-                      "end_col_offset": 46
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 8,
-                    "end_lineno": 8,
-                    "col_offset": 42,
-                    "end_col_offset": 48
+                    ]
                   }
-                ],
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 12,
-                "end_col_offset": 48
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 54,
-                "end_col_offset": 55
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 7,
-              "end_col_offset": 55
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 0,
-          "end_col_offset": 57
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 57
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/break_continue.py.json
+++ b/tests/json-ast/x/py/break_continue.py.json
@@ -1,296 +1,250 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 241,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "numbers",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 15
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 17,
-              "end_col_offset": 18
-            },
-            {
-              "_type": "Constant",
-              "value": 4,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 20,
-              "end_col_offset": 21
-            },
-            {
-              "_type": "Constant",
-              "value": 5,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 23,
-              "end_col_offset": 24
-            },
-            {
-              "_type": "Constant",
-              "value": 6,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 26,
-              "end_col_offset": 27
-            },
-            {
-              "_type": "Constant",
-              "value": 7,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 29,
-              "end_col_offset": 30
-            },
-            {
-              "_type": "Constant",
-              "value": 8,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 32,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Constant",
-              "value": 9,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 35,
-              "end_col_offset": 36
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 10,
-          "end_col_offset": 37
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 37
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "For",
-        "body": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 130,
+        "children": [
           {
-            "_type": "If",
-            "body": [
+            "kind": "assignment",
+            "start": 93,
+            "end": 130,
+            "children": [
               {
-                "_type": "Continue",
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 8,
-                "end_col_offset": 16
-              }
-            ],
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "BinOp",
-                "op": {
-                  "_type": "Mod"
-                },
-                "left": {
-                  "_type": "Name",
-                  "id": "n",
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 7,
-                  "end_col_offset": 8
-                },
-                "right": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 12
+                "kind": "identifier",
+                "start": 93,
+                "end": 100
               },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                }
-              ],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 17
-            },
-            "lineno": 5,
-            "end_lineno": 6,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "If",
-            "body": [
               {
-                "_type": "Break",
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 8,
-                "end_col_offset": 13
-              }
-            ],
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "n",
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "ops": [
-                {
-                  "_type": "Gt"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 7,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                }
-              ],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 12
-            },
-            "lineno": 7,
-            "end_lineno": 8,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "odd number:",
-                  "kind": null,
-                  "lineno": 9,
-                  "end_lineno": 9,
-                  "col_offset": 10,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Name",
-                  "id": "n",
-                  "ctx": {
-                    "_type": "Load"
+                "kind": "list",
+                "start": 103,
+                "end": 130,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
                   },
-                  "lineno": 9,
-                  "end_lineno": 9,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 27
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 27
+                  {
+                    "kind": "integer",
+                    "start": 107,
+                    "end": 108
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 110,
+                    "end": 111
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 113,
+                    "end": 114
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 116,
+                    "end": 117
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 119,
+                    "end": 120
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 122,
+                    "end": 123
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 125,
+                    "end": 126
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 128,
+                    "end": 129
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "n",
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "numbers",
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 9,
-          "end_col_offset": 16
-        },
-        "lineno": 4,
-        "end_lineno": 9,
-        "end_col_offset": 27
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 131,
+        "end": 240,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 135,
+            "end": 136
+          },
+          {
+            "kind": "identifier",
+            "start": 140,
+            "end": 147
+          },
+          {
+            "kind": "block",
+            "start": 153,
+            "end": 240,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 153,
+                "end": 184,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 156,
+                    "end": 166,
+                    "children": [
+                      {
+                        "kind": "binary_operator",
+                        "start": 156,
+                        "end": 161,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 156,
+                            "end": 157
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 160,
+                            "end": 161
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 165,
+                        "end": 166
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 176,
+                    "end": 184,
+                    "children": [
+                      {
+                        "kind": "continue_statement",
+                        "start": 176,
+                        "end": 184
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "if_statement",
+                "start": 189,
+                "end": 212,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 192,
+                    "end": 197,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 192,
+                        "end": 193
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 196,
+                        "end": 197
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 207,
+                    "end": 212,
+                    "children": [
+                      {
+                        "kind": "break_statement",
+                        "start": 207,
+                        "end": 212
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 217,
+                "end": 240,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 217,
+                    "end": 240,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 217,
+                        "end": 222
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 222,
+                        "end": 240,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 223,
+                            "end": 236,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 223,
+                                "end": 224
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 224,
+                                "end": 235
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 235,
+                                "end": 236
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 238,
+                            "end": 239
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/cast_string_to_int.py.json
+++ b/tests/json-ast/x/py/cast_string_to_int.py.json
@@ -1,63 +1,85 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 112,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "int",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 111,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 111,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "1995",
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 18
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 111,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 103,
+                            "end": 109,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 103,
+                                "end": 104
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 104,
+                                "end": 108
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 108,
+                                "end": 109
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/cast_struct.py.json
+++ b/tests/json-ast/x/py/cast_struct.py.json
@@ -1,169 +1,295 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 274,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Todo",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "title",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 9,
-        "end_col_offset": 14
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "Name",
-            "id": "todo",
-            "lineno": 11,
-            "end_lineno": 11,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "Todo",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 7,
-            "end_col_offset": 11
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
-          "args": [],
-          "keywords": [
-            {
-              "_type": "keyword",
-              "arg": "title",
-              "value": {
-                "_type": "Constant",
-                "value": "hi",
-                "kind": null,
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 18,
-                "end_col_offset": 22
-              },
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 12,
-              "end_col_offset": 22
-            }
-          ],
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 7,
-          "end_col_offset": 23
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 23
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "todo",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 6,
-                "end_col_offset": 10
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 230,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 230,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 214
               },
-              "attr": "title",
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "block",
+                "start": 220,
+                "end": 230,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 220,
+                    "end": 230,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 220,
+                        "end": 230,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 220,
+                            "end": 225
+                          },
+                          {
+                            "kind": "type",
+                            "start": 227,
+                            "end": 230,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 227,
+                                "end": 230
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 232,
+        "end": 255,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 232,
+            "end": 255,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 232,
+                "end": 236
               },
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 6,
-              "end_col_offset": 16
-            }
-          ],
-          "keywords": [],
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 0,
-          "end_col_offset": 17
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 17
+              {
+                "kind": "call",
+                "start": 239,
+                "end": 255,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 239,
+                    "end": 243
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 243,
+                    "end": 255,
+                    "children": [
+                      {
+                        "kind": "keyword_argument",
+                        "start": 244,
+                        "end": 254,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 244,
+                            "end": 249
+                          },
+                          {
+                            "kind": "string",
+                            "start": 250,
+                            "end": 254,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 250,
+                                "end": 251
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 251,
+                                "end": 253
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 253,
+                                "end": 254
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 256,
+        "end": 273,
+        "children": [
+          {
+            "kind": "call",
+            "start": 256,
+            "end": 273,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 256,
+                "end": 261
+              },
+              {
+                "kind": "argument_list",
+                "start": 261,
+                "end": 273,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 262,
+                    "end": 272,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 262,
+                        "end": 266
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 267,
+                        "end": 272
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/closure.py.json
+++ b/tests/json-ast/x/py/closure.py.json
@@ -1,205 +1,185 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 176,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "makeAdder",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 137,
+        "children": [
           {
-            "_type": "Return",
-            "value": {
-              "_type": "Lambda",
-              "args": {
-                "_type": "arguments",
-                "posonlyargs": [],
-                "args": [
+            "kind": "identifier",
+            "start": 97,
+            "end": 106
+          },
+          {
+            "kind": "parameters",
+            "start": 106,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 107,
+                "end": 108
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 115,
+            "end": 137,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 115,
+                "end": 137,
+                "children": [
                   {
-                    "_type": "arg",
-                    "arg": "x",
-                    "annotation": null,
-                    "type_comment": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 18,
-                    "end_col_offset": 19
+                    "kind": "lambda",
+                    "start": 122,
+                    "end": 137,
+                    "children": [
+                      {
+                        "kind": "lambda_parameters",
+                        "start": 129,
+                        "end": 130,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 129,
+                            "end": 130
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 132,
+                        "end": 137,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 132,
+                            "end": 133
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 136,
+                            "end": 137
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "vararg": null,
-                "kwonlyargs": [],
-                "kw_defaults": [],
-                "kwarg": null,
-                "defaults": []
-              },
-              "body": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Name",
-                  "id": "x",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                "op": {
-                  "_type": "Add"
-                },
-                "right": {
-                  "_type": "Name",
-                  "id": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 21,
-                "end_col_offset": 26
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 11,
-              "end_col_offset": 26
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 26
+                ]
+              }
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "n",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 15
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 26
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 138,
+        "end": 159,
+        "children": [
           {
-            "_type": "Name",
-            "id": "add10",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 5
+            "kind": "assignment",
+            "start": 138,
+            "end": 159,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 138,
+                "end": 143
+              },
+              {
+                "kind": "call",
+                "start": 146,
+                "end": 159,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 146,
+                    "end": 155
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 155,
+                    "end": 159,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 156,
+                        "end": 158
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "makeAdder",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 8,
-            "end_col_offset": 17
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 10,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 18,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 8,
-          "end_col_offset": 21
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 21
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "add10",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 11
+        "kind": "expression_statement",
+        "start": 160,
+        "end": 175,
+        "children": [
+          {
+            "kind": "call",
+            "start": 160,
+            "end": 175,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 160,
+                "end": 165
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 7,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 14
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 15
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 15
+              {
+                "kind": "argument_list",
+                "start": 165,
+                "end": 175,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 166,
+                    "end": 174,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 166,
+                        "end": 171
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 171,
+                        "end": 174,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 172,
+                            "end": 173
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/count_builtin.py.json
+++ b/tests/json-ast/x/py/count_builtin.py.json
@@ -1,93 +1,85 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 115,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 114,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 114,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "List",
-                  "elts": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 12
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 14,
-                      "end_col_offset": 15
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 3,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 17,
-                      "end_col_offset": 18
-                    }
-                  ],
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 19
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 21
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "list",
+                            "start": 103,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 104,
+                                "end": 105
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 107,
+                                "end": 108
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 110,
+                                "end": 111
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/cross_join.py.json
+++ b/tests/json-ast/x/py/cross_join.py.json
@@ -1,1011 +1,1197 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 897,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 78
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 78
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 125,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 50,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 64,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 50,
-              "end_col_offset": 68
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 69
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 69
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 21,
-              "end_col_offset": 24
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderCustomerId",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 19
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 24
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 24,
-              "end_col_offset": 27
-            },
-            "target": {
-              "_type": "Name",
-              "id": "pairedCustomerName",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 4,
-            "end_col_offset": 27
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderTotal",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 25,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 27,
-            "end_lineno": 27,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "id",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 23,
-                  "end_col_offset": 24
-                },
-                "attr": "customerId",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 23,
-                "end_col_offset": 35
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 37,
-                  "end_col_offset": 38
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 37,
-                "end_col_offset": 43
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 45,
-                  "end_col_offset": 46
-                },
-                "attr": "total",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 45,
-                "end_col_offset": 52
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 10,
-            "end_col_offset": 53
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 58,
-                "end_col_offset": 59
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 63,
-                "end_col_offset": 69
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 74,
-                "end_col_offset": 75
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "customers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 79,
-                "end_col_offset": 88
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 9,
-          "end_col_offset": 89
-        },
-        "lineno": 27,
-        "end_lineno": 27,
-        "end_col_offset": 89
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Cross Join: All order-customer pairs ---",
-              "kind": null,
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 6,
-              "end_col_offset": 52
-            }
-          ],
-          "keywords": [],
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 0,
-          "end_col_offset": 53
-        },
-        "lineno": 28,
-        "end_lineno": 28,
-        "end_col_offset": 53
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Order",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 19,
-                    "end_col_offset": 24
-                  },
-                  "attr": "orderId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 19,
-                  "end_col_offset": 32
-                },
-                {
-                  "_type": "Constant",
-                  "value": "(customerId:",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 34,
-                  "end_col_offset": 48
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 50,
-                    "end_col_offset": 55
-                  },
-                  "attr": "orderCustomerId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 50,
-                  "end_col_offset": 71
-                },
-                {
-                  "_type": "Constant",
-                  "value": ", total: $",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 73,
-                  "end_col_offset": 85
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 87,
-                    "end_col_offset": 92
-                  },
-                  "attr": "orderTotal",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 87,
-                  "end_col_offset": 103
-                },
-                {
-                  "_type": "Constant",
-                  "value": ") paired with",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 105,
-                  "end_col_offset": 120
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 122,
-                    "end_col_offset": 127
-                  },
-                  "attr": "pairedCustomerName",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 122,
-                  "end_col_offset": 146
-                }
-              ],
-              "keywords": [],
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 4,
-              "end_col_offset": 147
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 4,
-            "end_col_offset": 147
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "entry",
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 29,
-        "end_lineno": 30,
-        "end_col_offset": 147
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 325,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 326,
+        "end": 396,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 326,
+            "end": 336,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 327,
+                "end": 336
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 337,
+            "end": 396,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
+              },
+              {
+                "kind": "block",
+                "start": 354,
+                "end": 396,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 354,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 354,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 354,
+                            "end": 356
+                          },
+                          {
+                            "kind": "type",
+                            "start": 358,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 358,
+                                "end": 361
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 366,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 366,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 366,
+                            "end": 376
+                          },
+                          {
+                            "kind": "type",
+                            "start": 378,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 378,
+                                "end": 381
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 386,
+                    "end": 396,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 386,
+                        "end": 396,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 386,
+                            "end": 391
+                          },
+                          {
+                            "kind": "type",
+                            "start": 393,
+                            "end": 396,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 393,
+                                "end": 396
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 398,
+        "end": 467,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 398,
+            "end": 467,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 398,
+                "end": 404
+              },
+              {
+                "kind": "list",
+                "start": 407,
+                "end": 467,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 408,
+                    "end": 426,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 408,
+                        "end": 413
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 413,
+                        "end": 426,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 414,
+                            "end": 417
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 419,
+                            "end": 420
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 422,
+                            "end": 425
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 428,
+                    "end": 446,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 428,
+                        "end": 433
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 433,
+                        "end": 446,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 434,
+                            "end": 437
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 439,
+                            "end": 440
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 442,
+                            "end": 445
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 448,
+                    "end": 466,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 448,
+                        "end": 453
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 453,
+                        "end": 466,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 454,
+                            "end": 457
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 459,
+                            "end": 460
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 462,
+                            "end": 465
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 468,
+        "end": 582,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 468,
+            "end": 478,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 469,
+                "end": 478
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 479,
+            "end": 582,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 485,
+                "end": 491
+              },
+              {
+                "kind": "block",
+                "start": 497,
+                "end": 582,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 497,
+                    "end": 509,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 497,
+                        "end": 509,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 497,
+                            "end": 504
+                          },
+                          {
+                            "kind": "type",
+                            "start": 506,
+                            "end": 509,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 506,
+                                "end": 509
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 514,
+                    "end": 534,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 514,
+                        "end": 534,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 514,
+                            "end": 529
+                          },
+                          {
+                            "kind": "type",
+                            "start": 531,
+                            "end": 534,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 531,
+                                "end": 534
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 539,
+                    "end": 562,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 539,
+                        "end": 562,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 539,
+                            "end": 557
+                          },
+                          {
+                            "kind": "type",
+                            "start": 559,
+                            "end": 562,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 559,
+                                "end": 562
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 567,
+                    "end": 582,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 567,
+                        "end": 582,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 567,
+                            "end": 577
+                          },
+                          {
+                            "kind": "type",
+                            "start": 579,
+                            "end": 582,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 579,
+                                "end": 582
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 584,
+        "end": 673,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 584,
+            "end": 673,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 584,
+                "end": 590
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 593,
+                "end": 673,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 594,
+                    "end": 637,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 594,
+                        "end": 600
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 600,
+                        "end": 637,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 601,
+                            "end": 605,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 601,
+                                "end": 602
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 603,
+                                "end": 605
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 607,
+                            "end": 619,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 607,
+                                "end": 608
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 609,
+                                "end": 619
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 621,
+                            "end": 627,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 621,
+                                "end": 622
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 623,
+                                "end": 627
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 629,
+                            "end": 636,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 629,
+                                "end": 630
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 631,
+                                "end": 636
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 638,
+                    "end": 653,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 642,
+                        "end": 643
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 647,
+                        "end": 653
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 654,
+                    "end": 672,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 658,
+                        "end": 659
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 663,
+                        "end": 672
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 674,
+        "end": 727,
+        "children": [
+          {
+            "kind": "call",
+            "start": 674,
+            "end": 727,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 674,
+                "end": 679
+              },
+              {
+                "kind": "argument_list",
+                "start": 679,
+                "end": 727,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 680,
+                    "end": 726,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 680,
+                        "end": 681
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 681,
+                        "end": 725
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 725,
+                        "end": 726
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 728,
+        "end": 896,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 732,
+            "end": 737
+          },
+          {
+            "kind": "identifier",
+            "start": 741,
+            "end": 747
+          },
+          {
+            "kind": "block",
+            "start": 753,
+            "end": 896,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 753,
+                "end": 896,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 753,
+                    "end": 896,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 753,
+                        "end": 758
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 758,
+                        "end": 896,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 759,
+                            "end": 766,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 759,
+                                "end": 760
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 760,
+                                "end": 765
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 765,
+                                "end": 766
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 768,
+                            "end": 781,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 768,
+                                "end": 773
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 774,
+                                "end": 781
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 783,
+                            "end": 797,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 783,
+                                "end": 784
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 784,
+                                "end": 796
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 796,
+                                "end": 797
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 799,
+                            "end": 820,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 799,
+                                "end": 804
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 805,
+                                "end": 820
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 822,
+                            "end": 834,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 822,
+                                "end": 823
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 823,
+                                "end": 833
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 833,
+                                "end": 834
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 836,
+                            "end": 852,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 836,
+                                "end": 841
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 842,
+                                "end": 852
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 854,
+                            "end": 869,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 854,
+                                "end": 855
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 855,
+                                "end": 868
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 868,
+                                "end": 869
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 871,
+                            "end": 895,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 871,
+                                "end": 876
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 877,
+                                "end": 895
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/cross_join_filter.py.json
+++ b/tests/json-ast/x/py/cross_join_filter.py.json
@@ -1,497 +1,579 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 407,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Assign",
-        "targets": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 11,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 14,
-              "end_col_offset": 15
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 7,
-          "end_col_offset": 16
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 16
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "letters",
-            "lineno": 8,
-            "end_lineno": 8,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": "A",
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            {
-              "_type": "Constant",
-              "value": "B",
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 16,
-              "end_col_offset": 19
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 10,
-          "end_col_offset": 20
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Pair",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 10,
-        "end_lineno": 12,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "pairs",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Pair",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              {
-                "_type": "Name",
-                "id": "l",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 17,
-                "end_col_offset": 18
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 9,
-            "end_col_offset": 19
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 24,
-                "end_col_offset": 25
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "nums",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 29,
-                "end_col_offset": 33
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "l",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 38,
-                "end_col_offset": 39
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "letters",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 43,
-                "end_col_offset": 50
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "BinOp",
-                    "left": {
-                      "_type": "Name",
-                      "id": "n",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 14,
-                      "end_lineno": 14,
-                      "col_offset": 54,
-                      "end_col_offset": 55
-                    },
-                    "op": {
-                      "_type": "Mod"
-                    },
-                    "right": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 14,
-                      "end_lineno": 14,
-                      "col_offset": 58,
-                      "end_col_offset": 59
-                    },
-                    "lineno": 14,
-                    "end_lineno": 14,
-                    "col_offset": 54,
-                    "end_col_offset": 59
-                  },
-                  "ops": [
-                    {
-                      "_type": "Eq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 0,
-                      "kind": null,
-                      "lineno": 14,
-                      "end_lineno": 14,
-                      "col_offset": 63,
-                      "end_col_offset": 64
-                    }
-                  ],
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 54,
-                  "end_col_offset": 64
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 8,
-          "end_col_offset": 65
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 65
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Even pairs ---",
-              "kind": null,
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 6,
-              "end_col_offset": 26
-            }
-          ],
-          "keywords": [],
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 0,
-          "end_col_offset": 27
-        },
-        "lineno": 15,
-        "end_lineno": 15,
-        "end_col_offset": 27
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "p",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 10,
-                  "end_col_offset": 13
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "p",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 15,
-                    "end_col_offset": 16
-                  },
-                  "attr": "l",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 15,
-                  "end_col_offset": 18
-                }
-              ],
-              "keywords": [],
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 19
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 19
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "p",
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "pairs",
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 16,
-        "end_lineno": 17,
-        "end_col_offset": 19
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 193,
+        "end": 209,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 193,
+            "end": 209,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 193,
+                "end": 197
+              },
+              {
+                "kind": "list",
+                "start": 200,
+                "end": 209,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 201,
+                    "end": 202
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 204,
+                    "end": 205
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 207,
+                    "end": 208
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 210,
+        "end": 230,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 210,
+            "end": 230,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 217
+              },
+              {
+                "kind": "list",
+                "start": 220,
+                "end": 230,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 221,
+                    "end": 224,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 221,
+                        "end": 222
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 222,
+                        "end": 223
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 223,
+                        "end": 224
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "string",
+                    "start": 226,
+                    "end": 229,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 226,
+                        "end": 227
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 227,
+                        "end": 228
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 228,
+                        "end": 229
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 231,
+        "end": 275,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 231,
+            "end": 241,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 232,
+                "end": 241
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 242,
+            "end": 275,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 248,
+                "end": 252
+              },
+              {
+                "kind": "block",
+                "start": 258,
+                "end": 275,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 258,
+                    "end": 264,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 258,
+                        "end": 264,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 258,
+                            "end": 259
+                          },
+                          {
+                            "kind": "type",
+                            "start": 261,
+                            "end": 264,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 261,
+                                "end": 264
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 269,
+                    "end": 275,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 269,
+                        "end": 275,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "type",
+                            "start": 272,
+                            "end": 275,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 272,
+                                "end": 275
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 277,
+        "end": 342,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 277,
+            "end": 342,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 277,
+                "end": 282
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 285,
+                "end": 342,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 286,
+                    "end": 296,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 286,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 296,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 294,
+                            "end": 295
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 297,
+                    "end": 310,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 301,
+                        "end": 302
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 306,
+                        "end": 310
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 311,
+                    "end": 327,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 315,
+                        "end": 316
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 320,
+                        "end": 327
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 328,
+                    "end": 341,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 331,
+                        "end": 341,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 331,
+                            "end": 336,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 331,
+                                "end": 332
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 335,
+                                "end": 336
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 340,
+                            "end": 341
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 343,
+        "end": 370,
+        "children": [
+          {
+            "kind": "call",
+            "start": 343,
+            "end": 370,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
+              },
+              {
+                "kind": "argument_list",
+                "start": 348,
+                "end": 370,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 349,
+                    "end": 369,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 349,
+                        "end": 350
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 350,
+                        "end": 368
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 368,
+                        "end": 369
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 371,
+        "end": 406,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 375,
+            "end": 376
+          },
+          {
+            "kind": "identifier",
+            "start": 380,
+            "end": 385
+          },
+          {
+            "kind": "block",
+            "start": 391,
+            "end": 406,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 391,
+                "end": 406,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 391,
+                    "end": 406,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 391,
+                        "end": 396
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 396,
+                        "end": 406,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 397,
+                            "end": 400,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 397,
+                                "end": 398
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 399,
+                                "end": 400
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 402,
+                            "end": 405,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 402,
+                                "end": 403
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 404,
+                                "end": 405
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/cross_join_triple.py.json
+++ b/tests/json-ast/x/py/cross_join_triple.py.json
@@ -1,588 +1,702 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 491,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Assign",
-        "targets": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 7,
-          "end_col_offset": 13
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "letters",
-            "lineno": 8,
-            "end_lineno": 8,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": "A",
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            {
-              "_type": "Constant",
-              "value": "B",
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 16,
-              "end_col_offset": 19
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 10,
-          "end_col_offset": 20
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "bools",
-            "lineno": 9,
-            "end_lineno": 9,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": true,
-              "kind": null,
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            {
-              "_type": "Constant",
-              "value": false,
-              "kind": null,
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 15,
-              "end_col_offset": 20
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 9,
-          "end_lineno": 9,
-          "col_offset": 8,
-          "end_col_offset": 21
-        },
-        "lineno": 9,
-        "end_lineno": 9,
-        "end_col_offset": 21
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Combo",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l",
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "bool",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 7,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "b",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 4,
-            "end_col_offset": 11
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 11,
-        "end_lineno": 14,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "combos",
-            "lineno": 16,
-            "end_lineno": 16,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Combo",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 10,
-              "end_col_offset": 15
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 16,
-                "end_col_offset": 17
-              },
-              {
-                "_type": "Name",
-                "id": "l",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 19,
-                "end_col_offset": 20
-              },
-              {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 22,
-                "end_col_offset": 23
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 10,
-            "end_col_offset": 24
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 29,
-                "end_col_offset": 30
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "nums",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 34,
-                "end_col_offset": 38
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "l",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 43,
-                "end_col_offset": 44
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "letters",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 48,
-                "end_col_offset": 55
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 60,
-                "end_col_offset": 61
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "bools",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 65,
-                "end_col_offset": 70
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 9,
-          "end_col_offset": 71
-        },
-        "lineno": 16,
-        "end_lineno": 16,
-        "end_col_offset": 71
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Cross Join of three lists ---",
-              "kind": null,
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 6,
-              "end_col_offset": 41
-            }
-          ],
-          "keywords": [],
-          "lineno": 17,
-          "end_lineno": 17,
-          "col_offset": 0,
-          "end_col_offset": 42
-        },
-        "lineno": 17,
-        "end_lineno": 17,
-        "end_col_offset": 42
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "c",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 10,
-                  "end_col_offset": 13
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "c",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 15,
-                    "end_col_offset": 16
-                  },
-                  "attr": "l",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 15,
-                  "end_col_offset": 18
-                },
-                {
-                  "_type": "IfExp",
-                  "test": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "c",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 19,
-                      "end_lineno": 19,
-                      "col_offset": 31,
-                      "end_col_offset": 32
-                    },
-                    "attr": "b",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 31,
-                    "end_col_offset": 34
-                  },
-                  "body": {
-                    "_type": "Constant",
-                    "value": "true",
-                    "kind": null,
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 21,
-                    "end_col_offset": 27
-                  },
-                  "orelse": {
-                    "_type": "Constant",
-                    "value": "false",
-                    "kind": null,
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 40,
-                    "end_col_offset": 47
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 4,
-              "end_col_offset": 49
-            },
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 4,
-            "end_col_offset": 49
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "c",
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "combos",
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 18,
-        "end_lineno": 19,
-        "end_col_offset": 49
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 193,
+        "end": 206,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 193,
+            "end": 206,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 193,
+                "end": 197
+              },
+              {
+                "kind": "list",
+                "start": 200,
+                "end": 206,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 201,
+                    "end": 202
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 204,
+                    "end": 205
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 207,
+        "end": 227,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 207,
+            "end": 227,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 207,
+                "end": 214
+              },
+              {
+                "kind": "list",
+                "start": 217,
+                "end": 227,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 218,
+                    "end": 221,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 218,
+                        "end": 219
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 219,
+                        "end": 220
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 220,
+                        "end": 221
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "string",
+                    "start": 223,
+                    "end": 226,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 223,
+                        "end": 224
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 224,
+                        "end": 225
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 225,
+                        "end": 226
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 228,
+        "end": 249,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 228,
+            "end": 249,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 228,
+                "end": 233
+              },
+              {
+                "kind": "list",
+                "start": 236,
+                "end": 249,
+                "children": [
+                  {
+                    "kind": "true",
+                    "start": 237,
+                    "end": 241
+                  },
+                  {
+                    "kind": "false",
+                    "start": 243,
+                    "end": 248
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 250,
+        "end": 307,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 250,
+            "end": 260,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 251,
+                "end": 260
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 261,
+            "end": 307,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 267,
+                "end": 272
+              },
+              {
+                "kind": "block",
+                "start": 278,
+                "end": 307,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 278,
+                    "end": 284,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 278,
+                        "end": 284,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 278,
+                            "end": 279
+                          },
+                          {
+                            "kind": "type",
+                            "start": 281,
+                            "end": 284,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 281,
+                                "end": 284
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 289,
+                    "end": 295,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 289,
+                        "end": 295,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 289,
+                            "end": 290
+                          },
+                          {
+                            "kind": "type",
+                            "start": 292,
+                            "end": 295,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 292,
+                                "end": 295
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 300,
+                    "end": 307,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 300,
+                        "end": 307,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 300,
+                            "end": 301
+                          },
+                          {
+                            "kind": "type",
+                            "start": 303,
+                            "end": 307,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 303,
+                                "end": 307
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 309,
+        "end": 380,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 309,
+            "end": 380,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 309,
+                "end": 315
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 318,
+                "end": 380,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 319,
+                    "end": 333,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 319,
+                        "end": 324
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 324,
+                        "end": 333,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 325,
+                            "end": 326
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 328,
+                            "end": 329
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 331,
+                            "end": 332
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 334,
+                    "end": 347,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 338,
+                        "end": 339
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 343,
+                        "end": 347
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 348,
+                    "end": 364,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 352,
+                        "end": 353
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 357,
+                        "end": 364
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 365,
+                    "end": 379,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 369,
+                        "end": 370
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 374,
+                        "end": 379
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 381,
+        "end": 423,
+        "children": [
+          {
+            "kind": "call",
+            "start": 381,
+            "end": 423,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 381,
+                "end": 386
+              },
+              {
+                "kind": "argument_list",
+                "start": 386,
+                "end": 423,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 387,
+                    "end": 422,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 387,
+                        "end": 388
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 388,
+                        "end": 421
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 421,
+                        "end": 422
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 424,
+        "end": 490,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 428,
+            "end": 429
+          },
+          {
+            "kind": "identifier",
+            "start": 433,
+            "end": 439
+          },
+          {
+            "kind": "block",
+            "start": 445,
+            "end": 490,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 445,
+                "end": 490,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 445,
+                    "end": 490,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 445,
+                        "end": 450
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 450,
+                        "end": 490,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 451,
+                            "end": 454,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 451,
+                                "end": 452
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 453,
+                                "end": 454
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 456,
+                            "end": 459,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 456,
+                                "end": 457
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 458,
+                                "end": 459
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 461,
+                            "end": 489,
+                            "children": [
+                              {
+                                "kind": "conditional_expression",
+                                "start": 462,
+                                "end": 488,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 462,
+                                    "end": 468,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 462,
+                                        "end": 463
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 463,
+                                        "end": 467
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 467,
+                                        "end": 468
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 472,
+                                    "end": 475,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 472,
+                                        "end": 473
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 474,
+                                        "end": 475
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 481,
+                                    "end": 488,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 481,
+                                        "end": 482
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 482,
+                                        "end": 487
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 487,
+                                        "end": 488
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/dataset_sort_take_limit.py.json
+++ b/tests/json-ast/x/py/dataset_sort_take_limit.py.json
@@ -1,782 +1,905 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 664,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Product",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "price",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "products",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 12,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Laptop",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 20,
-                  "end_col_offset": 28
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1500,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 30,
-                  "end_col_offset": 34
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 12,
-              "end_col_offset": 35
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 37,
-                "end_col_offset": 44
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Smartphone",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 45,
-                  "end_col_offset": 57
-                },
-                {
-                  "_type": "Constant",
-                  "value": 900,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 59,
-                  "end_col_offset": 62
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 37,
-              "end_col_offset": 63
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 65,
-                "end_col_offset": 72
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Tablet",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 73,
-                  "end_col_offset": 81
-                },
-                {
-                  "_type": "Constant",
-                  "value": 600,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 83,
-                  "end_col_offset": 86
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 65,
-              "end_col_offset": 87
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 89,
-                "end_col_offset": 96
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Monitor",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 97,
-                  "end_col_offset": 106
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 108,
-                  "end_col_offset": 111
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 89,
-              "end_col_offset": 112
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 114,
-                "end_col_offset": 121
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Keyboard",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 122,
-                  "end_col_offset": 132
-                },
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 134,
-                  "end_col_offset": 137
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 114,
-              "end_col_offset": 138
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 140,
-                "end_col_offset": 147
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Mouse",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 148,
-                  "end_col_offset": 155
-                },
-                {
-                  "_type": "Constant",
-                  "value": 50,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 157,
-                  "end_col_offset": 159
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 140,
-              "end_col_offset": 160
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Product",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 162,
-                "end_col_offset": 169
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Headphones",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 170,
-                  "end_col_offset": 182
-                },
-                {
-                  "_type": "Constant",
-                  "value": 200,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 184,
-                  "end_col_offset": 187
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 162,
-              "end_col_offset": 188
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 11,
-          "end_col_offset": 189
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 189
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "expensive",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "Subscript",
-          "value": {
-            "_type": "ListComp",
-            "elt": {
-              "_type": "Name",
-              "id": "p",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 13,
-              "end_col_offset": 14
-            },
-            "generators": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "comprehension",
-                "target": {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Store"
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                "iter": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "sorted",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 24,
-                    "end_col_offset": 30
-                  },
-                  "args": [
-                    {
-                      "_type": "ListComp",
-                      "elt": {
-                        "_type": "Name",
-                        "id": "p",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 13,
-                        "end_lineno": 13,
-                        "col_offset": 32,
-                        "end_col_offset": 33
-                      },
-                      "generators": [
-                        {
-                          "_type": "comprehension",
-                          "target": {
-                            "_type": "Name",
-                            "id": "p",
-                            "ctx": {
-                              "_type": "Store"
-                            },
-                            "lineno": 13,
-                            "end_lineno": 13,
-                            "col_offset": 38,
-                            "end_col_offset": 39
-                          },
-                          "iter": {
-                            "_type": "Name",
-                            "id": "products",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 13,
-                            "end_lineno": 13,
-                            "col_offset": 43,
-                            "end_col_offset": 51
-                          },
-                          "ifs": [],
-                          "is_async": 0
-                        }
-                      ],
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 31,
-                      "end_col_offset": 52
-                    }
-                  ],
-                  "keywords": [
-                    {
-                      "_type": "keyword",
-                      "arg": "key",
-                      "value": {
-                        "_type": "Lambda",
-                        "args": {
-                          "_type": "arguments",
-                          "posonlyargs": [],
-                          "args": [
-                            {
-                              "_type": "arg",
-                              "arg": "p",
-                              "annotation": null,
-                              "type_comment": null,
-                              "lineno": 13,
-                              "end_lineno": 13,
-                              "col_offset": 65,
-                              "end_col_offset": 66
-                            }
-                          ],
-                          "vararg": null,
-                          "kwonlyargs": [],
-                          "kw_defaults": [],
-                          "kwarg": null,
-                          "defaults": []
-                        },
-                        "body": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "p",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 13,
-                            "end_lineno": 13,
-                            "col_offset": 68,
-                            "end_col_offset": 69
-                          },
-                          "attr": "price",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 13,
-                          "end_lineno": 13,
-                          "col_offset": 68,
-                          "end_col_offset": 75
-                        },
-                        "lineno": 13,
-                        "end_lineno": 13,
-                        "col_offset": 58,
-                        "end_col_offset": 75
-                      },
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 54,
-                      "end_col_offset": 75
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "reverse",
-                      "value": {
-                        "_type": "Constant",
-                        "value": true,
-                        "kind": null,
-                        "lineno": 13,
-                        "end_lineno": 13,
-                        "col_offset": 85,
-                        "end_col_offset": 89
-                      },
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 77,
-                      "end_col_offset": 89
-                    }
-                  ],
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 24,
-                  "end_col_offset": 90
-                },
-                "ifs": [],
-                "is_async": 0
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 12,
-            "end_col_offset": 91
-          },
-          "slice": {
-            "_type": "Slice",
-            "lower": {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 92,
-              "end_col_offset": 93
-            },
-            "upper": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 94,
-                "end_col_offset": 95
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 3,
-                "kind": null,
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 98,
-                "end_col_offset": 99
-              },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 94,
-              "end_col_offset": 99
-            },
-            "step": null,
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 92,
-            "end_col_offset": 99
-          },
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 12,
-          "end_col_offset": 100
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 100
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Top products (excluding most expensive) ---",
-              "kind": null,
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 6,
-              "end_col_offset": 55
-            }
-          ],
-          "keywords": [],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 0,
-          "end_col_offset": 56
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 56
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "item",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 10,
-                    "end_col_offset": 14
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 10,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": "costs $",
-                  "kind": null,
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 21,
-                  "end_col_offset": 30
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "item",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 32,
-                    "end_col_offset": 36
-                  },
-                  "attr": "price",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 32,
-                  "end_col_offset": 42
-                }
-              ],
-              "keywords": [],
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 43
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 43
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "item",
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 4,
-          "end_col_offset": 8
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "expensive",
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 12,
-          "end_col_offset": 21
-        },
-        "lineno": 15,
-        "end_lineno": 16,
-        "end_col_offset": 43
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 247,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 247,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 217
+              },
+              {
+                "kind": "block",
+                "start": 223,
+                "end": 247,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 223,
+                    "end": 232,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 223,
+                        "end": 232,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 223,
+                            "end": 227
+                          },
+                          {
+                            "kind": "type",
+                            "start": 229,
+                            "end": 232,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 229,
+                                "end": 232
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 237,
+                    "end": 247,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 237,
+                        "end": 247,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 237,
+                            "end": 242
+                          },
+                          {
+                            "kind": "type",
+                            "start": 244,
+                            "end": 247,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 244,
+                                "end": 247
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 249,
+        "end": 438,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 249,
+            "end": 438,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 249,
+                "end": 257
+              },
+              {
+                "kind": "list",
+                "start": 260,
+                "end": 438,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 261,
+                    "end": 284,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 261,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 284,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 269,
+                            "end": 277,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 269,
+                                "end": 270
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 270,
+                                "end": 276
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 276,
+                                "end": 277
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 279,
+                            "end": 283
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 286,
+                    "end": 312,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 286,
+                        "end": 293
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 293,
+                        "end": 312,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 306,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 305
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 305,
+                                "end": 306
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 308,
+                            "end": 311
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 314,
+                    "end": 336,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 314,
+                        "end": 321
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 321,
+                        "end": 336,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 322,
+                            "end": 330,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 322,
+                                "end": 323
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 323,
+                                "end": 329
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 329,
+                                "end": 330
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 332,
+                            "end": 335
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 338,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 338,
+                        "end": 345
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 345,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 346,
+                            "end": 355,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 346,
+                                "end": 347
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 347,
+                                "end": 354
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 354,
+                                "end": 355
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 357,
+                            "end": 360
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 363,
+                    "end": 387,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 363,
+                        "end": 370
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 370,
+                        "end": 387,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 371,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 371,
+                                "end": 372
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 372,
+                                "end": 380
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 380,
+                                "end": 381
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 383,
+                            "end": 386
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 389,
+                    "end": 409,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 389,
+                        "end": 396
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 396,
+                        "end": 409,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 397,
+                            "end": 404,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 397,
+                                "end": 398
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 398,
+                                "end": 403
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 403,
+                                "end": 404
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 406,
+                            "end": 408
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 411,
+                    "end": 437,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 411,
+                        "end": 418
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 418,
+                        "end": 437,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 419,
+                            "end": 431,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 419,
+                                "end": 420
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 420,
+                                "end": 430
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 430,
+                                "end": 431
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 433,
+                            "end": 436
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 439,
+        "end": 539,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 439,
+            "end": 539,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 439,
+                "end": 448
+              },
+              {
+                "kind": "subscript",
+                "start": 451,
+                "end": 539,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 451,
+                    "end": 530,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 452,
+                        "end": 453
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 454,
+                        "end": 529,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 458,
+                            "end": 459
+                          },
+                          {
+                            "kind": "call",
+                            "start": 463,
+                            "end": 529,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 463,
+                                "end": 469
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 469,
+                                "end": 529,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 470,
+                                    "end": 491,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 471,
+                                        "end": 472
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 473,
+                                        "end": 490,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 477,
+                                            "end": 478
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 482,
+                                            "end": 490
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 493,
+                                    "end": 514,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 493,
+                                        "end": 496
+                                      },
+                                      {
+                                        "kind": "lambda",
+                                        "start": 497,
+                                        "end": 514,
+                                        "children": [
+                                          {
+                                            "kind": "lambda_parameters",
+                                            "start": 504,
+                                            "end": 505,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 504,
+                                                "end": 505
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 507,
+                                            "end": 514,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 507,
+                                                "end": 508
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 509,
+                                                "end": 514
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 516,
+                                    "end": 528,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 516,
+                                        "end": 523
+                                      },
+                                      {
+                                        "kind": "true",
+                                        "start": 524,
+                                        "end": 528
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "slice",
+                    "start": 531,
+                    "end": 538,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 531,
+                        "end": 532
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 533,
+                        "end": 538,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 533,
+                            "end": 534
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 537,
+                            "end": 538
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 540,
+        "end": 596,
+        "children": [
+          {
+            "kind": "call",
+            "start": 540,
+            "end": 596,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 540,
+                "end": 545
+              },
+              {
+                "kind": "argument_list",
+                "start": 545,
+                "end": 596,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 546,
+                    "end": 595,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 546,
+                        "end": 547
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 547,
+                        "end": 594
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 594,
+                        "end": 595
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 597,
+        "end": 663,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 601,
+            "end": 605
+          },
+          {
+            "kind": "identifier",
+            "start": 609,
+            "end": 618
+          },
+          {
+            "kind": "block",
+            "start": 624,
+            "end": 663,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 624,
+                "end": 663,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 624,
+                    "end": 663,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 624,
+                        "end": 629
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 629,
+                        "end": 663,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 630,
+                            "end": 639,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 630,
+                                "end": 634
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 635,
+                                "end": 639
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 641,
+                            "end": 650,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 641,
+                                "end": 642
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 642,
+                                "end": 649
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 649,
+                                "end": 650
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 652,
+                            "end": 662,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 652,
+                                "end": 656
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 657,
+                                "end": 662
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/dataset_where_filter.py.json
+++ b/tests/json-ast/x/py/dataset_where_filter.py.json
@@ -1,760 +1,937 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 643,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 17,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "Constant",
-                  "value": 30,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 26,
-                  "end_col_offset": 28
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 10,
-              "end_col_offset": 29
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 31,
-                "end_col_offset": 37
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 38,
-                  "end_col_offset": 43
-                },
-                {
-                  "_type": "Constant",
-                  "value": 15,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 45,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 31,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 50,
-                "end_col_offset": 56
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 57,
-                  "end_col_offset": 66
-                },
-                {
-                  "_type": "Constant",
-                  "value": 65,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 68,
-                  "end_col_offset": 70
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 50,
-              "end_col_offset": 71
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 73,
-                "end_col_offset": 79
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Diana",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 80,
-                  "end_col_offset": 87
-                },
-                {
-                  "_type": "Constant",
-                  "value": 45,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 89,
-                  "end_col_offset": 91
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 73,
-              "end_col_offset": 92
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 9,
-          "end_col_offset": 93
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 93
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Adult",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "bool",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 15,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "is_senior",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "adults",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Adult",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 15
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "person",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 22
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 16,
-                "end_col_offset": 27
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "person",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 29,
-                  "end_col_offset": 35
-                },
-                "attr": "age",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 29,
-                "end_col_offset": 39
-              },
-              {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "person",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 41,
-                    "end_col_offset": 47
-                  },
-                  "attr": "age",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 51
-                },
-                "ops": [
-                  {
-                    "_type": "GtE"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 60,
-                    "kind": null,
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 55,
-                    "end_col_offset": 57
-                  }
-                ],
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 41,
-                "end_col_offset": 57
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 10,
-            "end_col_offset": 58
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "person",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 63,
-                "end_col_offset": 69
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "people",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 73,
-                "end_col_offset": 79
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "person",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 19,
-                      "end_lineno": 19,
-                      "col_offset": 83,
-                      "end_col_offset": 89
-                    },
-                    "attr": "age",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 83,
-                    "end_col_offset": 93
-                  },
-                  "ops": [
-                    {
-                      "_type": "GtE"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 18,
-                      "kind": null,
-                      "lineno": 19,
-                      "end_lineno": 19,
-                      "col_offset": 97,
-                      "end_col_offset": 99
-                    }
-                  ],
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 83,
-                  "end_col_offset": 99
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 100
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 100
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Adults ---",
-              "kind": null,
-              "lineno": 20,
-              "end_lineno": 20,
-              "col_offset": 6,
-              "end_col_offset": 22
-            }
-          ],
-          "keywords": [],
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 0,
-          "end_col_offset": 23
-        },
-        "lineno": 20,
-        "end_lineno": 20,
-        "end_col_offset": 23
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "person",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 10,
-                    "end_col_offset": 16
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 10,
-                  "end_col_offset": 21
-                },
-                {
-                  "_type": "Constant",
-                  "value": "is",
-                  "kind": null,
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 23,
-                  "end_col_offset": 27
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "person",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 29,
-                    "end_col_offset": 35
-                  },
-                  "attr": "age",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 29,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "IfExp",
-                  "test": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "person",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 22,
-                      "end_lineno": 22,
-                      "col_offset": 57,
-                      "end_col_offset": 63
-                    },
-                    "attr": "is_senior",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 57,
-                    "end_col_offset": 73
-                  },
-                  "body": {
-                    "_type": "Constant",
-                    "value": " (senior)",
-                    "kind": null,
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 42,
-                    "end_col_offset": 53
-                  },
-                  "orelse": {
-                    "_type": "Constant",
-                    "value": "",
-                    "kind": null,
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 79,
-                    "end_col_offset": 81
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 42,
-                  "end_col_offset": 81
-                }
-              ],
-              "keywords": [],
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 83
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 83
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "person",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 4,
-          "end_col_offset": 10
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "adults",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 14,
-          "end_col_offset": 20
-        },
-        "lineno": 21,
-        "end_lineno": 22,
-        "end_col_offset": 83
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 244,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 244,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 216
+              },
+              {
+                "kind": "block",
+                "start": 222,
+                "end": 244,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 222,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 222,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 239
+                          },
+                          {
+                            "kind": "type",
+                            "start": 241,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 241,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 246,
+        "end": 339,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 246,
+            "end": 339,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 246,
+                "end": 252
+              },
+              {
+                "kind": "list",
+                "start": 255,
+                "end": 339,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 256,
+                    "end": 275,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 256,
+                        "end": 262
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 262,
+                        "end": 275,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 263,
+                            "end": 270,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 263,
+                                "end": 264
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 264,
+                                "end": 269
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 269,
+                                "end": 270
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 272,
+                            "end": 274
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 277,
+                    "end": 294,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 277,
+                        "end": 283
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 283,
+                        "end": 294,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 284,
+                            "end": 289,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 284,
+                                "end": 285
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 285,
+                                "end": 288
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 288,
+                                "end": 289
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 293
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 296,
+                    "end": 317,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 296,
+                        "end": 302
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 302,
+                        "end": 317,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 303,
+                            "end": 312,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 303,
+                                "end": 304
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 304,
+                                "end": 311
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 311,
+                                "end": 312
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 314,
+                            "end": 316
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 319,
+                    "end": 338,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 319,
+                        "end": 325
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 325,
+                        "end": 338,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 326,
+                            "end": 333,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 326,
+                                "end": 327
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 327,
+                                "end": 332
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 332,
+                                "end": 333
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 335,
+                            "end": 337
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 340,
+        "end": 410,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 340,
+            "end": 350,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 341,
+                "end": 350
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 351,
+            "end": 410,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 357,
+                "end": 362
+              },
+              {
+                "kind": "block",
+                "start": 368,
+                "end": 410,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 368,
+                    "end": 377,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 368,
+                        "end": 377,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 368,
+                            "end": 372
+                          },
+                          {
+                            "kind": "type",
+                            "start": 374,
+                            "end": 377,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 374,
+                                "end": 377
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 382,
+                    "end": 390,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 382,
+                        "end": 390,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 382,
+                            "end": 385
+                          },
+                          {
+                            "kind": "type",
+                            "start": 387,
+                            "end": 390,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 387,
+                                "end": 390
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 395,
+                    "end": 410,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 395,
+                        "end": 410,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 395,
+                            "end": 404
+                          },
+                          {
+                            "kind": "type",
+                            "start": 406,
+                            "end": 410,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 406,
+                                "end": 410
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 412,
+        "end": 512,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 412,
+            "end": 512,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 412,
+                "end": 418
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 421,
+                "end": 512,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 422,
+                    "end": 470,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 422,
+                        "end": 427
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 427,
+                        "end": 470,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 428,
+                            "end": 439,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 428,
+                                "end": 434
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 435,
+                                "end": 439
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 441,
+                            "end": 451,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 441,
+                                "end": 447
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 448,
+                                "end": 451
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 453,
+                            "end": 469,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 453,
+                                "end": 463,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 453,
+                                    "end": 459
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 460,
+                                    "end": 463
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 467,
+                                "end": 469
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 471,
+                    "end": 491,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 475,
+                        "end": 481
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 485,
+                        "end": 491
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 492,
+                    "end": 511,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 495,
+                        "end": 511,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 495,
+                            "end": 505,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 495,
+                                "end": 501
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 502,
+                                "end": 505
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 509,
+                            "end": 511
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 513,
+        "end": 536,
+        "children": [
+          {
+            "kind": "call",
+            "start": 513,
+            "end": 536,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 513,
+                "end": 518
+              },
+              {
+                "kind": "argument_list",
+                "start": 518,
+                "end": 536,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 519,
+                    "end": 535,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 519,
+                        "end": 520
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 520,
+                        "end": 534
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 534,
+                        "end": 535
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 537,
+        "end": 642,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 541,
+            "end": 547
+          },
+          {
+            "kind": "identifier",
+            "start": 551,
+            "end": 557
+          },
+          {
+            "kind": "block",
+            "start": 563,
+            "end": 642,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 563,
+                "end": 642,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 563,
+                    "end": 642,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 563,
+                        "end": 568
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 568,
+                        "end": 642,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 569,
+                            "end": 580,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 569,
+                                "end": 575
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 576,
+                                "end": 580
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 582,
+                            "end": 586,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 582,
+                                "end": 583
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 583,
+                                "end": 585
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 585,
+                                "end": 586
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 588,
+                            "end": 598,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 588,
+                                "end": 594
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 595,
+                                "end": 598
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 600,
+                            "end": 641,
+                            "children": [
+                              {
+                                "kind": "conditional_expression",
+                                "start": 601,
+                                "end": 640,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 601,
+                                    "end": 612,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 601,
+                                        "end": 602
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 602,
+                                        "end": 611
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 611,
+                                        "end": 612
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 616,
+                                    "end": 632,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 616,
+                                        "end": 622
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 623,
+                                        "end": 632
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 638,
+                                    "end": 640,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 638,
+                                        "end": 639
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 639,
+                                        "end": 640
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/exists_builtin.py.json
+++ b/tests/json-ast/x/py/exists_builtin.py.json
@@ -1,255 +1,246 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 188,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "data",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 13
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 13
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 106,
+        "children": [
           {
-            "_type": "Name",
-            "id": "flag",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Compare",
-          "left": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "len",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "args": [
+            "kind": "assignment",
+            "start": 93,
+            "end": 106,
+            "children": [
               {
-                "_type": "ListComp",
-                "elt": {
-                  "_type": "Name",
-                  "id": "x",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "generators": [
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
+              },
+              {
+                "kind": "list",
+                "start": 100,
+                "end": 106,
+                "children": [
                   {
-                    "_type": "comprehension",
-                    "target": {
-                      "_type": "Name",
-                      "id": "x",
-                      "ctx": {
-                        "_type": "Store"
-                      },
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 18,
-                      "end_col_offset": 19
-                    },
-                    "iter": {
-                      "_type": "Name",
-                      "id": "data",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 23,
-                      "end_col_offset": 27
-                    },
-                    "ifs": [
-                      {
-                        "_type": "Compare",
-                        "left": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 4,
-                          "end_lineno": 4,
-                          "col_offset": 31,
-                          "end_col_offset": 32
-                        },
-                        "ops": [
-                          {
-                            "_type": "Eq"
-                          }
-                        ],
-                        "comparators": [
-                          {
-                            "_type": "Constant",
-                            "value": 1,
-                            "kind": null,
-                            "lineno": 4,
-                            "end_lineno": 4,
-                            "col_offset": 36,
-                            "end_col_offset": 37
-                          }
-                        ],
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 31,
-                        "end_col_offset": 37
-                      }
-                    ],
-                    "is_async": 0
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
                   }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 38
+                ]
               }
-            ],
-            "keywords": [],
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 7,
-            "end_col_offset": 39
-          },
-          "ops": [
-            {
-              "_type": "Gt"
-            }
-          ],
-          "comparators": [
-            {
-              "_type": "Constant",
-              "value": 0,
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 42,
-              "end_col_offset": 43
-            }
-          ],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 7,
-          "end_col_offset": 43
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 43
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Name",
-                "id": "flag",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 17,
-                "end_col_offset": 21
+        "kind": "expression_statement",
+        "start": 107,
+        "end": 150,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 107,
+            "end": 150,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 107,
+                "end": 111
               },
-              "body": {
-                "_type": "Constant",
-                "value": "true",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 13
+              {
+                "kind": "comparison_operator",
+                "start": 114,
+                "end": 150,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 114,
+                    "end": 146,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 114,
+                        "end": 117
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 117,
+                        "end": 146,
+                        "children": [
+                          {
+                            "kind": "list_comprehension",
+                            "start": 118,
+                            "end": 145,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 119,
+                                "end": 120
+                              },
+                              {
+                                "kind": "for_in_clause",
+                                "start": 121,
+                                "end": 134,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 125,
+                                    "end": 126
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 130,
+                                    "end": 134
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "if_clause",
+                                "start": 135,
+                                "end": 144,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 138,
+                                    "end": 144,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 138,
+                                        "end": 139
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 143,
+                                        "end": 144
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 149,
+                    "end": 150
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 151,
+        "end": 187,
+        "children": [
+          {
+            "kind": "call",
+            "start": 151,
+            "end": 187,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 151,
+                "end": 156
               },
-              "orelse": {
-                "_type": "Constant",
-                "value": "false",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 27,
-                "end_col_offset": 34
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 34
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 36
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 36
+              {
+                "kind": "argument_list",
+                "start": 156,
+                "end": 187,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 157,
+                    "end": 186,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 158,
+                        "end": 185,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 158,
+                            "end": 164,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 158,
+                                "end": 159
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 159,
+                                "end": 163
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 163,
+                                "end": 164
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 168,
+                            "end": 172
+                          },
+                          {
+                            "kind": "string",
+                            "start": 178,
+                            "end": 185,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 178,
+                                "end": 179
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 179,
+                                "end": 184
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 184,
+                                "end": 185
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/for_list_collection.py.json
+++ b/tests/json-ast/x/py/for_list_collection.py.json
@@ -1,94 +1,90 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 126,
+    "children": [
       {
-        "_type": "For",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "for_statement",
+        "start": 93,
+        "end": 125,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 4,
-                "end_col_offset": 9
+            "kind": "identifier",
+            "start": 97,
+            "end": 98
+          },
+          {
+            "kind": "list",
+            "start": 102,
+            "end": 111,
+            "children": [
+              {
+                "kind": "integer",
+                "start": 103,
+                "end": 104
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 12
+              {
+                "kind": "integer",
+                "start": 106,
+                "end": 107
+              },
+              {
+                "kind": "integer",
+                "start": 109,
+                "end": 110
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 117,
+            "end": 125,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 117,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 117,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 117,
+                        "end": 122
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 122,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 123,
+                            "end": 124
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "n",
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 14
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 16,
-              "end_col_offset": 17
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 18
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 12
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/for_loop.py.json
+++ b/tests/json-ast/x/py/for_loop.py.json
@@ -1,96 +1,97 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 128,
+    "children": [
       {
-        "_type": "For",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "for_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "i",
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "range",
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 9,
-            "end_col_offset": 14
+            "kind": "identifier",
+            "start": 97,
+            "end": 98
           },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 15,
-              "end_col_offset": 16
-            },
-            {
-              "_type": "Constant",
-              "value": 4,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 12
+          {
+            "kind": "call",
+            "start": 102,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 102,
+                "end": 107
+              },
+              {
+                "kind": "argument_list",
+                "start": 107,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 108,
+                    "end": 109
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 111,
+                    "end": 112
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 119,
+            "end": 127,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 119,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 119,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 119,
+                        "end": 124
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 124,
+                        "end": 127,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 125,
+                            "end": 126
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/for_map_collection.py.json
+++ b/tests/json-ast/x/py/for_map_collection.py.json
@@ -1,131 +1,167 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 139,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 16
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 20
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "For",
-        "body": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 113,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 4,
-                "end_col_offset": 9
+            "kind": "assignment",
+            "start": 93,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "k",
-                  "ctx": {
-                    "_type": "Load"
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 98,
+                        "end": 101,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 98,
+                            "end": 99
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 100,
+                            "end": 101
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
                   },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 12
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 106,
+                        "end": 109,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 108,
+                            "end": 109
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 111,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "k",
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "m",
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 9,
-          "end_col_offset": 10
-        },
-        "lineno": 4,
-        "end_lineno": 5,
-        "end_col_offset": 12
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 114,
+        "end": 138,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 118,
+            "end": 119
+          },
+          {
+            "kind": "identifier",
+            "start": 123,
+            "end": 124
+          },
+          {
+            "kind": "block",
+            "start": 130,
+            "end": 138,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 130,
+                "end": 138,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 130,
+                    "end": 138,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 130,
+                        "end": 135
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 135,
+                        "end": 138,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 136,
+                            "end": 137
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/fun_call.py.json
+++ b/tests/json-ast/x/py/fun_call.py.json
@@ -1,151 +1,133 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 142,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "add",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "a",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 12
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 15,
-                "end_col_offset": 16
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 11,
-              "end_col_offset": 16
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 16
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "a",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "arg",
-              "arg": "b",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 124,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 100
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "add",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 9
+          {
+            "kind": "parameters",
+            "start": 100,
+            "end": 106,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 101,
+                "end": 102
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 13,
-                  "end_col_offset": 14
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 16
+              {
+                "kind": "identifier",
+                "start": 104,
+                "end": 105
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 112,
+            "end": 124,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 112,
+                "end": 124,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 119,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 119,
+                        "end": 120
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 123,
+                        "end": 124
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 125,
+        "end": 141,
+        "children": [
+          {
+            "kind": "call",
+            "start": 125,
+            "end": 141,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 125,
+                "end": 130
+              },
+              {
+                "kind": "argument_list",
+                "start": 130,
+                "end": 141,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 131,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 131,
+                        "end": 134
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 134,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 135,
+                            "end": 136
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 138,
+                            "end": 139
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/fun_expr_in_let.py.json
+++ b/tests/json-ast/x/py/fun_expr_in_let.py.json
@@ -1,138 +1,123 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 135,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "square",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "Lambda",
-          "args": {
-            "_type": "arguments",
-            "posonlyargs": [],
-            "args": [
-              {
-                "_type": "arg",
-                "arg": "x",
-                "annotation": null,
-                "type_comment": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 16,
-                "end_col_offset": 17
-              }
-            ],
-            "vararg": null,
-            "kwonlyargs": [],
-            "kw_defaults": [],
-            "kwarg": null,
-            "defaults": []
-          },
-          "body": {
-            "_type": "BinOp",
-            "left": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 19,
-              "end_col_offset": 20
-            },
-            "op": {
-              "_type": "Mult"
-            },
-            "right": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 23,
-              "end_col_offset": 24
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 19,
-            "end_col_offset": 24
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 24
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 24
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "square",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 12
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 117,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 117,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 99
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 6,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 13,
-                  "end_col_offset": 14
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 16
+              {
+                "kind": "lambda",
+                "start": 102,
+                "end": 117,
+                "children": [
+                  {
+                    "kind": "lambda_parameters",
+                    "start": 109,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 109,
+                        "end": 110
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "binary_operator",
+                    "start": 112,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 112,
+                        "end": 113
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 116,
+                        "end": 117
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 118,
+        "end": 134,
+        "children": [
+          {
+            "kind": "call",
+            "start": 118,
+            "end": 134,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 118,
+                "end": 123
+              },
+              {
+                "kind": "argument_list",
+                "start": 123,
+                "end": 134,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 124,
+                    "end": 133,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 124,
+                        "end": 130
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 130,
+                        "end": 133,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 131,
+                            "end": 132
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/fun_three_args.py.json
+++ b/tests/json-ast/x/py/fun_three_args.py.json
@@ -1,191 +1,155 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 154,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "sum3",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Name",
-                  "id": "a",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "op": {
-                  "_type": "Add"
-                },
-                "right": {
-                  "_type": "Name",
-                  "id": "b",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 16
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 19,
-                "end_col_offset": 20
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 11,
-              "end_col_offset": 20
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 20
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "a",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 9,
-              "end_col_offset": 10
-            },
-            {
-              "_type": "arg",
-              "arg": "b",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 12,
-              "end_col_offset": 13
-            },
-            {
-              "_type": "arg",
-              "arg": "c",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 15,
-              "end_col_offset": 16
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 20
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 132,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 101
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "sum3",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 10
+          {
+            "kind": "parameters",
+            "start": 101,
+            "end": 110,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 102,
+                "end": 103
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 19
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 20
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 20
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 106
+              },
+              {
+                "kind": "identifier",
+                "start": 108,
+                "end": 109
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 116,
+            "end": 132,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 116,
+                "end": 132,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 123,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "binary_operator",
+                        "start": 123,
+                        "end": 128,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 123,
+                            "end": 124
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 127,
+                            "end": 128
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 131,
+                        "end": 132
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 133,
+        "end": 153,
+        "children": [
+          {
+            "kind": "call",
+            "start": 133,
+            "end": 153,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 138
+              },
+              {
+                "kind": "argument_list",
+                "start": 138,
+                "end": 153,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 139,
+                    "end": 152,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 139,
+                        "end": 143
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 143,
+                        "end": 152,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 144,
+                            "end": 145
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 147,
+                            "end": 148
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 150,
+                            "end": 151
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/go_auto.py.json
+++ b/tests/json-ast/x/py/go_auto.py.json
@@ -1,133 +1,123 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 128,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 2,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 7
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 3,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 10,
-                "end_col_offset": 11
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 12
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 3.14,
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 42,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 8
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 9
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 9
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 105,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 105,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
+              },
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 105,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 99,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 99,
+                        "end": 100
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 117,
+        "children": [
+          {
+            "kind": "call",
+            "start": 106,
+            "end": 117,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 111
+              },
+              {
+                "kind": "argument_list",
+                "start": 111,
+                "end": 117,
+                "children": [
+                  {
+                    "kind": "float",
+                    "start": 112,
+                    "end": 116
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 118,
+        "end": 127,
+        "children": [
+          {
+            "kind": "call",
+            "start": 118,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 118,
+                "end": 123
+              },
+              {
+                "kind": "argument_list",
+                "start": 123,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 124,
+                    "end": 126
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by.py.json
+++ b/tests/json-ast/x/py/group_by.py.json
@@ -1,1426 +1,1673 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 1016,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "city",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 11,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 17,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "Constant",
-                  "value": 30,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 26,
-                  "end_col_offset": 28
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 30,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 10,
-              "end_col_offset": 38
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 40,
-                "end_col_offset": 46
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                },
-                {
-                  "_type": "Constant",
-                  "value": 15,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 54,
-                  "end_col_offset": 56
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 58,
-                  "end_col_offset": 65
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 40,
-              "end_col_offset": 66
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 68,
-                "end_col_offset": 74
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 75,
-                  "end_col_offset": 84
-                },
-                {
-                  "_type": "Constant",
-                  "value": 65,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 86,
-                  "end_col_offset": 88
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 90,
-                  "end_col_offset": 97
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 68,
-              "end_col_offset": 98
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 100,
-                "end_col_offset": 106
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Diana",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 107,
-                  "end_col_offset": 114
-                },
-                {
-                  "_type": "Constant",
-                  "value": 45,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 116,
-                  "end_col_offset": 118
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 120,
-                  "end_col_offset": 127
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 100,
-              "end_col_offset": 128
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 130,
-                "end_col_offset": 136
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Eve",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 137,
-                  "end_col_offset": 142
-                },
-                {
-                  "_type": "Constant",
-                  "value": 70,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 144,
-                  "end_col_offset": 146
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 148,
-                  "end_col_offset": 155
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 130,
-              "end_col_offset": 156
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 158,
-                "end_col_offset": 164
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Frank",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 165,
-                  "end_col_offset": 172
-                },
-                {
-                  "_type": "Constant",
-                  "value": 22,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 174,
-                  "end_col_offset": 176
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 178,
-                  "end_col_offset": 185
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 158,
-              "end_col_offset": 186
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 9,
-          "end_col_offset": 187
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 187
-      },
-      {
-        "_type": "ClassDef",
-        "name": "StatsGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 15,
-        "end_lineno": 17,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_stats_groups",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 13
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 16,
-          "end_col_offset": 18
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_stats_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 9,
-                  "end_col_offset": 22
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 9,
-                "end_col_offset": 33
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "person",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 21,
-                    "end_lineno": 21,
-                    "col_offset": 34,
-                    "end_col_offset": 40
-                  },
-                  "attr": "city",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 34,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "StatsGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 21,
-                    "end_lineno": 21,
-                    "col_offset": 47,
-                    "end_col_offset": 57
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "person",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 21,
-                        "end_lineno": 21,
-                        "col_offset": 58,
-                        "end_col_offset": 64
-                      },
-                      "attr": "city",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 21,
-                      "end_lineno": 21,
-                      "col_offset": 58,
-                      "end_col_offset": 69
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 21,
-                      "end_lineno": 21,
-                      "col_offset": 71,
-                      "end_col_offset": 73
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 47,
-                  "end_col_offset": 74
-                }
-              ],
-              "keywords": [],
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 9,
-              "end_col_offset": 75
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 75
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "person",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 20,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 27
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 27
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "person",
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 4,
-          "end_col_offset": 10
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "people",
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 14,
-          "end_col_offset": 20
-        },
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 27
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Stat",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "city",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "count",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 13,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "avg_age",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 18
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 24,
-        "end_lineno": 27,
-        "end_col_offset": 18
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "stats",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 5
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Stat",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 258,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 14,
-                "end_col_offset": 19
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 258,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 216
               },
               {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "len",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 21,
-                  "end_col_offset": 24
-                },
-                "args": [
+                "kind": "block",
+                "start": 222,
+                "end": 258,
+                "children": [
                   {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "g",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 25,
-                      "end_col_offset": 26
-                    },
-                    "attr": "items",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 25,
-                    "end_col_offset": 32
+                    "kind": "expression_statement",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 222,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 222,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 239
+                          },
+                          {
+                            "kind": "type",
+                            "start": 241,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 241,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 249,
+                    "end": 258,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 249,
+                        "end": 258,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 249,
+                            "end": 253
+                          },
+                          {
+                            "kind": "type",
+                            "start": 255,
+                            "end": 258,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 255,
+                                "end": 258
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "keywords": [],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 21,
-                "end_col_offset": 33
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 260,
+        "end": 447,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 260,
+            "end": 447,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 260,
+                "end": 266
               },
               {
-                "_type": "IfExp",
-                "test": {
-                  "_type": "ListComp",
-                  "elt": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "p",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 102,
-                      "end_col_offset": 103
-                    },
-                    "attr": "age",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 102,
-                    "end_col_offset": 107
-                  },
-                  "generators": [
-                    {
-                      "_type": "comprehension",
-                      "target": {
-                        "_type": "Name",
-                        "id": "p",
-                        "ctx": {
-                          "_type": "Store"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 112,
-                        "end_col_offset": 113
-                      },
-                      "iter": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "g",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 117,
-                          "end_col_offset": 118
-                        },
-                        "attr": "items",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 117,
-                        "end_col_offset": 124
-                      },
-                      "ifs": [],
-                      "is_async": 0
-                    }
-                  ],
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 101,
-                  "end_col_offset": 125
-                },
-                "body": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "sum",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 36,
-                      "end_col_offset": 39
-                    },
-                    "args": [
+                "kind": "list",
+                "start": 269,
+                "end": 447,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 270,
+                    "end": 298,
+                    "children": [
                       {
-                        "_type": "ListComp",
-                        "elt": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "p",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 41,
-                            "end_col_offset": 42
-                          },
-                          "attr": "age",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 41,
-                          "end_col_offset": 46
-                        },
-                        "generators": [
-                          {
-                            "_type": "comprehension",
-                            "target": {
-                              "_type": "Name",
-                              "id": "p",
-                              "ctx": {
-                                "_type": "Store"
-                              },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 51,
-                              "end_col_offset": 52
-                            },
-                            "iter": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "g",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 29,
-                                "end_lineno": 29,
-                                "col_offset": 56,
-                                "end_col_offset": 57
-                              },
-                              "attr": "items",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 56,
-                              "end_col_offset": 63
-                            },
-                            "ifs": [],
-                            "is_async": 0
-                          }
-                        ],
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 40,
-                        "end_col_offset": 64
-                      }
-                    ],
-                    "keywords": [],
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 36,
-                    "end_col_offset": 65
-                  },
-                  "op": {
-                    "_type": "Div"
-                  },
-                  "right": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "len",
-                      "ctx": {
-                        "_type": "Load"
+                        "kind": "identifier",
+                        "start": 270,
+                        "end": 276
                       },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 68,
-                      "end_col_offset": 71
-                    },
-                    "args": [
                       {
-                        "_type": "ListComp",
-                        "elt": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "p",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 73,
-                            "end_col_offset": 74
-                          },
-                          "attr": "age",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 73,
-                          "end_col_offset": 78
-                        },
-                        "generators": [
+                        "kind": "argument_list",
+                        "start": 276,
+                        "end": 298,
+                        "children": [
                           {
-                            "_type": "comprehension",
-                            "target": {
-                              "_type": "Name",
-                              "id": "p",
-                              "ctx": {
-                                "_type": "Store"
+                            "kind": "string",
+                            "start": 277,
+                            "end": 284,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 277,
+                                "end": 278
                               },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 83,
-                              "end_col_offset": 84
-                            },
-                            "iter": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "g",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 29,
-                                "end_lineno": 29,
-                                "col_offset": 88,
-                                "end_col_offset": 89
+                              {
+                                "kind": "string_content",
+                                "start": 278,
+                                "end": 283
                               },
-                              "attr": "items",
-                              "ctx": {
-                                "_type": "Load"
+                              {
+                                "kind": "string_end",
+                                "start": 283,
+                                "end": 284
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 286,
+                            "end": 288
+                          },
+                          {
+                            "kind": "string",
+                            "start": 290,
+                            "end": 297,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 290,
+                                "end": 291
                               },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 88,
-                              "end_col_offset": 95
-                            },
-                            "ifs": [],
-                            "is_async": 0
+                              {
+                                "kind": "string_content",
+                                "start": 291,
+                                "end": 296
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 296,
+                                "end": 297
+                              }
+                            ]
                           }
-                        ],
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 72,
-                        "end_col_offset": 96
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 68,
-                    "end_col_offset": 97
+                    ]
                   },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 36,
-                  "end_col_offset": 97
-                },
-                "orelse": {
-                  "_type": "Constant",
-                  "value": 0.0,
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 131,
-                  "end_col_offset": 134
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 36,
-                "end_col_offset": 134
+                  {
+                    "kind": "call",
+                    "start": 300,
+                    "end": 326,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 300,
+                        "end": 306
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 306,
+                        "end": 326,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 307,
+                            "end": 312,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 307,
+                                "end": 308
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 308,
+                                "end": 311
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 311,
+                                "end": 312
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 314,
+                            "end": 316
+                          },
+                          {
+                            "kind": "string",
+                            "start": 318,
+                            "end": 325,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 318,
+                                "end": 319
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 319,
+                                "end": 324
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 324,
+                                "end": 325
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 328,
+                    "end": 358,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 328,
+                        "end": 334
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 334,
+                        "end": 358,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 335,
+                            "end": 344,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 335,
+                                "end": 336
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 336,
+                                "end": 343
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 343,
+                                "end": 344
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 346,
+                            "end": 348
+                          },
+                          {
+                            "kind": "string",
+                            "start": 350,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 350,
+                                "end": 351
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 351,
+                                "end": 356
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 356,
+                                "end": 357
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 360,
+                    "end": 388,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 360,
+                        "end": 366
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 366,
+                        "end": 388,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 367,
+                            "end": 374,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 367,
+                                "end": 368
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 368,
+                                "end": 373
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 373,
+                                "end": 374
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 376,
+                            "end": 378
+                          },
+                          {
+                            "kind": "string",
+                            "start": 380,
+                            "end": 387,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 380,
+                                "end": 381
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 381,
+                                "end": 386
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 386,
+                                "end": 387
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 390,
+                    "end": 416,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 390,
+                        "end": 396
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 396,
+                        "end": 416,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 397,
+                            "end": 402,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 397,
+                                "end": 398
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 398,
+                                "end": 401
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 401,
+                                "end": 402
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 404,
+                            "end": 406
+                          },
+                          {
+                            "kind": "string",
+                            "start": 408,
+                            "end": 415,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 408,
+                                "end": 409
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 409,
+                                "end": 414
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 414,
+                                "end": 415
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 418,
+                    "end": 446,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 418,
+                        "end": 424
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 424,
+                        "end": 446,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 425,
+                            "end": 432,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 425,
+                                "end": 426
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 426,
+                                "end": 431
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 431,
+                                "end": 432
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 434,
+                            "end": 436
+                          },
+                          {
+                            "kind": "string",
+                            "start": 438,
+                            "end": 445,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 438,
+                                "end": 439
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 439,
+                                "end": 444
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 444,
+                                "end": 445
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "keywords": [],
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 9,
-            "end_col_offset": 136
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 141,
-                "end_col_offset": 142
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_stats_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 146,
-                    "end_col_offset": 159
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 146,
-                  "end_col_offset": 166
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 146,
-                "end_col_offset": 168
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 8,
-          "end_col_offset": 169
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 169
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- People grouped by city ---",
-              "kind": null,
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 6,
-              "end_col_offset": 38
-            }
-          ],
-          "keywords": [],
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 0,
-          "end_col_offset": 39
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 39
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "city",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": ": count =",
-                  "kind": null,
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 18,
-                  "end_col_offset": 29
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 31,
-                    "end_col_offset": 32
-                  },
-                  "attr": "count",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 31,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Constant",
-                  "value": ", avg_age =",
-                  "kind": null,
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 40,
-                  "end_col_offset": 53
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 55,
-                    "end_col_offset": 56
-                  },
-                  "attr": "avg_age",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 55,
-                  "end_col_offset": 64
-                }
-              ],
-              "keywords": [],
-              "lineno": 32,
-              "end_lineno": 32,
-              "col_offset": 4,
-              "end_col_offset": 65
-            },
-            "lineno": 32,
-            "end_lineno": 32,
-            "col_offset": 4,
-            "end_col_offset": 65
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "s",
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "stats",
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 31,
-        "end_lineno": 32,
-        "end_col_offset": 65
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 448,
+        "end": 505,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 448,
+            "end": 458,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 449,
+                "end": 458
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 459,
+            "end": 505,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 465,
+                "end": 475
+              },
+              {
+                "kind": "block",
+                "start": 481,
+                "end": 505,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 481,
+                    "end": 489,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 481,
+                        "end": 489,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 481,
+                            "end": 484
+                          },
+                          {
+                            "kind": "type",
+                            "start": 486,
+                            "end": 489,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 486,
+                                "end": 489
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 494,
+                    "end": 505,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 494,
+                        "end": 505,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 494,
+                            "end": 499
+                          },
+                          {
+                            "kind": "type",
+                            "start": 501,
+                            "end": 505,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 501,
+                                "end": 505
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 507,
+        "end": 525,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 507,
+            "end": 525,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 507,
+                "end": 520
+              },
+              {
+                "kind": "dictionary",
+                "start": 523,
+                "end": 525
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 526,
+        "end": 651,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 530,
+            "end": 536
+          },
+          {
+            "kind": "identifier",
+            "start": 540,
+            "end": 546
+          },
+          {
+            "kind": "block",
+            "start": 552,
+            "end": 651,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 552,
+                "end": 623,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 552,
+                    "end": 623,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 552,
+                        "end": 554
+                      },
+                      {
+                        "kind": "call",
+                        "start": 557,
+                        "end": 623,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 557,
+                            "end": 581,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 557,
+                                "end": 570
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 571,
+                                "end": 581
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 581,
+                            "end": 623,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 582,
+                                "end": 593,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 582,
+                                    "end": 588
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 589,
+                                    "end": 593
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 595,
+                                "end": 622,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 595,
+                                    "end": 605
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 605,
+                                    "end": 622,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 606,
+                                        "end": 617,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 606,
+                                            "end": 612
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 613,
+                                            "end": 617
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 619,
+                                        "end": 621
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 628,
+                "end": 651,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 628,
+                    "end": 651,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 628,
+                        "end": 643,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 628,
+                            "end": 636,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 628,
+                                "end": 630
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 631,
+                                "end": 636
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 637,
+                            "end": 643
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 643,
+                        "end": 651,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 644,
+                            "end": 650
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 652,
+        "end": 722,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 652,
+            "end": 662,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 653,
+                "end": 662
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 663,
+            "end": 722,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 669,
+                "end": 673
+              },
+              {
+                "kind": "block",
+                "start": 679,
+                "end": 722,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 679,
+                    "end": 688,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 679,
+                        "end": 688,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 679,
+                            "end": 683
+                          },
+                          {
+                            "kind": "type",
+                            "start": 685,
+                            "end": 688,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 685,
+                                "end": 688
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 693,
+                    "end": 703,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 693,
+                        "end": 703,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 693,
+                            "end": 698
+                          },
+                          {
+                            "kind": "type",
+                            "start": 700,
+                            "end": 703,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 700,
+                                "end": 703
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 708,
+                    "end": 722,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 708,
+                        "end": 722,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 708,
+                            "end": 715
+                          },
+                          {
+                            "kind": "type",
+                            "start": 717,
+                            "end": 722,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 717,
+                                "end": 722
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 724,
+        "end": 893,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 724,
+            "end": 893,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 724,
+                "end": 729
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 732,
+                "end": 893,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 733,
+                    "end": 860,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 733,
+                        "end": 737
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 737,
+                        "end": 860,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 738,
+                            "end": 743,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 738,
+                                "end": 739
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 740,
+                                "end": 743
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 745,
+                            "end": 757,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 745,
+                                "end": 748
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 748,
+                                "end": 757,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 749,
+                                    "end": 756,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 749,
+                                        "end": 750
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 751,
+                                        "end": 756
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 759,
+                            "end": 859,
+                            "children": [
+                              {
+                                "kind": "conditional_expression",
+                                "start": 760,
+                                "end": 858,
+                                "children": [
+                                  {
+                                    "kind": "binary_operator",
+                                    "start": 760,
+                                    "end": 821,
+                                    "children": [
+                                      {
+                                        "kind": "call",
+                                        "start": 760,
+                                        "end": 789,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 760,
+                                            "end": 763
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 763,
+                                            "end": 789,
+                                            "children": [
+                                              {
+                                                "kind": "list_comprehension",
+                                                "start": 764,
+                                                "end": 788,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 765,
+                                                    "end": 770,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 765,
+                                                        "end": 766
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 767,
+                                                        "end": 770
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "for_in_clause",
+                                                    "start": 771,
+                                                    "end": 787,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 775,
+                                                        "end": 776
+                                                      },
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 780,
+                                                        "end": 787,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 780,
+                                                            "end": 781
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 782,
+                                                            "end": 787
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 792,
+                                        "end": 821,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 792,
+                                            "end": 795
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 795,
+                                            "end": 821,
+                                            "children": [
+                                              {
+                                                "kind": "list_comprehension",
+                                                "start": 796,
+                                                "end": 820,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 797,
+                                                    "end": 802,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 797,
+                                                        "end": 798
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 799,
+                                                        "end": 802
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "for_in_clause",
+                                                    "start": 803,
+                                                    "end": 819,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 807,
+                                                        "end": 808
+                                                      },
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 812,
+                                                        "end": 819,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 812,
+                                                            "end": 813
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 814,
+                                                            "end": 819
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 825,
+                                    "end": 849,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 826,
+                                        "end": 831,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 826,
+                                            "end": 827
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 828,
+                                            "end": 831
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 832,
+                                        "end": 848,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 836,
+                                            "end": 837
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 841,
+                                            "end": 848,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 841,
+                                                "end": 842
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 843,
+                                                "end": 848
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "float",
+                                    "start": 855,
+                                    "end": 858
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 861,
+                    "end": 892,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 865,
+                        "end": 866
+                      },
+                      {
+                        "kind": "call",
+                        "start": 870,
+                        "end": 892,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 870,
+                            "end": 890,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 870,
+                                "end": 883
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 884,
+                                "end": 890
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 890,
+                            "end": 892
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 894,
+        "end": 933,
+        "children": [
+          {
+            "kind": "call",
+            "start": 894,
+            "end": 933,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 894,
+                "end": 899
+              },
+              {
+                "kind": "argument_list",
+                "start": 899,
+                "end": 933,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 900,
+                    "end": 932,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 900,
+                        "end": 901
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 901,
+                        "end": 931
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 931,
+                        "end": 932
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 934,
+        "end": 1015,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 938,
+            "end": 939
+          },
+          {
+            "kind": "identifier",
+            "start": 943,
+            "end": 948
+          },
+          {
+            "kind": "block",
+            "start": 954,
+            "end": 1015,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 954,
+                "end": 1015,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 954,
+                    "end": 1015,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 954,
+                        "end": 959
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 959,
+                        "end": 1015,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 960,
+                            "end": 966,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 960,
+                                "end": 961
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 962,
+                                "end": 966
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 968,
+                            "end": 979,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 968,
+                                "end": 969
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 969,
+                                "end": 978
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 978,
+                                "end": 979
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 981,
+                            "end": 988,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 981,
+                                "end": 982
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 983,
+                                "end": 988
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 990,
+                            "end": 1003,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 990,
+                                "end": 991
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 991,
+                                "end": 1002
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 1002,
+                                "end": 1003
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 1005,
+                            "end": 1014,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1005,
+                                "end": 1006
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1007,
+                                "end": 1014
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_conditional_sum.py.json
+++ b/tests/json-ast/x/py/group_by_conditional_sum.py.json
@@ -1,1188 +1,1294 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 807,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "cat",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "val",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "bool",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 10,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "flag",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 12,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 14,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Constant",
-                  "value": 10,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 19,
-                  "end_col_offset": 21
-                },
-                {
-                  "_type": "Constant",
-                  "value": true,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 23,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 9,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 30,
-                "end_col_offset": 34
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 35,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 40,
-                  "end_col_offset": 41
-                },
-                {
-                  "_type": "Constant",
-                  "value": false,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 43,
-                  "end_col_offset": 48
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 30,
-              "end_col_offset": 49
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 51,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 20,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 61,
-                  "end_col_offset": 63
-                },
-                {
-                  "_type": "Constant",
-                  "value": true,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 65,
-                  "end_col_offset": 69
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 51,
-              "end_col_offset": 70
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 8,
-          "end_col_offset": 71
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 71
-      },
-      {
-        "_type": "ClassDef",
-        "name": "ResultGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 18,
-            "end_lineno": 18,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 16,
-        "end_lineno": 18,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_result_groups",
-            "lineno": 20,
-            "end_lineno": 20,
-            "end_col_offset": 14
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 17,
-          "end_col_offset": 19
-        },
-        "lineno": 20,
-        "end_lineno": 20,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_result_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 9,
-                  "end_col_offset": 23
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 9,
-                "end_col_offset": 34
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "i",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 35,
-                    "end_col_offset": 36
-                  },
-                  "attr": "cat",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 35,
-                  "end_col_offset": 40
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "ResultGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 42,
-                    "end_col_offset": 53
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "i",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 22,
-                        "end_lineno": 22,
-                        "col_offset": 54,
-                        "end_col_offset": 55
-                      },
-                      "attr": "cat",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 22,
-                      "end_lineno": 22,
-                      "col_offset": 54,
-                      "end_col_offset": 59
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 22,
-                      "end_lineno": 22,
-                      "col_offset": 61,
-                      "end_col_offset": 63
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 42,
-                  "end_col_offset": 64
-                }
-              ],
-              "keywords": [],
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 9,
-              "end_col_offset": 65
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 65
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 23,
-                "end_lineno": 23,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "i",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "items",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "cat",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "share",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 25,
-        "end_lineno": 27,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 17,
-                "end_col_offset": 22
-              },
-              {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "sum",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 24,
-                    "end_col_offset": 27
-                  },
-                  "args": [
-                    {
-                      "_type": "ListComp",
-                      "elt": {
-                        "_type": "IfExp",
-                        "test": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "x",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 39,
-                            "end_col_offset": 40
-                          },
-                          "attr": "flag",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 39,
-                          "end_col_offset": 45
-                        },
-                        "body": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "x",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 30,
-                            "end_col_offset": 31
-                          },
-                          "attr": "val",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 30,
-                          "end_col_offset": 35
-                        },
-                        "orelse": {
-                          "_type": "Constant",
-                          "value": 0,
-                          "kind": null,
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 51,
-                          "end_col_offset": 52
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 30,
-                        "end_col_offset": 52
-                      },
-                      "generators": [
-                        {
-                          "_type": "comprehension",
-                          "target": {
-                            "_type": "Name",
-                            "id": "x",
-                            "ctx": {
-                              "_type": "Store"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 58,
-                            "end_col_offset": 59
-                          },
-                          "iter": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "g",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 63,
-                              "end_col_offset": 64
-                            },
-                            "attr": "items",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 63,
-                            "end_col_offset": 70
-                          },
-                          "ifs": [],
-                          "is_async": 0
-                        }
-                      ],
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 28,
-                      "end_col_offset": 71
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 24,
-                  "end_col_offset": 72
-                },
-                "op": {
-                  "_type": "FloorDiv"
-                },
-                "right": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "sum",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 76,
-                    "end_col_offset": 79
-                  },
-                  "args": [
-                    {
-                      "_type": "ListComp",
-                      "elt": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 81,
-                          "end_col_offset": 82
-                        },
-                        "attr": "val",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 81,
-                        "end_col_offset": 86
-                      },
-                      "generators": [
-                        {
-                          "_type": "comprehension",
-                          "target": {
-                            "_type": "Name",
-                            "id": "x",
-                            "ctx": {
-                              "_type": "Store"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 91,
-                            "end_col_offset": 92
-                          },
-                          "iter": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "g",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 29,
-                              "end_lineno": 29,
-                              "col_offset": 96,
-                              "end_col_offset": 97
-                            },
-                            "attr": "items",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 96,
-                            "end_col_offset": 103
-                          },
-                          "ifs": [],
-                          "is_async": 0
-                        }
-                      ],
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 80,
-                      "end_col_offset": 104
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 76,
-                  "end_col_offset": 105
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 24,
-                "end_col_offset": 105
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
               }
-            ],
-            "keywords": [],
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 10,
-            "end_col_offset": 106
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 111,
-                "end_col_offset": 112
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 275,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 275,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 233
               },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 116,
-                  "end_col_offset": 122
-                },
-                "args": [
+              {
+                "kind": "block",
+                "start": 239,
+                "end": 275,
+                "children": [
                   {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_result_groups",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 123,
-                        "end_col_offset": 137
-                      },
-                      "attr": "values",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 123,
-                      "end_col_offset": 144
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 123,
-                    "end_col_offset": 146
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                    "kind": "expression_statement",
+                    "start": 239,
+                    "end": 247,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 239,
+                        "end": 247,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "g",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 159,
-                            "end_col_offset": 160
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "g",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 239,
+                            "end": 242
                           },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 162,
-                          "end_col_offset": 163
-                        },
-                        "attr": "key",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 162,
-                        "end_col_offset": 167
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 152,
-                      "end_col_offset": 167
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 148,
-                    "end_col_offset": 167
+                          {
+                            "kind": "type",
+                            "start": 244,
+                            "end": 247,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 244,
+                                "end": 247
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 252,
+                    "end": 260,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 252,
+                        "end": 260,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 252,
+                            "end": 255
+                          },
+                          {
+                            "kind": "type",
+                            "start": 257,
+                            "end": 260,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 257,
+                                "end": 260
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 265,
+                    "end": 275,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 265,
+                        "end": 275,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 265,
+                            "end": 269
+                          },
+                          {
+                            "kind": "type",
+                            "start": 271,
+                            "end": 275,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 271,
+                                "end": 275
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 116,
-                "end_col_offset": 168
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 9,
-          "end_col_offset": 169
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 169
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 7,
-                "end_col_offset": 29
+        "kind": "expression_statement",
+        "start": 277,
+        "end": 348,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 277,
+            "end": 348,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 277,
+                "end": 282
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 34,
-                    "end_col_offset": 36
+              {
+                "kind": "list",
+                "start": 285,
+                "end": 348,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 286,
+                    "end": 305,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 286,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 305,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 291,
+                            "end": 294,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 291,
+                                "end": 292
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 292,
+                                "end": 293
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 293,
+                                "end": 294
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 296,
+                            "end": 298
+                          },
+                          {
+                            "kind": "true",
+                            "start": 300,
+                            "end": 304
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "result",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 40,
-                    "end_col_offset": 46
+                  {
+                    "kind": "call",
+                    "start": 307,
+                    "end": 326,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 307,
+                        "end": 311
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 311,
+                        "end": 326,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 312,
+                            "end": 315,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 312,
+                                "end": 313
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 313,
+                                "end": 314
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 314,
+                                "end": 315
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 317,
+                            "end": 318
+                          },
+                          {
+                            "kind": "false",
+                            "start": 320,
+                            "end": 325
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 6,
-              "end_col_offset": 47
-            }
-          ],
-          "keywords": [],
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 0,
-          "end_col_offset": 48
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 48
+                  {
+                    "kind": "call",
+                    "start": 328,
+                    "end": 347,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 328,
+                        "end": 332
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 332,
+                        "end": 347,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 333,
+                            "end": 336,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 333,
+                                "end": 334
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 334,
+                                "end": 335
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 335,
+                                "end": 336
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 338,
+                            "end": 340
+                          },
+                          {
+                            "kind": "true",
+                            "start": 342,
+                            "end": 346
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 349,
+        "end": 407,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 349,
+            "end": 359,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 350,
+                "end": 359
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 360,
+            "end": 407,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 366,
+                "end": 377
+              },
+              {
+                "kind": "block",
+                "start": 383,
+                "end": 407,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 383,
+                    "end": 391,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 383,
+                        "end": 391,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 383,
+                            "end": 386
+                          },
+                          {
+                            "kind": "type",
+                            "start": 388,
+                            "end": 391,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 388,
+                                "end": 391
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 396,
+                    "end": 407,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 396,
+                        "end": 407,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 396,
+                            "end": 401
+                          },
+                          {
+                            "kind": "type",
+                            "start": 403,
+                            "end": 407,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 403,
+                                "end": 407
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 409,
+        "end": 428,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 409,
+            "end": 428,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 409,
+                "end": 423
+              },
+              {
+                "kind": "dictionary",
+                "start": 426,
+                "end": 428
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 429,
+        "end": 533,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 433,
+            "end": 434
+          },
+          {
+            "kind": "identifier",
+            "start": 438,
+            "end": 443
+          },
+          {
+            "kind": "block",
+            "start": 449,
+            "end": 533,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 449,
+                "end": 510,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 449,
+                    "end": 510,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 449,
+                        "end": 451
+                      },
+                      {
+                        "kind": "call",
+                        "start": 454,
+                        "end": 510,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 454,
+                            "end": 479,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 454,
+                                "end": 468
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 469,
+                                "end": 479
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 479,
+                            "end": 510,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 480,
+                                "end": 485,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 480,
+                                    "end": 481
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 482,
+                                    "end": 485
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 487,
+                                "end": 509,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 487,
+                                    "end": 498
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 498,
+                                    "end": 509,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 499,
+                                        "end": 504,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 499,
+                                            "end": 500
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 501,
+                                            "end": 504
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 506,
+                                        "end": 508
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 515,
+                "end": 533,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 515,
+                    "end": 533,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 515,
+                        "end": 530,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 515,
+                            "end": 523,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 515,
+                                "end": 517
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 518,
+                                "end": 523
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 524,
+                            "end": 530
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 530,
+                        "end": 533,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 531,
+                            "end": 532
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 534,
+        "end": 586,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 534,
+            "end": 544,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 535,
+                "end": 544
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 545,
+            "end": 586,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 551,
+                "end": 557
+              },
+              {
+                "kind": "block",
+                "start": 563,
+                "end": 586,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 563,
+                    "end": 571,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 563,
+                        "end": 571,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 563,
+                            "end": 566
+                          },
+                          {
+                            "kind": "type",
+                            "start": 568,
+                            "end": 571,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 568,
+                                "end": 571
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 576,
+                    "end": 586,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 576,
+                        "end": 586,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 576,
+                            "end": 581
+                          },
+                          {
+                            "kind": "type",
+                            "start": 583,
+                            "end": 586,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 583,
+                                "end": 586
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 588,
+        "end": 757,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 588,
+            "end": 757,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 588,
+                "end": 594
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 597,
+                "end": 757,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 598,
+                    "end": 694,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 598,
+                        "end": 604
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 604,
+                        "end": 694,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 605,
+                            "end": 610,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 605,
+                                "end": 606
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 607,
+                                "end": 610
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "binary_operator",
+                            "start": 612,
+                            "end": 693,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 612,
+                                "end": 660,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 612,
+                                    "end": 615
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 615,
+                                    "end": 660,
+                                    "children": [
+                                      {
+                                        "kind": "list_comprehension",
+                                        "start": 616,
+                                        "end": 659,
+                                        "children": [
+                                          {
+                                            "kind": "parenthesized_expression",
+                                            "start": 617,
+                                            "end": 641,
+                                            "children": [
+                                              {
+                                                "kind": "conditional_expression",
+                                                "start": 618,
+                                                "end": 640,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 618,
+                                                    "end": 623,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 618,
+                                                        "end": 619
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 620,
+                                                        "end": 623
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 627,
+                                                    "end": 633,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 627,
+                                                        "end": 628
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 629,
+                                                        "end": 633
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "integer",
+                                                    "start": 639,
+                                                    "end": 640
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "for_in_clause",
+                                            "start": 642,
+                                            "end": 658,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 646,
+                                                "end": 647
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 651,
+                                                "end": 658,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 651,
+                                                    "end": 652
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 653,
+                                                    "end": 658
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 664,
+                                "end": 693,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 664,
+                                    "end": 667
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 667,
+                                    "end": 693,
+                                    "children": [
+                                      {
+                                        "kind": "list_comprehension",
+                                        "start": 668,
+                                        "end": 692,
+                                        "children": [
+                                          {
+                                            "kind": "attribute",
+                                            "start": 669,
+                                            "end": 674,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 669,
+                                                "end": 670
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 671,
+                                                "end": 674
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "for_in_clause",
+                                            "start": 675,
+                                            "end": 691,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 679,
+                                                "end": 680
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 684,
+                                                "end": 691,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 684,
+                                                    "end": 685
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 686,
+                                                    "end": 691
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 695,
+                    "end": 756,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 699,
+                        "end": 700
+                      },
+                      {
+                        "kind": "call",
+                        "start": 704,
+                        "end": 756,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 704,
+                            "end": 710
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 710,
+                            "end": 756,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 711,
+                                "end": 734,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 711,
+                                    "end": 732,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 711,
+                                        "end": 725
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 726,
+                                        "end": 732
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 732,
+                                    "end": 734
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 736,
+                                "end": 755,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 736,
+                                    "end": 739
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 740,
+                                    "end": 755,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 747,
+                                        "end": 748,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 747,
+                                            "end": 748
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 750,
+                                        "end": 755,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 750,
+                                            "end": 751
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 752,
+                                            "end": 755
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 758,
+        "end": 806,
+        "children": [
+          {
+            "kind": "call",
+            "start": 758,
+            "end": 806,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 758,
+                "end": 763
+              },
+              {
+                "kind": "argument_list",
+                "start": 763,
+                "end": 806,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 764,
+                    "end": 805,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 765,
+                        "end": 787,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 765,
+                            "end": 783,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 765,
+                                "end": 776
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 777,
+                                "end": 783
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 783,
+                            "end": 787,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 784,
+                                "end": 786
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 788,
+                        "end": 804,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 792,
+                            "end": 794
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 798,
+                            "end": 804
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_having.py.json
+++ b/tests/json-ast/x/py/group_by_having.py.json
@@ -1,1151 +1,1455 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 847,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "Import",
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "city",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 10,
-        "end_lineno": 12,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 17,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 26,
-                  "end_col_offset": 33
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 10,
-              "end_col_offset": 34
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 36,
-                "end_col_offset": 42
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 43,
-                  "end_col_offset": 48
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 50,
-                  "end_col_offset": 57
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 36,
-              "end_col_offset": 58
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 60,
-                "end_col_offset": 66
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 78,
-                  "end_col_offset": 85
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 60,
-              "end_col_offset": 86
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 88,
-                "end_col_offset": 94
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Diana",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 95,
-                  "end_col_offset": 102
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 104,
-                  "end_col_offset": 111
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 88,
-              "end_col_offset": 112
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 114,
-                "end_col_offset": 120
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Eve",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 121,
-                  "end_col_offset": 126
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 128,
-                  "end_col_offset": 135
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 114,
-              "end_col_offset": 136
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 138,
-                "end_col_offset": 144
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Frank",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 145,
-                  "end_col_offset": 152
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Hanoi",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 154,
-                  "end_col_offset": 161
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 138,
-              "end_col_offset": 162
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 164,
-                "end_col_offset": 170
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "George",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 171,
-                  "end_col_offset": 179
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Paris",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 181,
-                  "end_col_offset": 188
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 164,
-              "end_col_offset": 189
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 9,
-          "end_col_offset": 190
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 190
-      },
-      {
-        "_type": "ClassDef",
-        "name": "BigGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 18,
-            "end_lineno": 18,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 16,
-        "end_lineno": 18,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_big_groups",
-            "lineno": 20,
-            "end_lineno": 20,
-            "end_col_offset": 11
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 14,
-          "end_col_offset": 16
-        },
-        "lineno": 20,
-        "end_lineno": 20,
-        "end_col_offset": 16
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_big_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 9,
-                  "end_col_offset": 20
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 9,
-                "end_col_offset": 31
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "p",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 32,
-                    "end_col_offset": 33
-                  },
-                  "attr": "city",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 32,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "BigGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 40,
-                    "end_col_offset": 48
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "p",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 22,
-                        "end_lineno": 22,
-                        "col_offset": 49,
-                        "end_col_offset": 50
-                      },
-                      "attr": "city",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 22,
-                      "end_lineno": 22,
-                      "col_offset": 49,
-                      "end_col_offset": 55
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 22,
-                      "end_lineno": 22,
-                      "col_offset": 57,
-                      "end_col_offset": 59
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 40,
-                  "end_col_offset": 60
-                }
-              ],
-              "keywords": [],
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 9,
-              "end_col_offset": 61
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 61
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 23,
-                "end_lineno": 23,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "p",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "people",
-          "lineno": 21,
-          "end_lineno": 21,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Big",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "city",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "num",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 12
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 25,
-        "end_lineno": 27,
-        "end_col_offset": 12
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "big",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 3
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Big",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 11,
-                "end_col_offset": 16
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 211,
+        "end": 222,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 218,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 218,
+                "end": 222
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 224,
+        "end": 276,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 224,
+            "end": 234,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 225,
+                "end": 234
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 235,
+            "end": 276,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 241,
+                "end": 247
               },
               {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "len",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 18,
-                  "end_col_offset": 21
-                },
-                "args": [
+                "kind": "block",
+                "start": 253,
+                "end": 276,
+                "children": [
                   {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "g",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 22,
-                      "end_col_offset": 23
-                    },
-                    "attr": "items",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 22,
-                    "end_col_offset": 29
-                  }
-                ],
-                "keywords": [],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 18,
-                "end_col_offset": 30
-              }
-            ],
-            "keywords": [],
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 7,
-            "end_col_offset": 31
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 36,
-                "end_col_offset": 37
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_big_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 41,
-                    "end_col_offset": 52
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 41,
-                  "end_col_offset": 59
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 41,
-                "end_col_offset": 61
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "len",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 65,
-                      "end_col_offset": 68
-                    },
-                    "args": [
+                    "kind": "expression_statement",
+                    "start": 253,
+                    "end": 262,
+                    "children": [
                       {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "g",
-                          "ctx": {
-                            "_type": "Load"
+                        "kind": "assignment",
+                        "start": 253,
+                        "end": 262,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 253,
+                            "end": 257
                           },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 69,
-                          "end_col_offset": 70
-                        },
-                        "attr": "items",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 69,
-                        "end_col_offset": 76
+                          {
+                            "kind": "type",
+                            "start": 259,
+                            "end": 262,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 259,
+                                "end": 262
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 65,
-                    "end_col_offset": 77
+                    ]
                   },
-                  "ops": [
-                    {
-                      "_type": "GtE"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 4,
-                      "kind": null,
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 81,
-                      "end_col_offset": 82
-                    }
-                  ],
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 65,
-                  "end_col_offset": 82
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 6,
-          "end_col_offset": 83
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 83
+                  {
+                    "kind": "expression_statement",
+                    "start": 267,
+                    "end": 276,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 267,
+                        "end": 276,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 267,
+                            "end": 271
+                          },
+                          {
+                            "kind": "type",
+                            "start": 273,
+                            "end": 276,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 273,
+                                "end": 276
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "json",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "attr": "dumps",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 6,
-                "end_col_offset": 16
+        "kind": "expression_statement",
+        "start": 278,
+        "end": 468,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 278,
+            "end": 468,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 278,
+                "end": 284
               },
-              "args": [
-                {
-                  "_type": "ListComp",
-                  "elt": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "dataclasses",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 18,
-                        "end_col_offset": 29
-                      },
-                      "attr": "asdict",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 30,
-                      "end_lineno": 30,
-                      "col_offset": 18,
-                      "end_col_offset": 36
-                    },
-                    "args": [
+              {
+                "kind": "list",
+                "start": 287,
+                "end": 468,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 288,
+                    "end": 312,
+                    "children": [
                       {
-                        "_type": "Name",
-                        "id": "_x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 37,
-                        "end_col_offset": 39
+                        "kind": "identifier",
+                        "start": 288,
+                        "end": 294
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 294,
+                        "end": 312,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 295,
+                            "end": 302,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 295,
+                                "end": 296
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 296,
+                                "end": 301
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 301,
+                                "end": 302
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 304,
+                            "end": 311,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 304,
+                                "end": 305
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 305,
+                                "end": 310
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 310,
+                                "end": 311
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 18,
-                    "end_col_offset": 40
+                    ]
                   },
-                  "generators": [
-                    {
-                      "_type": "comprehension",
-                      "target": {
-                        "_type": "Name",
-                        "id": "_x",
-                        "ctx": {
-                          "_type": "Store"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 45,
-                        "end_col_offset": 47
+                  {
+                    "kind": "call",
+                    "start": 314,
+                    "end": 336,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 314,
+                        "end": 320
                       },
-                      "iter": {
-                        "_type": "Name",
-                        "id": "big",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 51,
-                        "end_col_offset": 54
-                      },
-                      "ifs": [],
-                      "is_async": 0
-                    }
-                  ],
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 17,
-                  "end_col_offset": 55
-                }
-              ],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "indent",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 64,
-                    "end_col_offset": 65
+                      {
+                        "kind": "argument_list",
+                        "start": 320,
+                        "end": 336,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 321,
+                            "end": 326,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 321,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 322,
+                                "end": 325
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 325,
+                                "end": 326
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 328,
+                            "end": 335,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 328,
+                                "end": 329
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 329,
+                                "end": 334
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 334,
+                                "end": 335
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 57,
-                  "end_col_offset": 65
-                }
-              ],
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 6,
-              "end_col_offset": 66
-            }
-          ],
-          "keywords": [],
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 0,
-          "end_col_offset": 67
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 67
+                  {
+                    "kind": "call",
+                    "start": 338,
+                    "end": 364,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 338,
+                        "end": 344
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 344,
+                        "end": 364,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 345,
+                            "end": 354,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 345,
+                                "end": 346
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 346,
+                                "end": 353
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 353,
+                                "end": 354
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 356,
+                            "end": 363,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 356,
+                                "end": 357
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 357,
+                                "end": 362
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 362,
+                                "end": 363
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 366,
+                    "end": 390,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 366,
+                        "end": 372
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 372,
+                        "end": 390,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 373,
+                            "end": 380,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 373,
+                                "end": 374
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 374,
+                                "end": 379
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 379,
+                                "end": 380
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 382,
+                            "end": 389,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 382,
+                                "end": 383
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 383,
+                                "end": 388
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 388,
+                                "end": 389
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 392,
+                    "end": 414,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 392,
+                        "end": 398
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 398,
+                        "end": 414,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 399,
+                            "end": 404,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 399,
+                                "end": 400
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 400,
+                                "end": 403
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 403,
+                                "end": 404
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 406,
+                            "end": 413,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 406,
+                                "end": 407
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 407,
+                                "end": 412
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 412,
+                                "end": 413
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 416,
+                    "end": 440,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 416,
+                        "end": 422
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 422,
+                        "end": 440,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 423,
+                            "end": 430,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 423,
+                                "end": 424
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 424,
+                                "end": 429
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 429,
+                                "end": 430
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 432,
+                            "end": 439,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 432,
+                                "end": 433
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 433,
+                                "end": 438
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 438,
+                                "end": 439
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 442,
+                    "end": 467,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 442,
+                        "end": 448
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 448,
+                        "end": 467,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 449,
+                            "end": 457,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 449,
+                                "end": 450
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 450,
+                                "end": 456
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 456,
+                                "end": 457
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 459,
+                            "end": 466,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 459,
+                                "end": 460
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 460,
+                                "end": 465
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 465,
+                                "end": 466
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 469,
+        "end": 524,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 469,
+            "end": 479,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 470,
+                "end": 479
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 480,
+            "end": 524,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 486,
+                "end": 494
+              },
+              {
+                "kind": "block",
+                "start": 500,
+                "end": 524,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 500,
+                    "end": 508,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 500,
+                        "end": 508,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 500,
+                            "end": 503
+                          },
+                          {
+                            "kind": "type",
+                            "start": 505,
+                            "end": 508,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 505,
+                                "end": 508
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 513,
+                    "end": 524,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 513,
+                        "end": 524,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 513,
+                            "end": 518
+                          },
+                          {
+                            "kind": "type",
+                            "start": 520,
+                            "end": 524,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 520,
+                                "end": 524
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 526,
+        "end": 542,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 526,
+            "end": 542,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 526,
+                "end": 537
+              },
+              {
+                "kind": "dictionary",
+                "start": 540,
+                "end": 542
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 543,
+        "end": 644,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 547,
+            "end": 548
+          },
+          {
+            "kind": "identifier",
+            "start": 552,
+            "end": 558
+          },
+          {
+            "kind": "block",
+            "start": 564,
+            "end": 644,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 564,
+                "end": 621,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 564,
+                    "end": 621,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 564,
+                        "end": 566
+                      },
+                      {
+                        "kind": "call",
+                        "start": 569,
+                        "end": 621,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 569,
+                            "end": 591,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 569,
+                                "end": 580
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 581,
+                                "end": 591
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 591,
+                            "end": 621,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 592,
+                                "end": 598,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 592,
+                                    "end": 593
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 594,
+                                    "end": 598
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 600,
+                                "end": 620,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 600,
+                                    "end": 608
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 608,
+                                    "end": 620,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 609,
+                                        "end": 615,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 609,
+                                            "end": 610
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 611,
+                                            "end": 615
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 617,
+                                        "end": 619
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 626,
+                "end": 644,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 626,
+                    "end": 644,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 626,
+                        "end": 641,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 626,
+                            "end": 634,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 626,
+                                "end": 628
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 629,
+                                "end": 634
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 635,
+                            "end": 641
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 641,
+                        "end": 644,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 642,
+                            "end": 643
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 645,
+        "end": 693,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 645,
+            "end": 655,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 646,
+                "end": 655
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 656,
+            "end": 693,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 662,
+                "end": 665
+              },
+              {
+                "kind": "block",
+                "start": 671,
+                "end": 693,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 671,
+                    "end": 680,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 671,
+                        "end": 680,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 671,
+                            "end": 675
+                          },
+                          {
+                            "kind": "type",
+                            "start": 677,
+                            "end": 680,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 677,
+                                "end": 680
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 685,
+                    "end": 693,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 685,
+                        "end": 693,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 685,
+                            "end": 688
+                          },
+                          {
+                            "kind": "type",
+                            "start": 690,
+                            "end": 693,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 690,
+                                "end": 693
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 695,
+        "end": 778,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 695,
+            "end": 778,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 695,
+                "end": 698
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 701,
+                "end": 778,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 702,
+                    "end": 726,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 702,
+                        "end": 705
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 705,
+                        "end": 726,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 706,
+                            "end": 711,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 706,
+                                "end": 707
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 708,
+                                "end": 711
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 713,
+                            "end": 725,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 713,
+                                "end": 716
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 716,
+                                "end": 725,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 717,
+                                    "end": 724,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 717,
+                                        "end": 718
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 719,
+                                        "end": 724
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 727,
+                    "end": 756,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 731,
+                        "end": 732
+                      },
+                      {
+                        "kind": "call",
+                        "start": 736,
+                        "end": 756,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 736,
+                            "end": 754,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 736,
+                                "end": 747
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 748,
+                                "end": 754
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 754,
+                            "end": 756
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 757,
+                    "end": 777,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 760,
+                        "end": 777,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 760,
+                            "end": 772,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 760,
+                                "end": 763
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 763,
+                                "end": 772,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 764,
+                                    "end": 771,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 764,
+                                        "end": 765
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 766,
+                                        "end": 771
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 776,
+                            "end": 777
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 779,
+        "end": 846,
+        "children": [
+          {
+            "kind": "call",
+            "start": 779,
+            "end": 846,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 779,
+                "end": 784
+              },
+              {
+                "kind": "argument_list",
+                "start": 784,
+                "end": 846,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 785,
+                    "end": 845,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 785,
+                        "end": 795,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 785,
+                            "end": 789
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 790,
+                            "end": 795
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 795,
+                        "end": 845,
+                        "children": [
+                          {
+                            "kind": "list_comprehension",
+                            "start": 796,
+                            "end": 834,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 797,
+                                "end": 819,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 797,
+                                    "end": 815,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 797,
+                                        "end": 808
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 809,
+                                        "end": 815
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 815,
+                                    "end": 819,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 816,
+                                        "end": 818
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "for_in_clause",
+                                "start": 820,
+                                "end": 833,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 824,
+                                    "end": 826
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 830,
+                                    "end": 833
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 836,
+                            "end": 844,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 836,
+                                "end": 842
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 843,
+                                "end": 844
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_join.py.json
+++ b/tests/json-ast/x/py/group_by_join.py.json
@@ -1,1279 +1,1466 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 942,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 54
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 16,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 18,
-            "end_lineno": 18,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 10,
-              "end_col_offset": 23
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 25,
-                "end_col_offset": 30
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 36,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 25,
-              "end_col_offset": 38
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 40,
-                "end_col_offset": 45
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 46,
-                  "end_col_offset": 49
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 51,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 40,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 9,
-          "end_col_offset": 54
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "StatsGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "ClassDef",
-        "name": "StatsRow",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 25,
-        "end_lineno": 27,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_stats_groups",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 13
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 16,
-          "end_col_offset": 18
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "For",
-            "body": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Name",
-                    "id": "_g",
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 8,
-                    "end_col_offset": 10
-                  }
-                ],
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "_stats_groups",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 13,
-                      "end_col_offset": 26
-                    },
-                    "attr": "setdefault",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 13,
-                    "end_col_offset": 37
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "c",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 32,
-                        "end_lineno": 32,
-                        "col_offset": 38,
-                        "end_col_offset": 39
-                      },
-                      "attr": "name",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 38,
-                      "end_col_offset": 44
-                    },
-                    {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "StatsGroup",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 32,
-                        "end_lineno": 32,
-                        "col_offset": 46,
-                        "end_col_offset": 56
-                      },
-                      "args": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 32,
-                            "end_lineno": 32,
-                            "col_offset": 57,
-                            "end_col_offset": 58
-                          },
-                          "attr": "name",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 57,
-                          "end_col_offset": 63
-                        },
-                        {
-                          "_type": "List",
-                          "elts": [],
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 65,
-                          "end_col_offset": 67
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 46,
-                      "end_col_offset": 68
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 13,
-                  "end_col_offset": 69
-                },
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 8,
-                "end_col_offset": 69
-              },
-              {
-                "_type": "Expr",
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_g",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 8,
-                        "end_col_offset": 10
-                      },
-                      "attr": "items",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 8,
-                      "end_col_offset": 16
-                    },
-                    "attr": "append",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 8,
-                    "end_col_offset": 23
-                  },
-                  "args": [
-                    {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "StatsRow",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 24,
-                        "end_col_offset": 32
-                      },
-                      "args": [
-                        {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 33,
-                          "end_col_offset": 34
-                        },
-                        {
-                          "_type": "Name",
-                          "id": "c",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 36,
-                          "end_col_offset": 37
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 24,
-                      "end_col_offset": 38
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 8,
-                  "end_col_offset": 39
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 8,
-                "end_col_offset": 39
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "target": {
-              "_type": "Name",
-              "id": "c",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            "iter": {
-              "_type": "ListComp",
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "c",
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 20,
-                    "end_col_offset": 21
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "customers",
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 25,
-                    "end_col_offset": 34
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 31,
-                          "end_lineno": 31,
-                          "col_offset": 38,
-                          "end_col_offset": 39
-                        },
-                        "attr": "customerId",
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 38,
-                        "end_col_offset": 50
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 31,
-                            "end_lineno": 31,
-                            "col_offset": 54,
-                            "end_col_offset": 55
-                          },
-                          "attr": "id",
-                          "lineno": 31,
-                          "end_lineno": 31,
-                          "col_offset": 54,
-                          "end_col_offset": 58
-                        }
-                      ],
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 38,
-                      "end_col_offset": 58
-                    }
-                  ]
-                }
-              ],
-              "elt": {
-                "_type": "Name",
-                "id": "c",
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 13,
-              "end_col_offset": 59
-            },
-            "lineno": 31,
-            "end_lineno": 33,
-            "col_offset": 4,
-            "end_col_offset": 39
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "o",
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "orders",
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 30,
-        "end_lineno": 33,
-        "end_col_offset": 39
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Stat",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 36,
-            "end_lineno": 36,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "count",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 37,
-            "end_lineno": 37,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 35,
-        "end_lineno": 37,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "stats",
-            "lineno": 39,
-            "end_lineno": 39,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Stat",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 39,
-              "end_lineno": 39,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 14,
-                "end_col_offset": 19
-              },
-              {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "len",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 21,
-                  "end_col_offset": 24
-                },
-                "args": [
-                  {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "g",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 39,
-                      "end_lineno": 39,
-                      "col_offset": 25,
-                      "end_col_offset": 26
-                    },
-                    "attr": "items",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 39,
-                    "end_lineno": 39,
-                    "col_offset": 25,
-                    "end_col_offset": 32
-                  }
-                ],
-                "keywords": [],
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 21,
-                "end_col_offset": 33
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
               }
-            ],
-            "keywords": [],
-            "lineno": 39,
-            "end_lineno": 39,
-            "col_offset": 9,
-            "end_col_offset": 34
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 39,
-                "end_col_offset": 40
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_stats_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 39,
-                    "end_lineno": 39,
-                    "col_offset": 44,
-                    "end_col_offset": 57
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 44,
-                  "end_col_offset": 64
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 44,
-                "end_col_offset": 66
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 39,
-          "end_lineno": 39,
-          "col_offset": 8,
-          "end_col_offset": 67
-        },
-        "lineno": 39,
-        "end_lineno": 39,
-        "end_col_offset": 67
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 40,
-            "end_lineno": 40,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Orders per customer ---",
-              "kind": null,
-              "lineno": 40,
-              "end_lineno": 40,
-              "col_offset": 6,
-              "end_col_offset": 35
-            }
-          ],
-          "keywords": [],
-          "lineno": 40,
-          "end_lineno": 40,
-          "col_offset": 0,
-          "end_col_offset": 36
-        },
-        "lineno": 40,
-        "end_lineno": 40,
-        "end_col_offset": 36
-      },
-      {
-        "_type": "For",
-        "body": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 42,
-                "end_lineno": 42,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 42,
-                    "end_lineno": 42,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": "orders:",
-                  "kind": null,
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 18,
-                  "end_col_offset": 27
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 42,
-                    "end_lineno": 42,
-                    "col_offset": 29,
-                    "end_col_offset": 30
-                  },
-                  "attr": "count",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 29,
-                  "end_col_offset": 36
-                }
-              ],
-              "keywords": [],
-              "lineno": 42,
-              "end_lineno": 42,
-              "col_offset": 4,
-              "end_col_offset": 37
-            },
-            "lineno": 42,
-            "end_lineno": 42,
-            "col_offset": 4,
-            "end_col_offset": 37
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "s",
-          "lineno": 41,
-          "end_lineno": 41,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "stats",
-          "lineno": 41,
-          "end_lineno": 41,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 41,
-        "end_lineno": 42,
-        "end_col_offset": 37
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 301,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 301,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 301,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 302,
+        "end": 357,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 302,
+            "end": 312,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 303,
+                "end": 312
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 313,
+            "end": 357,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 319,
+                "end": 324
+              },
+              {
+                "kind": "block",
+                "start": 330,
+                "end": 357,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 330,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 330,
+                        "end": 337,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 330,
+                            "end": 332
+                          },
+                          {
+                            "kind": "type",
+                            "start": 334,
+                            "end": 337,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 334,
+                                "end": 337
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 342,
+                    "end": 357,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 342,
+                        "end": 357,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 342,
+                            "end": 352
+                          },
+                          {
+                            "kind": "type",
+                            "start": 354,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 354,
+                                "end": 357
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 359,
+        "end": 413,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 359,
+            "end": 413,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 359,
+                "end": 365
+              },
+              {
+                "kind": "list",
+                "start": 368,
+                "end": 413,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 369,
+                    "end": 382,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 369,
+                        "end": 374
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 374,
+                        "end": 382,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 375,
+                            "end": 378
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 380,
+                            "end": 381
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 384,
+                    "end": 397,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 384,
+                        "end": 389
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 389,
+                        "end": 397,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 390,
+                            "end": 393
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 395,
+                            "end": 396
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 399,
+                    "end": 412,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 399,
+                        "end": 404
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 404,
+                        "end": 412,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 405,
+                            "end": 408
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 410,
+                            "end": 411
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 414,
+        "end": 471,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 414,
+            "end": 424,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 415,
+                "end": 424
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 425,
+            "end": 471,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 431,
+                "end": 441
+              },
+              {
+                "kind": "block",
+                "start": 447,
+                "end": 471,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 447,
+                    "end": 455,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 447,
+                        "end": 455,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 447,
+                            "end": 450
+                          },
+                          {
+                            "kind": "type",
+                            "start": 452,
+                            "end": 455,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 452,
+                                "end": 455
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 460,
+                    "end": 471,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 460,
+                        "end": 471,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 460,
+                            "end": 465
+                          },
+                          {
+                            "kind": "type",
+                            "start": 467,
+                            "end": 471,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 467,
+                                "end": 471
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 473,
+        "end": 521,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 473,
+            "end": 483,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 474,
+                "end": 483
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 484,
+            "end": 521,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 490,
+                "end": 498
+              },
+              {
+                "kind": "block",
+                "start": 504,
+                "end": 521,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 504,
+                    "end": 510,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 504,
+                        "end": 510,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 504,
+                            "end": 505
+                          },
+                          {
+                            "kind": "type",
+                            "start": 507,
+                            "end": 510,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 507,
+                                "end": 510
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 515,
+                    "end": 521,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 515,
+                        "end": 521,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 515,
+                            "end": 516
+                          },
+                          {
+                            "kind": "type",
+                            "start": 518,
+                            "end": 521,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 518,
+                                "end": 521
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 523,
+        "end": 541,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 523,
+            "end": 541,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 523,
+                "end": 536
+              },
+              {
+                "kind": "dictionary",
+                "start": 539,
+                "end": 541
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 542,
+        "end": 729,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 546,
+            "end": 547
+          },
+          {
+            "kind": "identifier",
+            "start": 551,
+            "end": 557
+          },
+          {
+            "kind": "block",
+            "start": 563,
+            "end": 729,
+            "children": [
+              {
+                "kind": "for_statement",
+                "start": 563,
+                "end": 729,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 567,
+                    "end": 568
+                  },
+                  {
+                    "kind": "list_comprehension",
+                    "start": 572,
+                    "end": 618,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 573,
+                        "end": 574
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 575,
+                        "end": 593,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 579,
+                            "end": 580
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 584,
+                            "end": 593
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 594,
+                        "end": 617,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 597,
+                            "end": 617,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 597,
+                                "end": 609,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 597,
+                                    "end": 598
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 599,
+                                    "end": 609
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "attribute",
+                                "start": 613,
+                                "end": 617,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 613,
+                                    "end": 614
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 615,
+                                    "end": 617
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 628,
+                    "end": 729,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 628,
+                        "end": 689,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 628,
+                            "end": 689,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 628,
+                                "end": 630
+                              },
+                              {
+                                "kind": "call",
+                                "start": 633,
+                                "end": 689,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 633,
+                                    "end": 657,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 633,
+                                        "end": 646
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 647,
+                                        "end": 657
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 657,
+                                    "end": 689,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 658,
+                                        "end": 664,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 658,
+                                            "end": 659
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 660,
+                                            "end": 664
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 666,
+                                        "end": 688,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 666,
+                                            "end": 676
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 676,
+                                            "end": 688,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 677,
+                                                "end": 683,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 677,
+                                                    "end": 678
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 679,
+                                                    "end": 683
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "list",
+                                                "start": 685,
+                                                "end": 687
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 698,
+                        "end": 729,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 698,
+                            "end": 729,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 698,
+                                "end": 713,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 698,
+                                    "end": 706,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 698,
+                                        "end": 700
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 701,
+                                        "end": 706
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 707,
+                                    "end": 713
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 713,
+                                "end": 729,
+                                "children": [
+                                  {
+                                    "kind": "call",
+                                    "start": 714,
+                                    "end": 728,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 714,
+                                        "end": 722
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 722,
+                                        "end": 728,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 723,
+                                            "end": 724
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 726,
+                                            "end": 727
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 730,
+        "end": 781,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 730,
+            "end": 740,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 731,
+                "end": 740
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 741,
+            "end": 781,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 747,
+                "end": 751
+              },
+              {
+                "kind": "block",
+                "start": 757,
+                "end": 781,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 757,
+                    "end": 766,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 757,
+                        "end": 766,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 757,
+                            "end": 761
+                          },
+                          {
+                            "kind": "type",
+                            "start": 763,
+                            "end": 766,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 763,
+                                "end": 766
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 771,
+                    "end": 781,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 771,
+                        "end": 781,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 771,
+                            "end": 776
+                          },
+                          {
+                            "kind": "type",
+                            "start": 778,
+                            "end": 781,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 778,
+                                "end": 781
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 783,
+        "end": 850,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 783,
+            "end": 850,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 783,
+                "end": 788
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 791,
+                "end": 850,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 792,
+                    "end": 817,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 792,
+                        "end": 796
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 796,
+                        "end": 817,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 797,
+                            "end": 802,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 797,
+                                "end": 798
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 799,
+                                "end": 802
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 804,
+                            "end": 816,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 804,
+                                "end": 807
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 807,
+                                "end": 816,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 808,
+                                    "end": 815,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 808,
+                                        "end": 809
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 810,
+                                        "end": 815
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 818,
+                    "end": 849,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 822,
+                        "end": 823
+                      },
+                      {
+                        "kind": "call",
+                        "start": 827,
+                        "end": 849,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 827,
+                            "end": 847,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 827,
+                                "end": 840
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 841,
+                                "end": 847
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 847,
+                            "end": 849
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 851,
+        "end": 887,
+        "children": [
+          {
+            "kind": "call",
+            "start": 851,
+            "end": 887,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 851,
+                "end": 856
+              },
+              {
+                "kind": "argument_list",
+                "start": 856,
+                "end": 887,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 857,
+                    "end": 886,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 857,
+                        "end": 858
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 858,
+                        "end": 885
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 885,
+                        "end": 886
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 888,
+        "end": 941,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 892,
+            "end": 893
+          },
+          {
+            "kind": "identifier",
+            "start": 897,
+            "end": 902
+          },
+          {
+            "kind": "block",
+            "start": 908,
+            "end": 941,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 908,
+                "end": 941,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 908,
+                    "end": 941,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 908,
+                        "end": 913
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 913,
+                        "end": 941,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 914,
+                            "end": 920,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 914,
+                                "end": 915
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 916,
+                                "end": 920
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 922,
+                            "end": 931,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 922,
+                                "end": 923
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 923,
+                                "end": 930
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 930,
+                                "end": 931
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 933,
+                            "end": 940,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 933,
+                                "end": 934
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 935,
+                                "end": 940
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_left_join.py.json
+++ b/tests/json-ast/x/py/group_by_left_join.py.json
@@ -1,1406 +1,1579 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 992,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 78
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 78
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 16,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 18,
-            "end_lineno": 18,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 10,
-              "end_col_offset": 23
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 25,
-                "end_col_offset": 30
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 36,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 25,
-              "end_col_offset": 38
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 40,
-                "end_col_offset": 45
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 46,
-                  "end_col_offset": 49
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 51,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 40,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 9,
-          "end_col_offset": 54
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "StatsGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "ClassDef",
-        "name": "StatsRow",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 25,
-        "end_lineno": 27,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_stats_groups",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 13
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 16,
-          "end_col_offset": 18
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "For",
-            "body": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Name",
-                    "id": "_g",
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 8,
-                    "end_col_offset": 10
-                  }
-                ],
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "_stats_groups",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 13,
-                      "end_col_offset": 26
-                    },
-                    "attr": "setdefault",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 13,
-                    "end_col_offset": 37
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "c",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 32,
-                        "end_lineno": 32,
-                        "col_offset": 38,
-                        "end_col_offset": 39
-                      },
-                      "attr": "name",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 38,
-                      "end_col_offset": 44
-                    },
-                    {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "StatsGroup",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 32,
-                        "end_lineno": 32,
-                        "col_offset": 46,
-                        "end_col_offset": 56
-                      },
-                      "args": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 32,
-                            "end_lineno": 32,
-                            "col_offset": 57,
-                            "end_col_offset": 58
-                          },
-                          "attr": "name",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 57,
-                          "end_col_offset": 63
-                        },
-                        {
-                          "_type": "List",
-                          "elts": [],
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 65,
-                          "end_col_offset": 67
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 46,
-                      "end_col_offset": 68
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 32,
-                  "end_lineno": 32,
-                  "col_offset": 13,
-                  "end_col_offset": 69
-                },
-                "lineno": 32,
-                "end_lineno": 32,
-                "col_offset": 8,
-                "end_col_offset": 69
-              },
-              {
-                "_type": "Expr",
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_g",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 8,
-                        "end_col_offset": 10
-                      },
-                      "attr": "items",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 8,
-                      "end_col_offset": 16
-                    },
-                    "attr": "append",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 8,
-                    "end_col_offset": 23
-                  },
-                  "args": [
-                    {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "StatsRow",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 24,
-                        "end_col_offset": 32
-                      },
-                      "args": [
-                        {
-                          "_type": "Name",
-                          "id": "c",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 33,
-                          "end_col_offset": 34
-                        },
-                        {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 36,
-                          "end_col_offset": 37
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 24,
-                      "end_col_offset": 38
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 8,
-                  "end_col_offset": 39
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 8,
-                "end_col_offset": 39
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "target": {
-              "_type": "Name",
-              "id": "o",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            "iter": {
-              "_type": "BoolOp",
-              "op": {
-                "_type": "Or"
-              },
-              "values": [
-                {
-                  "_type": "ListComp",
-                  "generators": [
-                    {
-                      "_type": "comprehension",
-                      "target": {
-                        "_type": "Name",
-                        "id": "o",
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 20,
-                        "end_col_offset": 21
-                      },
-                      "iter": {
-                        "_type": "Name",
-                        "id": "orders",
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 25,
-                        "end_col_offset": 31
-                      },
-                      "ifs": [
-                        {
-                          "_type": "Compare",
-                          "left": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "o",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 31,
-                              "end_lineno": 31,
-                              "col_offset": 35,
-                              "end_col_offset": 36
-                            },
-                            "attr": "customerId",
-                            "lineno": 31,
-                            "end_lineno": 31,
-                            "col_offset": 35,
-                            "end_col_offset": 47
-                          },
-                          "ops": [
-                            {
-                              "_type": "Eq"
-                            }
-                          ],
-                          "comparators": [
-                            {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "c",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 31,
-                                "end_lineno": 31,
-                                "col_offset": 51,
-                                "end_col_offset": 52
-                              },
-                              "attr": "id",
-                              "lineno": 31,
-                              "end_lineno": 31,
-                              "col_offset": 51,
-                              "end_col_offset": 55
-                            }
-                          ],
-                          "lineno": 31,
-                          "end_lineno": 31,
-                          "col_offset": 35,
-                          "end_col_offset": 55
-                        }
-                      ]
-                    }
-                  ],
-                  "elt": {
-                    "_type": "Name",
-                    "id": "o",
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 14,
-                    "end_col_offset": 15
-                  },
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 13,
-                  "end_col_offset": 56
-                },
-                {
-                  "_type": "List",
-                  "elts": [
-                    {
-                      "_type": "Constant",
-                      "value": null,
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 61,
-                      "end_col_offset": 65
-                    }
-                  ],
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 60,
-                  "end_col_offset": 66
-                }
-              ],
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 13,
-              "end_col_offset": 66
-            },
-            "lineno": 31,
-            "end_lineno": 33,
-            "col_offset": 4,
-            "end_col_offset": 39
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "c",
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "customers",
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 9,
-          "end_col_offset": 18
-        },
-        "lineno": 30,
-        "end_lineno": 33,
-        "end_col_offset": 39
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Stat",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 36,
-            "end_lineno": 36,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "count",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 37,
-            "end_lineno": 37,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 35,
-        "end_lineno": 37,
-        "end_col_offset": 14
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "stats",
-            "lineno": 39,
-            "end_lineno": 39,
-            "end_col_offset": 5
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Stat",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 39,
-              "end_lineno": 39,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 14,
-                "end_col_offset": 19
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
               },
               {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "len",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 21,
-                  "end_col_offset": 24
-                },
-                "args": [
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "r",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 39,
-                      "end_lineno": 39,
-                      "col_offset": 26,
-                      "end_col_offset": 27
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "r",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 39,
-                          "end_lineno": 39,
-                          "col_offset": 32,
-                          "end_col_offset": 33
-                        },
-                        "iter": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "g",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 39,
-                            "end_lineno": 39,
-                            "col_offset": 37,
-                            "end_col_offset": 38
-                          },
-                          "attr": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 39,
-                          "end_lineno": 39,
-                          "col_offset": 37,
-                          "end_col_offset": 44
-                        },
-                        "ifs": [
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
                           {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "r",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 39,
-                              "end_lineno": 39,
-                              "col_offset": 48,
-                              "end_col_offset": 49
-                            },
-                            "attr": "o",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 39,
-                            "end_lineno": 39,
-                            "col_offset": 48,
-                            "end_col_offset": 51
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
                           }
-                        ],
-                        "is_async": 0
+                        ]
                       }
-                    ],
-                    "lineno": 39,
-                    "end_lineno": 39,
-                    "col_offset": 25,
-                    "end_col_offset": 52
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "keywords": [],
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 21,
-                "end_col_offset": 53
+                ]
               }
-            ],
-            "keywords": [],
-            "lineno": 39,
-            "end_lineno": 39,
-            "col_offset": 9,
-            "end_col_offset": 54
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 59,
-                "end_col_offset": 60
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_stats_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 39,
-                    "end_lineno": 39,
-                    "col_offset": 64,
-                    "end_col_offset": 77
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 64,
-                  "end_col_offset": 84
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 64,
-                "end_col_offset": 86
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 39,
-          "end_lineno": 39,
-          "col_offset": 8,
-          "end_col_offset": 87
-        },
-        "lineno": 39,
-        "end_lineno": 39,
-        "end_col_offset": 87
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 40,
-            "end_lineno": 40,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Group Left Join ---",
-              "kind": null,
-              "lineno": 40,
-              "end_lineno": 40,
-              "col_offset": 6,
-              "end_col_offset": 31
-            }
-          ],
-          "keywords": [],
-          "lineno": 40,
-          "end_lineno": 40,
-          "col_offset": 0,
-          "end_col_offset": 32
-        },
-        "lineno": 40,
-        "end_lineno": 40,
-        "end_col_offset": 32
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 42,
-                "end_lineno": 42,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 42,
-                    "end_lineno": 42,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": "orders:",
-                  "kind": null,
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 18,
-                  "end_col_offset": 27
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 42,
-                    "end_lineno": 42,
-                    "col_offset": 29,
-                    "end_col_offset": 30
-                  },
-                  "attr": "count",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 29,
-                  "end_col_offset": 36
-                }
-              ],
-              "keywords": [],
-              "lineno": 42,
-              "end_lineno": 42,
-              "col_offset": 4,
-              "end_col_offset": 37
-            },
-            "lineno": 42,
-            "end_lineno": 42,
-            "col_offset": 4,
-            "end_col_offset": 37
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "s",
-          "lineno": 41,
-          "end_lineno": 41,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "stats",
-          "lineno": 41,
-          "end_lineno": 41,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 41,
-        "end_lineno": 42,
-        "end_col_offset": 37
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 325,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 326,
+        "end": 381,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 326,
+            "end": 336,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 327,
+                "end": 336
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 337,
+            "end": 381,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
+              },
+              {
+                "kind": "block",
+                "start": 354,
+                "end": 381,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 354,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 354,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 354,
+                            "end": 356
+                          },
+                          {
+                            "kind": "type",
+                            "start": 358,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 358,
+                                "end": 361
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 366,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 366,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 366,
+                            "end": 376
+                          },
+                          {
+                            "kind": "type",
+                            "start": 378,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 378,
+                                "end": 381
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 383,
+        "end": 437,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 383,
+            "end": 437,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 383,
+                "end": 389
+              },
+              {
+                "kind": "list",
+                "start": 392,
+                "end": 437,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 393,
+                    "end": 406,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 393,
+                        "end": 398
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 398,
+                        "end": 406,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 399,
+                            "end": 402
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 404,
+                            "end": 405
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 408,
+                    "end": 421,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 408,
+                        "end": 413
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 413,
+                        "end": 421,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 414,
+                            "end": 417
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 419,
+                            "end": 420
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 423,
+                    "end": 436,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 423,
+                        "end": 428
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 428,
+                        "end": 436,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 429,
+                            "end": 432
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 434,
+                            "end": 435
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 438,
+        "end": 495,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 438,
+            "end": 448,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 439,
+                "end": 448
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 449,
+            "end": 495,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 455,
+                "end": 465
+              },
+              {
+                "kind": "block",
+                "start": 471,
+                "end": 495,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 471,
+                    "end": 479,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 471,
+                        "end": 479,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 471,
+                            "end": 474
+                          },
+                          {
+                            "kind": "type",
+                            "start": 476,
+                            "end": 479,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 476,
+                                "end": 479
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 484,
+                    "end": 495,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 484,
+                        "end": 495,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 484,
+                            "end": 489
+                          },
+                          {
+                            "kind": "type",
+                            "start": 491,
+                            "end": 495,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 491,
+                                "end": 495
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 497,
+        "end": 545,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 497,
+            "end": 507,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 498,
+                "end": 507
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 508,
+            "end": 545,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 514,
+                "end": 522
+              },
+              {
+                "kind": "block",
+                "start": 528,
+                "end": 545,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 528,
+                    "end": 534,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 528,
+                        "end": 534,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 528,
+                            "end": 529
+                          },
+                          {
+                            "kind": "type",
+                            "start": 531,
+                            "end": 534,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 531,
+                                "end": 534
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 539,
+                    "end": 545,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 539,
+                        "end": 545,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 539,
+                            "end": 540
+                          },
+                          {
+                            "kind": "type",
+                            "start": 542,
+                            "end": 545,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 542,
+                                "end": 545
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 547,
+        "end": 565,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 547,
+            "end": 565,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 547,
+                "end": 560
+              },
+              {
+                "kind": "dictionary",
+                "start": 563,
+                "end": 565
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 566,
+        "end": 763,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 570,
+            "end": 571
+          },
+          {
+            "kind": "identifier",
+            "start": 575,
+            "end": 584
+          },
+          {
+            "kind": "block",
+            "start": 590,
+            "end": 763,
+            "children": [
+              {
+                "kind": "for_statement",
+                "start": 590,
+                "end": 763,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 594,
+                    "end": 595
+                  },
+                  {
+                    "kind": "boolean_operator",
+                    "start": 599,
+                    "end": 652,
+                    "children": [
+                      {
+                        "kind": "list_comprehension",
+                        "start": 599,
+                        "end": 642,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 600,
+                            "end": 601
+                          },
+                          {
+                            "kind": "for_in_clause",
+                            "start": 602,
+                            "end": 617,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 606,
+                                "end": 607
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 611,
+                                "end": 617
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "if_clause",
+                            "start": 618,
+                            "end": 641,
+                            "children": [
+                              {
+                                "kind": "comparison_operator",
+                                "start": 621,
+                                "end": 641,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 621,
+                                    "end": 633,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 621,
+                                        "end": 622
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 623,
+                                        "end": 633
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 637,
+                                    "end": 641,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 637,
+                                        "end": 638
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 639,
+                                        "end": 641
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "list",
+                        "start": 646,
+                        "end": 652,
+                        "children": [
+                          {
+                            "kind": "none",
+                            "start": 647,
+                            "end": 651
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 662,
+                    "end": 763,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 662,
+                        "end": 723,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 662,
+                            "end": 723,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 662,
+                                "end": 664
+                              },
+                              {
+                                "kind": "call",
+                                "start": 667,
+                                "end": 723,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 667,
+                                    "end": 691,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 667,
+                                        "end": 680
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 681,
+                                        "end": 691
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 691,
+                                    "end": 723,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 692,
+                                        "end": 698,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 692,
+                                            "end": 693
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 694,
+                                            "end": 698
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 700,
+                                        "end": 722,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 700,
+                                            "end": 710
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 710,
+                                            "end": 722,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 711,
+                                                "end": 717,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 711,
+                                                    "end": 712
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 713,
+                                                    "end": 717
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "list",
+                                                "start": 719,
+                                                "end": 721
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 732,
+                        "end": 763,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 732,
+                            "end": 763,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 732,
+                                "end": 747,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 732,
+                                    "end": 740,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 732,
+                                        "end": 734
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 735,
+                                        "end": 740
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 741,
+                                    "end": 747
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 747,
+                                "end": 763,
+                                "children": [
+                                  {
+                                    "kind": "call",
+                                    "start": 748,
+                                    "end": 762,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 748,
+                                        "end": 756
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 756,
+                                        "end": 762,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 757,
+                                            "end": 758
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 760,
+                                            "end": 761
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 764,
+        "end": 815,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 764,
+            "end": 774,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 765,
+                "end": 774
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 775,
+            "end": 815,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 781,
+                "end": 785
+              },
+              {
+                "kind": "block",
+                "start": 791,
+                "end": 815,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 791,
+                    "end": 800,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 791,
+                        "end": 800,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 791,
+                            "end": 795
+                          },
+                          {
+                            "kind": "type",
+                            "start": 797,
+                            "end": 800,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 797,
+                                "end": 800
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 805,
+                    "end": 815,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 805,
+                        "end": 815,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 805,
+                            "end": 810
+                          },
+                          {
+                            "kind": "type",
+                            "start": 812,
+                            "end": 815,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 812,
+                                "end": 815
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 817,
+        "end": 904,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 817,
+            "end": 904,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 817,
+                "end": 822
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 825,
+                "end": 904,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 826,
+                    "end": 871,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 826,
+                        "end": 830
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 830,
+                        "end": 871,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 831,
+                            "end": 836,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 831,
+                                "end": 832
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 833,
+                                "end": 836
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 838,
+                            "end": 870,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 838,
+                                "end": 841
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 841,
+                                "end": 870,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 842,
+                                    "end": 869,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 843,
+                                        "end": 844
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 845,
+                                        "end": 861,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 849,
+                                            "end": 850
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 854,
+                                            "end": 861,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 854,
+                                                "end": 855
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 856,
+                                                "end": 861
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "if_clause",
+                                        "start": 862,
+                                        "end": 868,
+                                        "children": [
+                                          {
+                                            "kind": "attribute",
+                                            "start": 865,
+                                            "end": 868,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 865,
+                                                "end": 866
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 867,
+                                                "end": 868
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 872,
+                    "end": 903,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 876,
+                        "end": 877
+                      },
+                      {
+                        "kind": "call",
+                        "start": 881,
+                        "end": 903,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 881,
+                            "end": 901,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 881,
+                                "end": 894
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 895,
+                                "end": 901
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 901,
+                            "end": 903
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 905,
+        "end": 937,
+        "children": [
+          {
+            "kind": "call",
+            "start": 905,
+            "end": 937,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 905,
+                "end": 910
+              },
+              {
+                "kind": "argument_list",
+                "start": 910,
+                "end": 937,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 911,
+                    "end": 936,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 911,
+                        "end": 912
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 912,
+                        "end": 935
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 935,
+                        "end": 936
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 938,
+        "end": 991,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 942,
+            "end": 943
+          },
+          {
+            "kind": "identifier",
+            "start": 947,
+            "end": 952
+          },
+          {
+            "kind": "block",
+            "start": 958,
+            "end": 991,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 958,
+                "end": 991,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 958,
+                    "end": 991,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 958,
+                        "end": 963
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 963,
+                        "end": 991,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 964,
+                            "end": 970,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 964,
+                                "end": 965
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 966,
+                                "end": 970
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 972,
+                            "end": 981,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 972,
+                                "end": 973
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 973,
+                                "end": 980
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 980,
+                                "end": 981
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 983,
+                            "end": 990,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 983,
+                                "end": 984
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 985,
+                                "end": 990
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_multi_join.py.json
+++ b/tests/json-ast/x/py/group_by_multi_join.py.json
@@ -1,1808 +1,1912 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 1208,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Nation",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 11,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "nations",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Nation",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 11,
-                "end_col_offset": 17
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 18,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": "A",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 21,
-                  "end_col_offset": 24
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 11,
-              "end_col_offset": 25
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Nation",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 27,
-                "end_col_offset": 33
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 34,
-                  "end_col_offset": 35
-                },
-                {
-                  "_type": "Constant",
-                  "value": "B",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 37,
-                  "end_col_offset": 40
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 27,
-              "end_col_offset": 41
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 10,
-          "end_col_offset": 42
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 42
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Supplier",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "nation",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 15,
-        "end_lineno": 17,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "suppliers",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Supplier",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 13,
-              "end_col_offset": 27
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Supplier",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 29,
-                "end_col_offset": 37
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 38,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 29,
-              "end_col_offset": 43
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 12,
-          "end_col_offset": 44
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 44
-      },
-      {
-        "_type": "ClassDef",
-        "name": "PartSupp",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "part",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 14,
-              "end_col_offset": 17
-            },
-            "target": {
-              "_type": "Name",
-              "id": "supplier",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 17
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 10,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "cost",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 4,
-            "end_col_offset": 15
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "qty",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 25,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "partsupp",
-            "lineno": 27,
-            "end_lineno": 27,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "PartSupp",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 21,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 26,
-                  "end_col_offset": 27
-                },
-                {
-                  "_type": "Constant",
-                  "value": 10.0,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 29,
-                  "end_col_offset": 33
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 35,
-                  "end_col_offset": 36
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 12,
-              "end_col_offset": 37
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "PartSupp",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 39,
-                "end_col_offset": 47
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 48,
-                  "end_col_offset": 51
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 53,
-                  "end_col_offset": 54
-                },
-                {
-                  "_type": "Constant",
-                  "value": 20.0,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 56,
-                  "end_col_offset": 60
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 62,
-                  "end_col_offset": 63
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 39,
-              "end_col_offset": 64
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "PartSupp",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 66,
-                "end_col_offset": 74
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 200,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 75,
-                  "end_col_offset": 78
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 80,
-                  "end_col_offset": 81
-                },
-                {
-                  "_type": "Constant",
-                  "value": 5.0,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 83,
-                  "end_col_offset": 86
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 88,
-                  "end_col_offset": 89
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 66,
-              "end_col_offset": 90
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 11,
-          "end_col_offset": 91
-        },
-        "lineno": 27,
-        "end_lineno": 27,
-        "end_col_offset": 91
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Filtered",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "part",
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 11,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "value",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 31,
-            "end_lineno": 31,
-            "col_offset": 4,
-            "end_col_offset": 16
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 29,
-        "end_lineno": 31,
-        "end_col_offset": 16
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "filtered",
-            "lineno": 33,
-            "end_lineno": 33,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Filtered",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 33,
-              "end_lineno": 33,
-              "col_offset": 12,
-              "end_col_offset": 20
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "ps",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 21,
-                  "end_col_offset": 23
-                },
-                "attr": "part",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 21,
-                "end_col_offset": 28
-              },
-              {
-                "_type": "BinOp",
-                "left": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "ps",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 30,
-                    "end_col_offset": 32
-                  },
-                  "attr": "cost",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 30,
-                  "end_col_offset": 37
-                },
-                "op": {
-                  "_type": "Mult"
-                },
-                "right": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "ps",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 40,
-                    "end_col_offset": 42
-                  },
-                  "attr": "qty",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 40,
-                  "end_col_offset": 46
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 30,
-                "end_col_offset": 46
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 33,
-            "end_lineno": 33,
-            "col_offset": 12,
-            "end_col_offset": 47
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "ps",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 52,
-                "end_col_offset": 54
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "partsupp",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 58,
-                "end_col_offset": 66
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "s",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 71,
-                "end_col_offset": 72
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "suppliers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 76,
-                "end_col_offset": 85
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 90,
-                "end_col_offset": 91
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "nations",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 95,
-                "end_col_offset": 102
-              },
-              "ifs": [
-                {
-                  "_type": "BoolOp",
-                  "op": {
-                    "_type": "And"
-                  },
-                  "values": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "s",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 106,
-                          "end_col_offset": 107
-                        },
-                        "attr": "id",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 106,
-                        "end_col_offset": 110
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "ps",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 33,
-                            "end_lineno": 33,
-                            "col_offset": 114,
-                            "end_col_offset": 116
-                          },
-                          "attr": "supplier",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 114,
-                          "end_col_offset": 125
-                        }
-                      ],
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 106,
-                      "end_col_offset": 125
-                    },
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "n",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 130,
-                          "end_col_offset": 131
-                        },
-                        "attr": "id",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 130,
-                        "end_col_offset": 134
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "s",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 33,
-                            "end_lineno": 33,
-                            "col_offset": 138,
-                            "end_col_offset": 139
-                          },
-                          "attr": "nation",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 138,
-                          "end_col_offset": 146
-                        }
-                      ],
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 130,
-                      "end_col_offset": 146
-                    },
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "n",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 151,
-                          "end_col_offset": 152
-                        },
-                        "attr": "name",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 33,
-                        "end_lineno": 33,
-                        "col_offset": 151,
-                        "end_col_offset": 157
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Constant",
-                          "value": "A",
-                          "kind": null,
-                          "lineno": 33,
-                          "end_lineno": 33,
-                          "col_offset": 161,
-                          "end_col_offset": 164
-                        }
-                      ],
-                      "lineno": 33,
-                      "end_lineno": 33,
-                      "col_offset": 151,
-                      "end_col_offset": 164
-                    }
-                  ],
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 106,
-                  "end_col_offset": 164
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 33,
-          "end_lineno": 33,
-          "col_offset": 11,
-          "end_col_offset": 165
-        },
-        "lineno": 33,
-        "end_lineno": 33,
-        "end_col_offset": 165
+            ]
+          }
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "GroupedGroup",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 36,
-            "end_lineno": 36,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 37,
-            "end_lineno": 37,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 35,
-        "end_lineno": 37,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_grouped_groups",
-            "lineno": 39,
-            "end_lineno": 39,
-            "end_col_offset": 15
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 39,
-          "end_lineno": 39,
-          "col_offset": 18,
-          "end_col_offset": 20
-        },
-        "lineno": 39,
-        "end_lineno": 39,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 41,
-                "end_lineno": 41,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_grouped_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 41,
-                  "end_lineno": 41,
-                  "col_offset": 9,
-                  "end_col_offset": 24
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 41,
-                "end_lineno": 41,
-                "col_offset": 9,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 41,
-                    "end_lineno": 41,
-                    "col_offset": 36,
-                    "end_col_offset": 37
-                  },
-                  "attr": "part",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 41,
-                  "end_lineno": 41,
-                  "col_offset": 36,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "GroupedGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 41,
-                    "end_lineno": 41,
-                    "col_offset": 44,
-                    "end_col_offset": 56
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 41,
-                        "end_lineno": 41,
-                        "col_offset": 57,
-                        "end_col_offset": 58
-                      },
-                      "attr": "part",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 41,
-                      "end_lineno": 41,
-                      "col_offset": 57,
-                      "end_col_offset": 63
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 41,
-                      "end_lineno": 41,
-                      "col_offset": 65,
-                      "end_col_offset": 67
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 41,
-                  "end_lineno": 41,
-                  "col_offset": 44,
-                  "end_col_offset": 68
-                }
-              ],
-              "keywords": [],
-              "lineno": 41,
-              "end_lineno": 41,
-              "col_offset": 9,
-              "end_col_offset": 69
-            },
-            "lineno": 41,
-            "end_lineno": 41,
-            "col_offset": 4,
-            "end_col_offset": 69
+            ]
           },
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 42,
-                    "end_lineno": 42,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 42,
-                "end_lineno": 42,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "x",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 42,
-                  "end_lineno": 42,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 42,
-              "end_lineno": 42,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 42,
-            "end_lineno": 42,
-            "col_offset": 4,
-            "end_col_offset": 22
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "x",
-          "lineno": 40,
-          "end_lineno": 40,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "filtered",
-          "lineno": 40,
-          "end_lineno": 40,
-          "col_offset": 9,
-          "end_col_offset": 17
-        },
-        "lineno": 40,
-        "end_lineno": 42,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Grouped",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 45,
-              "end_lineno": 45,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "part",
-              "lineno": 45,
-              "end_lineno": 45,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 45,
-            "end_lineno": 45,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 46,
-              "end_lineno": 46,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 46,
-              "end_lineno": 46,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 46,
-            "end_lineno": 46,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
           {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 43,
-            "end_lineno": 43,
-            "col_offset": 1,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "lineno": 44,
-        "end_lineno": 46,
-        "end_col_offset": 14
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
           {
-            "_type": "Name",
-            "id": "grouped",
-            "lineno": 48,
-            "end_lineno": 48,
-            "end_col_offset": 7
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Grouped",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 48,
-              "end_lineno": 48,
-              "col_offset": 11,
-              "end_col_offset": 18
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 262,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 48,
-                  "end_lineno": 48,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 48,
-                "end_lineno": 48,
-                "col_offset": 19,
-                "end_col_offset": 24
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 262,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 235
               },
               {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sum",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 48,
-                  "end_lineno": 48,
-                  "col_offset": 26,
-                  "end_col_offset": 29
-                },
-                "args": [
+                "kind": "block",
+                "start": 241,
+                "end": 262,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "r",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 48,
-                        "end_lineno": 48,
-                        "col_offset": 31,
-                        "end_col_offset": 32
-                      },
-                      "attr": "value",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 48,
-                      "end_lineno": 48,
-                      "col_offset": 31,
-                      "end_col_offset": 38
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 241,
+                    "end": 248,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "r",
-                          "ctx": {
-                            "_type": "Store"
+                        "kind": "assignment",
+                        "start": 241,
+                        "end": 248,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 241,
+                            "end": 243
                           },
-                          "lineno": 48,
-                          "end_lineno": 48,
-                          "col_offset": 43,
-                          "end_col_offset": 44
-                        },
-                        "iter": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "g",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 48,
-                            "end_lineno": 48,
-                            "col_offset": 48,
-                            "end_col_offset": 49
-                          },
-                          "attr": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 48,
-                          "end_lineno": 48,
-                          "col_offset": 48,
-                          "end_col_offset": 55
-                        },
-                        "ifs": [],
-                        "is_async": 0
+                          {
+                            "kind": "type",
+                            "start": 245,
+                            "end": 248,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 245,
+                                "end": 248
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "lineno": 48,
-                    "end_lineno": 48,
-                    "col_offset": 30,
-                    "end_col_offset": 56
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 253,
+                    "end": 262,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 253,
+                        "end": 262,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 253,
+                            "end": 257
+                          },
+                          {
+                            "kind": "type",
+                            "start": 259,
+                            "end": 262,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 259,
+                                "end": 262
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "keywords": [],
-                "lineno": 48,
-                "end_lineno": 48,
-                "col_offset": 26,
-                "end_col_offset": 57
+                ]
               }
-            ],
-            "keywords": [],
-            "lineno": 48,
-            "end_lineno": 48,
-            "col_offset": 11,
-            "end_col_offset": 58
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 48,
-                "end_lineno": 48,
-                "col_offset": 63,
-                "end_col_offset": 64
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_grouped_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 48,
-                    "end_lineno": 48,
-                    "col_offset": 68,
-                    "end_col_offset": 83
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 48,
-                  "end_lineno": 48,
-                  "col_offset": 68,
-                  "end_col_offset": 90
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 48,
-                "end_lineno": 48,
-                "col_offset": 68,
-                "end_col_offset": 92
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 48,
-          "end_lineno": 48,
-          "col_offset": 10,
-          "end_col_offset": 93
-        },
-        "lineno": 48,
-        "end_lineno": 48,
-        "end_col_offset": 93
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 49,
-            "end_lineno": 49,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 49,
-                    "end_lineno": 49,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 49,
-                  "end_lineno": 49,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 49,
-                    "end_lineno": 49,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 49,
-                "end_lineno": 49,
-                "col_offset": 7,
-                "end_col_offset": 29
+        "kind": "expression_statement",
+        "start": 264,
+        "end": 306,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 264,
+            "end": 306,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 264,
+                "end": 271
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 49,
-                    "end_lineno": 49,
-                    "col_offset": 34,
-                    "end_col_offset": 36
+              {
+                "kind": "list",
+                "start": 274,
+                "end": 306,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 275,
+                    "end": 289,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 275,
+                        "end": 281
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 281,
+                        "end": 289,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 282,
+                            "end": 283
+                          },
+                          {
+                            "kind": "string",
+                            "start": 285,
+                            "end": 288,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 285,
+                                "end": 286
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 286,
+                                "end": 287
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 287,
+                                "end": 288
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "grouped",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 49,
-                    "end_lineno": 49,
-                    "col_offset": 40,
-                    "end_col_offset": 47
+                  {
+                    "kind": "call",
+                    "start": 291,
+                    "end": 305,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 291,
+                        "end": 297
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 297,
+                        "end": 305,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 298,
+                            "end": 299
+                          },
+                          {
+                            "kind": "string",
+                            "start": 301,
+                            "end": 304,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 301,
+                                "end": 302
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 302,
+                                "end": 303
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 303,
+                                "end": 304
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 307,
+        "end": 361,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 307,
+            "end": 317,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 308,
+                "end": 317
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 318,
+            "end": 361,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 324,
+                "end": 332
+              },
+              {
+                "kind": "block",
+                "start": 338,
+                "end": 361,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 338,
+                    "end": 345,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 338,
+                        "end": 345,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 338,
+                            "end": 340
+                          },
+                          {
+                            "kind": "type",
+                            "start": 342,
+                            "end": 345,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 342,
+                                "end": 345
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 49,
-              "end_lineno": 49,
-              "col_offset": 6,
-              "end_col_offset": 48
-            }
-          ],
-          "keywords": [],
-          "lineno": 49,
-          "end_lineno": 49,
-          "col_offset": 0,
-          "end_col_offset": 49
-        },
-        "lineno": 49,
-        "end_lineno": 49,
-        "end_col_offset": 49
+                  {
+                    "kind": "expression_statement",
+                    "start": 350,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 350,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 350,
+                            "end": 356
+                          },
+                          {
+                            "kind": "type",
+                            "start": 358,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 358,
+                                "end": 361
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 363,
+        "end": 407,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 363,
+            "end": 407,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 363,
+                "end": 372
+              },
+              {
+                "kind": "list",
+                "start": 375,
+                "end": 407,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 376,
+                    "end": 390,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 376,
+                        "end": 384
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 384,
+                        "end": 390,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 385,
+                            "end": 386
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 388,
+                            "end": 389
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 392,
+                    "end": 406,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 392,
+                        "end": 400
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 400,
+                        "end": 406,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 401,
+                            "end": 402
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 404,
+                            "end": 405
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 408,
+        "end": 495,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 408,
+            "end": 418,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 409,
+                "end": 418
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 419,
+            "end": 495,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 425,
+                "end": 433
+              },
+              {
+                "kind": "block",
+                "start": 439,
+                "end": 495,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 439,
+                    "end": 448,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 439,
+                        "end": 448,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 439,
+                            "end": 443
+                          },
+                          {
+                            "kind": "type",
+                            "start": 445,
+                            "end": 448,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 445,
+                                "end": 448
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 453,
+                    "end": 466,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 453,
+                        "end": 466,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 453,
+                            "end": 461
+                          },
+                          {
+                            "kind": "type",
+                            "start": 463,
+                            "end": 466,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 463,
+                                "end": 466
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 471,
+                    "end": 482,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 471,
+                        "end": 482,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 471,
+                            "end": 475
+                          },
+                          {
+                            "kind": "type",
+                            "start": 477,
+                            "end": 482,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 477,
+                                "end": 482
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 487,
+                    "end": 495,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 487,
+                        "end": 495,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 487,
+                            "end": 490
+                          },
+                          {
+                            "kind": "type",
+                            "start": 492,
+                            "end": 495,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 492,
+                                "end": 495
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 497,
+        "end": 588,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 497,
+            "end": 588,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 497,
+                "end": 505
+              },
+              {
+                "kind": "list",
+                "start": 508,
+                "end": 588,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 509,
+                    "end": 534,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 509,
+                        "end": 517
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 517,
+                        "end": 534,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 518,
+                            "end": 521
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 523,
+                            "end": 524
+                          },
+                          {
+                            "kind": "float",
+                            "start": 526,
+                            "end": 530
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 532,
+                            "end": 533
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 536,
+                    "end": 561,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 536,
+                        "end": 544
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 544,
+                        "end": 561,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 545,
+                            "end": 548
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 550,
+                            "end": 551
+                          },
+                          {
+                            "kind": "float",
+                            "start": 553,
+                            "end": 557
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 559,
+                            "end": 560
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 563,
+                    "end": 587,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 563,
+                        "end": 571
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 571,
+                        "end": 587,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 572,
+                            "end": 575
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 577,
+                            "end": 578
+                          },
+                          {
+                            "kind": "float",
+                            "start": 580,
+                            "end": 583
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 585,
+                            "end": 586
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 589,
+        "end": 646,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 589,
+            "end": 599,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 590,
+                "end": 599
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 600,
+            "end": 646,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 606,
+                "end": 614
+              },
+              {
+                "kind": "block",
+                "start": 620,
+                "end": 646,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 620,
+                    "end": 629,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 620,
+                        "end": 629,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 620,
+                            "end": 624
+                          },
+                          {
+                            "kind": "type",
+                            "start": 626,
+                            "end": 629,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 626,
+                                "end": 629
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 634,
+                    "end": 646,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 634,
+                        "end": 646,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 634,
+                            "end": 639
+                          },
+                          {
+                            "kind": "type",
+                            "start": 641,
+                            "end": 646,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 641,
+                                "end": 646
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 648,
+        "end": 813,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 648,
+            "end": 813,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 648,
+                "end": 656
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 659,
+                "end": 813,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 660,
+                    "end": 695,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 660,
+                        "end": 668
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 668,
+                        "end": 695,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 669,
+                            "end": 676,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 669,
+                                "end": 671
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 672,
+                                "end": 676
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "binary_operator",
+                            "start": 678,
+                            "end": 694,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 678,
+                                "end": 685,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 678,
+                                    "end": 680
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 681,
+                                    "end": 685
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "attribute",
+                                "start": 688,
+                                "end": 694,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 688,
+                                    "end": 690
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 691,
+                                    "end": 694
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 696,
+                    "end": 714,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 700,
+                        "end": 702
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 706,
+                        "end": 714
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 715,
+                    "end": 733,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 719,
+                        "end": 720
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 724,
+                        "end": 733
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 734,
+                    "end": 750,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 738,
+                        "end": 739
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 743,
+                        "end": 750
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 751,
+                    "end": 812,
+                    "children": [
+                      {
+                        "kind": "boolean_operator",
+                        "start": 754,
+                        "end": 812,
+                        "children": [
+                          {
+                            "kind": "boolean_operator",
+                            "start": 754,
+                            "end": 794,
+                            "children": [
+                              {
+                                "kind": "comparison_operator",
+                                "start": 754,
+                                "end": 773,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 754,
+                                    "end": 758,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 754,
+                                        "end": 755
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 756,
+                                        "end": 758
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 762,
+                                    "end": 773,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 762,
+                                        "end": 764
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 765,
+                                        "end": 773
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 778,
+                                "end": 794,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 778,
+                                    "end": 782,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 778,
+                                        "end": 779
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 780,
+                                        "end": 782
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 786,
+                                    "end": 794,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 786,
+                                        "end": 787
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 788,
+                                        "end": 794
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 799,
+                            "end": 812,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 799,
+                                "end": 805,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 799,
+                                    "end": 800
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 801,
+                                    "end": 805
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 809,
+                                "end": 812,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 809,
+                                    "end": 810
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 810,
+                                    "end": 811
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 811,
+                                    "end": 812
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 814,
+        "end": 873,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 814,
+            "end": 824,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 815,
+                "end": 824
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 825,
+            "end": 873,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 831,
+                "end": 843
+              },
+              {
+                "kind": "block",
+                "start": 849,
+                "end": 873,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 849,
+                    "end": 857,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 849,
+                        "end": 857,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 849,
+                            "end": 852
+                          },
+                          {
+                            "kind": "type",
+                            "start": 854,
+                            "end": 857,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 854,
+                                "end": 857
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 862,
+                    "end": 873,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 862,
+                        "end": 873,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 862,
+                            "end": 867
+                          },
+                          {
+                            "kind": "type",
+                            "start": 869,
+                            "end": 873,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 869,
+                                "end": 873
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 875,
+        "end": 895,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 875,
+            "end": 895,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 875,
+                "end": 890
+              },
+              {
+                "kind": "dictionary",
+                "start": 893,
+                "end": 895
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 896,
+        "end": 1007,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 900,
+            "end": 901
+          },
+          {
+            "kind": "identifier",
+            "start": 905,
+            "end": 913
+          },
+          {
+            "kind": "block",
+            "start": 919,
+            "end": 1007,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 919,
+                "end": 984,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 919,
+                    "end": 984,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 919,
+                        "end": 921
+                      },
+                      {
+                        "kind": "call",
+                        "start": 924,
+                        "end": 984,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 924,
+                            "end": 950,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 924,
+                                "end": 939
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 940,
+                                "end": 950
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 950,
+                            "end": 984,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 951,
+                                "end": 957,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 951,
+                                    "end": 952
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 953,
+                                    "end": 957
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 959,
+                                "end": 983,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 959,
+                                    "end": 971
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 971,
+                                    "end": 983,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 972,
+                                        "end": 978,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 972,
+                                            "end": 973
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 974,
+                                            "end": 978
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 980,
+                                        "end": 982
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 989,
+                "end": 1007,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 989,
+                    "end": 1007,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 989,
+                        "end": 1004,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 989,
+                            "end": 997,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 989,
+                                "end": 991
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 992,
+                                "end": 997
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 998,
+                            "end": 1004
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 1004,
+                        "end": 1007,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1005,
+                            "end": 1006
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 1008,
+        "end": 1062,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 1008,
+            "end": 1018,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1009,
+                "end": 1018
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 1019,
+            "end": 1062,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1025,
+                "end": 1032
+              },
+              {
+                "kind": "block",
+                "start": 1038,
+                "end": 1062,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 1038,
+                    "end": 1047,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1038,
+                        "end": 1047,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1038,
+                            "end": 1042
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1044,
+                            "end": 1047,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1044,
+                                "end": 1047
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1052,
+                    "end": 1062,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1052,
+                        "end": 1062,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1052,
+                            "end": 1057
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1059,
+                            "end": 1062,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1059,
+                                "end": 1062
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 1064,
+        "end": 1157,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 1064,
+            "end": 1157,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1064,
+                "end": 1071
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 1074,
+                "end": 1157,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 1075,
+                    "end": 1122,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 1075,
+                        "end": 1082
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 1082,
+                        "end": 1122,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 1083,
+                            "end": 1088,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1083,
+                                "end": 1084
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1085,
+                                "end": 1088
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 1090,
+                            "end": 1121,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1090,
+                                "end": 1093
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 1093,
+                                "end": 1121,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 1094,
+                                    "end": 1120,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 1095,
+                                        "end": 1102,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1095,
+                                            "end": 1096
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1097,
+                                            "end": 1102
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 1103,
+                                        "end": 1119,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1107,
+                                            "end": 1108
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 1112,
+                                            "end": 1119,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1112,
+                                                "end": 1113
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1114,
+                                                "end": 1119
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 1123,
+                    "end": 1156,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 1127,
+                        "end": 1128
+                      },
+                      {
+                        "kind": "call",
+                        "start": 1132,
+                        "end": 1156,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 1132,
+                            "end": 1154,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1132,
+                                "end": 1147
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1148,
+                                "end": 1154
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 1154,
+                            "end": 1156
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 1158,
+        "end": 1207,
+        "children": [
+          {
+            "kind": "call",
+            "start": 1158,
+            "end": 1207,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1158,
+                "end": 1163
+              },
+              {
+                "kind": "argument_list",
+                "start": 1163,
+                "end": 1207,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 1164,
+                    "end": 1206,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 1165,
+                        "end": 1187,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 1165,
+                            "end": 1183,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1165,
+                                "end": 1176
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 1177,
+                                "end": 1183
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 1183,
+                            "end": 1187,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1184,
+                                "end": 1186
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 1188,
+                        "end": 1205,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1192,
+                            "end": 1194
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1198,
+                            "end": 1205
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_multi_join_sort.py.json
+++ b/tests/json-ast/x/py/group_by_multi_join_sort.py.json
@@ -1,3460 +1,3783 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 2443,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Nation",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 17,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n_nationkey",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 15
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n_name",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 11,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "nation",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Nation",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                {
-                  "_type": "Constant",
-                  "value": "BRAZIL",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 20,
-                  "end_col_offset": 28
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 10,
-              "end_col_offset": 29
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 9,
-          "end_col_offset": 30
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 30
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_custkey",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_name",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 15
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 15,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_acctbal",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 18,
-            "end_lineno": 18,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 17,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_nationkey",
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 4,
-              "end_col_offset": 15
-            },
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 20,
-              "end_lineno": 20,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_address",
-              "lineno": 20,
-              "end_lineno": 20,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_phone",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_comment",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 18
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 15,
-        "end_lineno": 22,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customer",
-            "lineno": 24,
-            "end_lineno": 24,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 24,
-                "end_lineno": 24,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 24,
-                  "end_col_offset": 31
-                },
-                {
-                  "_type": "Constant",
-                  "value": 100.0,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 33,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 40,
-                  "end_col_offset": 41
-                },
-                {
-                  "_type": "Constant",
-                  "value": "123 St",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 43,
-                  "end_col_offset": 51
-                },
-                {
-                  "_type": "Constant",
-                  "value": "123-456",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 53,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Loyal",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 64,
-                  "end_col_offset": 71
-                }
-              ],
-              "keywords": [],
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 12,
-              "end_col_offset": 72
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 11,
-          "end_col_offset": 73
-        },
-        "lineno": 24,
-        "end_lineno": 24,
-        "end_col_offset": 73
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o_orderkey",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o_custkey",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 17,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o_orderdate",
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 4,
-              "end_col_offset": 15
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 4,
-            "end_col_offset": 20
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 26,
-        "end_lineno": 29,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 31,
-            "end_lineno": 31,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1000,
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 16,
-                  "end_col_offset": 20
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "1993-10-15",
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 25,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 10,
-              "end_col_offset": 38
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 40,
-                "end_col_offset": 45
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2000,
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 46,
-                  "end_col_offset": 50
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 52,
-                  "end_col_offset": 53
-                },
-                {
-                  "_type": "Constant",
-                  "value": "1994-01-02",
-                  "kind": null,
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 55,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 40,
-              "end_col_offset": 68
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 9,
-          "end_col_offset": 69
-        },
-        "lineno": 31,
-        "end_lineno": 31,
-        "end_col_offset": 69
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Lineitem",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 34,
-              "end_lineno": 34,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l_orderkey",
-              "lineno": 34,
-              "end_lineno": 34,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 35,
-              "end_lineno": 35,
-              "col_offset": 18,
-              "end_col_offset": 21
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l_returnflag",
-              "lineno": 35,
-              "end_lineno": 35,
-              "col_offset": 4,
-              "end_col_offset": 16
-            },
-            "lineno": 35,
-            "end_lineno": 35,
-            "col_offset": 4,
-            "end_col_offset": 21
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 21,
-              "end_col_offset": 26
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l_extendedprice",
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 4,
-              "end_col_offset": 19
-            },
-            "lineno": 36,
-            "end_lineno": 36,
-            "col_offset": 4,
-            "end_col_offset": 26
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 16,
-              "end_col_offset": 21
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l_discount",
-              "lineno": 37,
-              "end_lineno": 37,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 37,
-            "end_lineno": 37,
-            "col_offset": 4,
-            "end_col_offset": 21
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 32,
-            "end_lineno": 32,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 33,
-        "end_lineno": 37,
-        "end_col_offset": 21
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "lineitem",
-            "lineno": 39,
-            "end_lineno": 39,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Lineitem",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1000,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 21,
-                  "end_col_offset": 25
-                },
-                {
-                  "_type": "Constant",
-                  "value": "R",
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 27,
-                  "end_col_offset": 30
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1000.0,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 32,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Constant",
-                  "value": 0.1,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 40,
-                  "end_col_offset": 43
-                }
-              ],
-              "keywords": [],
-              "lineno": 39,
-              "end_lineno": 39,
-              "col_offset": 12,
-              "end_col_offset": 44
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Lineitem",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 39,
-                "end_lineno": 39,
-                "col_offset": 46,
-                "end_col_offset": 54
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2000,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 55,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": "N",
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 61,
-                  "end_col_offset": 64
-                },
-                {
-                  "_type": "Constant",
-                  "value": 500.0,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 66,
-                  "end_col_offset": 71
-                },
-                {
-                  "_type": "Constant",
-                  "value": 0.0,
-                  "kind": null,
-                  "lineno": 39,
-                  "end_lineno": 39,
-                  "col_offset": 73,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 39,
-              "end_lineno": 39,
-              "col_offset": 46,
-              "end_col_offset": 77
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 39,
-          "end_lineno": 39,
-          "col_offset": 11,
-          "end_col_offset": 78
-        },
-        "lineno": 39,
-        "end_lineno": 39,
-        "end_col_offset": 78
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "start_date",
-            "lineno": 40,
-            "end_lineno": 40,
-            "end_col_offset": 10
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "1993-10-01",
-          "kind": null,
-          "lineno": 40,
-          "end_lineno": 40,
-          "col_offset": 13,
-          "end_col_offset": 25
-        },
-        "lineno": 40,
-        "end_lineno": 40,
-        "end_col_offset": 25
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "end_date",
-            "lineno": 41,
-            "end_lineno": 41,
-            "end_col_offset": 8
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "1994-01-01",
-          "kind": null,
-          "lineno": 41,
-          "end_lineno": 41,
-          "col_offset": 11,
-          "end_col_offset": 23
-        },
-        "lineno": 41,
-        "end_lineno": 41,
-        "end_col_offset": 23
-      },
-      {
-        "_type": "ClassDef",
-        "name": "GKey",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 44,
-              "end_lineno": 44,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_custkey",
-              "lineno": 44,
-              "end_lineno": 44,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 44,
-            "end_lineno": 44,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 45,
-              "end_lineno": 45,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_name",
-              "lineno": 45,
-              "end_lineno": 45,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 45,
-            "end_lineno": 45,
-            "col_offset": 4,
-            "end_col_offset": 15
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 46,
-              "end_lineno": 46,
-              "col_offset": 15,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_acctbal",
-              "lineno": 46,
-              "end_lineno": 46,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 46,
-            "end_lineno": 46,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 47,
-              "end_lineno": 47,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_address",
-              "lineno": 47,
-              "end_lineno": 47,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 47,
-            "end_lineno": 47,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 48,
-              "end_lineno": 48,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_phone",
-              "lineno": 48,
-              "end_lineno": 48,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 48,
-            "end_lineno": 48,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 49,
-              "end_lineno": 49,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_comment",
-              "lineno": 49,
-              "end_lineno": 49,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 49,
-            "end_lineno": 49,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 50,
-              "end_lineno": 50,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n_name",
-              "lineno": 50,
-              "end_lineno": 50,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 50,
-            "end_lineno": 50,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 42,
-            "end_lineno": 42,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 43,
-        "end_lineno": 50,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "ClassDef",
-        "name": "ResultGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "GKey",
-              "lineno": 54,
-              "end_lineno": 54,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 54,
-              "end_lineno": 54,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 54,
-            "end_lineno": 54,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 55,
-              "end_lineno": 55,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 55,
-              "end_lineno": 55,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 55,
-            "end_lineno": 55,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 52,
-            "end_lineno": 52,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 53,
-        "end_lineno": 55,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "ClassDef",
-        "name": "ResultRow",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 59,
-              "end_lineno": 59,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c",
-              "lineno": 59,
-              "end_lineno": 59,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 59,
-            "end_lineno": 59,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 60,
-              "end_lineno": 60,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "o",
-              "lineno": 60,
-              "end_lineno": 60,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 60,
-            "end_lineno": 60,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 61,
-              "end_lineno": 61,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "l",
-              "lineno": 61,
-              "end_lineno": 61,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 61,
-            "end_lineno": 61,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 62,
-              "end_lineno": 62,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n",
-              "lineno": 62,
-              "end_lineno": 62,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 62,
-            "end_lineno": 62,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 57,
-            "end_lineno": 57,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 58,
-        "end_lineno": 62,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_result_groups",
-            "lineno": 64,
-            "end_lineno": 64,
-            "end_col_offset": 14
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 64,
-          "end_lineno": 64,
-          "col_offset": 17,
-          "end_col_offset": 19
-        },
-        "lineno": 64,
-        "end_lineno": 64,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "For",
-            "body": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "For",
-                "body": [
-                  {
-                    "_type": "For",
-                    "body": [
-                      {
-                        "_type": "If",
-                        "body": [
-                          {
-                            "_type": "Assign",
-                            "targets": [
-                              {
-                                "_type": "Name",
-                                "id": "_g",
-                                "lineno": 70,
-                                "end_lineno": 70,
-                                "col_offset": 20,
-                                "end_col_offset": 22
-                              }
-                            ],
-                            "value": {
-                              "_type": "Call",
-                              "func": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "_result_groups",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 70,
-                                  "end_lineno": 70,
-                                  "col_offset": 25,
-                                  "end_col_offset": 39
-                                },
-                                "attr": "setdefault",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 70,
-                                "end_lineno": 70,
-                                "col_offset": 25,
-                                "end_col_offset": 50
-                              },
-                              "args": [
-                                {
-                                  "_type": "Call",
-                                  "func": {
-                                    "_type": "Name",
-                                    "id": "tuple",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 70,
-                                    "end_lineno": 70,
-                                    "col_offset": 51,
-                                    "end_col_offset": 56
-                                  },
-                                  "args": [
-                                    {
-                                      "_type": "List",
-                                      "elts": [
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 58,
-                                            "end_col_offset": 59
-                                          },
-                                          "attr": "c_custkey",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 58,
-                                          "end_col_offset": 69
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 71,
-                                            "end_col_offset": 72
-                                          },
-                                          "attr": "c_name",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 71,
-                                          "end_col_offset": 79
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 81,
-                                            "end_col_offset": 82
-                                          },
-                                          "attr": "c_acctbal",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 81,
-                                          "end_col_offset": 92
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 94,
-                                            "end_col_offset": 95
-                                          },
-                                          "attr": "c_address",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 94,
-                                          "end_col_offset": 105
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 107,
-                                            "end_col_offset": 108
-                                          },
-                                          "attr": "c_phone",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 107,
-                                          "end_col_offset": 116
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 118,
-                                            "end_col_offset": 119
-                                          },
-                                          "attr": "c_comment",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 118,
-                                          "end_col_offset": 129
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "n",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 131,
-                                            "end_col_offset": 132
-                                          },
-                                          "attr": "n_name",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 131,
-                                          "end_col_offset": 139
-                                        }
-                                      ],
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 70,
-                                      "end_lineno": 70,
-                                      "col_offset": 57,
-                                      "end_col_offset": 140
-                                    }
-                                  ],
-                                  "keywords": [],
-                                  "lineno": 70,
-                                  "end_lineno": 70,
-                                  "col_offset": 51,
-                                  "end_col_offset": 141
-                                },
-                                {
-                                  "_type": "Call",
-                                  "func": {
-                                    "_type": "Name",
-                                    "id": "ResultGroup",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 70,
-                                    "end_lineno": 70,
-                                    "col_offset": 143,
-                                    "end_col_offset": 154
-                                  },
-                                  "args": [
-                                    {
-                                      "_type": "Call",
-                                      "func": {
-                                        "_type": "Name",
-                                        "id": "GKey",
-                                        "ctx": {
-                                          "_type": "Load"
-                                        },
-                                        "lineno": 70,
-                                        "end_lineno": 70,
-                                        "col_offset": 155,
-                                        "end_col_offset": 159
-                                      },
-                                      "args": [
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 160,
-                                            "end_col_offset": 161
-                                          },
-                                          "attr": "c_custkey",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 160,
-                                          "end_col_offset": 171
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 173,
-                                            "end_col_offset": 174
-                                          },
-                                          "attr": "c_name",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 173,
-                                          "end_col_offset": 181
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 183,
-                                            "end_col_offset": 184
-                                          },
-                                          "attr": "c_acctbal",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 183,
-                                          "end_col_offset": 194
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 196,
-                                            "end_col_offset": 197
-                                          },
-                                          "attr": "c_address",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 196,
-                                          "end_col_offset": 207
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 209,
-                                            "end_col_offset": 210
-                                          },
-                                          "attr": "c_phone",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 209,
-                                          "end_col_offset": 218
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "c",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 220,
-                                            "end_col_offset": 221
-                                          },
-                                          "attr": "c_comment",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 220,
-                                          "end_col_offset": 231
-                                        },
-                                        {
-                                          "_type": "Attribute",
-                                          "value": {
-                                            "_type": "Name",
-                                            "id": "n",
-                                            "ctx": {
-                                              "_type": "Load"
-                                            },
-                                            "lineno": 70,
-                                            "end_lineno": 70,
-                                            "col_offset": 233,
-                                            "end_col_offset": 234
-                                          },
-                                          "attr": "n_name",
-                                          "ctx": {
-                                            "_type": "Load"
-                                          },
-                                          "lineno": 70,
-                                          "end_lineno": 70,
-                                          "col_offset": 233,
-                                          "end_col_offset": 241
-                                        }
-                                      ],
-                                      "keywords": [],
-                                      "lineno": 70,
-                                      "end_lineno": 70,
-                                      "col_offset": 155,
-                                      "end_col_offset": 242
-                                    },
-                                    {
-                                      "_type": "List",
-                                      "elts": [],
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 70,
-                                      "end_lineno": 70,
-                                      "col_offset": 244,
-                                      "end_col_offset": 246
-                                    }
-                                  ],
-                                  "keywords": [],
-                                  "lineno": 70,
-                                  "end_lineno": 70,
-                                  "col_offset": 143,
-                                  "end_col_offset": 247
-                                }
-                              ],
-                              "keywords": [],
-                              "lineno": 70,
-                              "end_lineno": 70,
-                              "col_offset": 25,
-                              "end_col_offset": 248
-                            },
-                            "lineno": 70,
-                            "end_lineno": 70,
-                            "col_offset": 20,
-                            "end_col_offset": 248
-                          },
-                          {
-                            "_type": "Expr",
-                            "value": {
-                              "_type": "Call",
-                              "func": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "_g",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 71,
-                                    "end_lineno": 71,
-                                    "col_offset": 20,
-                                    "end_col_offset": 22
-                                  },
-                                  "attr": "items",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 71,
-                                  "end_lineno": 71,
-                                  "col_offset": 20,
-                                  "end_col_offset": 28
-                                },
-                                "attr": "append",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 71,
-                                "end_lineno": 71,
-                                "col_offset": 20,
-                                "end_col_offset": 35
-                              },
-                              "args": [
-                                {
-                                  "_type": "Call",
-                                  "func": {
-                                    "_type": "Name",
-                                    "id": "ResultRow",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 71,
-                                    "end_lineno": 71,
-                                    "col_offset": 36,
-                                    "end_col_offset": 45
-                                  },
-                                  "args": [
-                                    {
-                                      "_type": "Name",
-                                      "id": "c",
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 71,
-                                      "end_lineno": 71,
-                                      "col_offset": 46,
-                                      "end_col_offset": 47
-                                    },
-                                    {
-                                      "_type": "Name",
-                                      "id": "o",
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 71,
-                                      "end_lineno": 71,
-                                      "col_offset": 49,
-                                      "end_col_offset": 50
-                                    },
-                                    {
-                                      "_type": "Name",
-                                      "id": "l",
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 71,
-                                      "end_lineno": 71,
-                                      "col_offset": 52,
-                                      "end_col_offset": 53
-                                    },
-                                    {
-                                      "_type": "Name",
-                                      "id": "n",
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 71,
-                                      "end_lineno": 71,
-                                      "col_offset": 55,
-                                      "end_col_offset": 56
-                                    }
-                                  ],
-                                  "keywords": [],
-                                  "lineno": 71,
-                                  "end_lineno": 71,
-                                  "col_offset": 36,
-                                  "end_col_offset": 57
-                                }
-                              ],
-                              "keywords": [],
-                              "lineno": 71,
-                              "end_lineno": 71,
-                              "col_offset": 20,
-                              "end_col_offset": 58
-                            },
-                            "lineno": 71,
-                            "end_lineno": 71,
-                            "col_offset": 20,
-                            "end_col_offset": 58
-                          }
-                        ],
-                        "test": {
-                          "_type": "BoolOp",
-                          "op": {
-                            "_type": "And"
-                          },
-                          "values": [
-                            {
-                              "_type": "Compare",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "o",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 19,
-                                  "end_col_offset": 20
-                                },
-                                "attr": "o_orderdate",
-                                "lineno": 69,
-                                "end_lineno": 69,
-                                "col_offset": 19,
-                                "end_col_offset": 32
-                              },
-                              "ops": [
-                                {
-                                  "_type": "GtE"
-                                }
-                              ],
-                              "comparators": [
-                                {
-                                  "_type": "Name",
-                                  "id": "start_date",
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 36,
-                                  "end_col_offset": 46
-                                }
-                              ],
-                              "lineno": 69,
-                              "end_lineno": 69,
-                              "col_offset": 19,
-                              "end_col_offset": 46
-                            },
-                            {
-                              "_type": "Compare",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "o",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 51,
-                                  "end_col_offset": 52
-                                },
-                                "attr": "o_orderdate",
-                                "lineno": 69,
-                                "end_lineno": 69,
-                                "col_offset": 51,
-                                "end_col_offset": 64
-                              },
-                              "ops": [
-                                {
-                                  "_type": "Lt"
-                                }
-                              ],
-                              "comparators": [
-                                {
-                                  "_type": "Name",
-                                  "id": "end_date",
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 67,
-                                  "end_col_offset": 75
-                                }
-                              ],
-                              "lineno": 69,
-                              "end_lineno": 69,
-                              "col_offset": 51,
-                              "end_col_offset": 75
-                            },
-                            {
-                              "_type": "Compare",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "l",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 80,
-                                  "end_col_offset": 81
-                                },
-                                "attr": "l_returnflag",
-                                "lineno": 69,
-                                "end_lineno": 69,
-                                "col_offset": 80,
-                                "end_col_offset": 94
-                              },
-                              "ops": [
-                                {
-                                  "_type": "Eq"
-                                }
-                              ],
-                              "comparators": [
-                                {
-                                  "_type": "Constant",
-                                  "value": "R",
-                                  "lineno": 69,
-                                  "end_lineno": 69,
-                                  "col_offset": 98,
-                                  "end_col_offset": 101
-                                }
-                              ],
-                              "lineno": 69,
-                              "end_lineno": 69,
-                              "col_offset": 80,
-                              "end_col_offset": 101
-                            }
-                          ],
-                          "lineno": 69,
-                          "end_lineno": 69,
-                          "col_offset": 19,
-                          "end_col_offset": 101
-                        },
-                        "lineno": 69,
-                        "end_lineno": 71,
-                        "col_offset": 16,
-                        "end_col_offset": 58
-                      }
-                    ],
-                    "target": {
-                      "_type": "Name",
-                      "id": "n",
-                      "lineno": 68,
-                      "end_lineno": 68,
-                      "col_offset": 16,
-                      "end_col_offset": 17
-                    },
-                    "iter": {
-                      "_type": "ListComp",
-                      "generators": [
-                        {
-                          "_type": "comprehension",
-                          "target": {
-                            "_type": "Name",
-                            "id": "n",
-                            "lineno": 68,
-                            "end_lineno": 68,
-                            "col_offset": 28,
-                            "end_col_offset": 29
-                          },
-                          "iter": {
-                            "_type": "Name",
-                            "id": "nation",
-                            "lineno": 68,
-                            "end_lineno": 68,
-                            "col_offset": 33,
-                            "end_col_offset": 39
-                          },
-                          "ifs": [
-                            {
-                              "_type": "Compare",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "n",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 68,
-                                  "end_lineno": 68,
-                                  "col_offset": 43,
-                                  "end_col_offset": 44
-                                },
-                                "attr": "n_nationkey",
-                                "lineno": 68,
-                                "end_lineno": 68,
-                                "col_offset": 43,
-                                "end_col_offset": 56
-                              },
-                              "ops": [
-                                {
-                                  "_type": "Eq"
-                                }
-                              ],
-                              "comparators": [
-                                {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "c",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 68,
-                                    "end_lineno": 68,
-                                    "col_offset": 60,
-                                    "end_col_offset": 61
-                                  },
-                                  "attr": "c_nationkey",
-                                  "lineno": 68,
-                                  "end_lineno": 68,
-                                  "col_offset": 60,
-                                  "end_col_offset": 73
-                                }
-                              ],
-                              "lineno": 68,
-                              "end_lineno": 68,
-                              "col_offset": 43,
-                              "end_col_offset": 73
-                            }
-                          ]
-                        }
-                      ],
-                      "elt": {
-                        "_type": "Name",
-                        "id": "n",
-                        "lineno": 68,
-                        "end_lineno": 68,
-                        "col_offset": 22,
-                        "end_col_offset": 23
-                      },
-                      "lineno": 68,
-                      "end_lineno": 68,
-                      "col_offset": 21,
-                      "end_col_offset": 74
-                    },
-                    "lineno": 68,
-                    "end_lineno": 71,
-                    "col_offset": 12,
-                    "end_col_offset": 58
-                  }
-                ],
-                "target": {
-                  "_type": "Name",
-                  "id": "l",
-                  "lineno": 67,
-                  "end_lineno": 67,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "iter": {
-                  "_type": "ListComp",
-                  "generators": [
-                    {
-                      "_type": "comprehension",
-                      "target": {
-                        "_type": "Name",
-                        "id": "l",
-                        "lineno": 67,
-                        "end_lineno": 67,
-                        "col_offset": 24,
-                        "end_col_offset": 25
-                      },
-                      "iter": {
-                        "_type": "Name",
-                        "id": "lineitem",
-                        "lineno": 67,
-                        "end_lineno": 67,
-                        "col_offset": 29,
-                        "end_col_offset": 37
-                      },
-                      "ifs": [
-                        {
-                          "_type": "Compare",
-                          "left": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "l",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 67,
-                              "end_lineno": 67,
-                              "col_offset": 41,
-                              "end_col_offset": 42
-                            },
-                            "attr": "l_orderkey",
-                            "lineno": 67,
-                            "end_lineno": 67,
-                            "col_offset": 41,
-                            "end_col_offset": 53
-                          },
-                          "ops": [
-                            {
-                              "_type": "Eq"
-                            }
-                          ],
-                          "comparators": [
-                            {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 67,
-                                "end_lineno": 67,
-                                "col_offset": 57,
-                                "end_col_offset": 58
-                              },
-                              "attr": "o_orderkey",
-                              "lineno": 67,
-                              "end_lineno": 67,
-                              "col_offset": 57,
-                              "end_col_offset": 69
-                            }
-                          ],
-                          "lineno": 67,
-                          "end_lineno": 67,
-                          "col_offset": 41,
-                          "end_col_offset": 69
-                        }
-                      ]
-                    }
-                  ],
-                  "elt": {
-                    "_type": "Name",
-                    "id": "l",
-                    "lineno": 67,
-                    "end_lineno": 67,
-                    "col_offset": 18,
-                    "end_col_offset": 19
-                  },
-                  "lineno": 67,
-                  "end_lineno": 67,
-                  "col_offset": 17,
-                  "end_col_offset": 70
-                },
-                "lineno": 67,
-                "end_lineno": 71,
-                "col_offset": 8,
-                "end_col_offset": 58
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "target": {
-              "_type": "Name",
-              "id": "o",
-              "lineno": 66,
-              "end_lineno": 66,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            "iter": {
-              "_type": "ListComp",
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "o",
-                    "lineno": 66,
-                    "end_lineno": 66,
-                    "col_offset": 20,
-                    "end_col_offset": 21
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "orders",
-                    "lineno": 66,
-                    "end_lineno": 66,
-                    "col_offset": 25,
-                    "end_col_offset": 31
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 66,
-                          "end_lineno": 66,
-                          "col_offset": 35,
-                          "end_col_offset": 36
-                        },
-                        "attr": "o_custkey",
-                        "lineno": 66,
-                        "end_lineno": 66,
-                        "col_offset": 35,
-                        "end_col_offset": 46
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 66,
-                            "end_lineno": 66,
-                            "col_offset": 50,
-                            "end_col_offset": 51
-                          },
-                          "attr": "c_custkey",
-                          "lineno": 66,
-                          "end_lineno": 66,
-                          "col_offset": 50,
-                          "end_col_offset": 61
-                        }
-                      ],
-                      "lineno": 66,
-                      "end_lineno": 66,
-                      "col_offset": 35,
-                      "end_col_offset": 61
-                    }
-                  ]
-                }
-              ],
-              "elt": {
-                "_type": "Name",
-                "id": "o",
-                "lineno": 66,
-                "end_lineno": 66,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "lineno": 66,
-              "end_lineno": 66,
-              "col_offset": 13,
-              "end_col_offset": 62
-            },
-            "lineno": 66,
-            "end_lineno": 71,
-            "col_offset": 4,
-            "end_col_offset": 58
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "c",
-          "lineno": 65,
-          "end_lineno": 65,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "customer",
-          "lineno": 65,
-          "end_lineno": 65,
-          "col_offset": 9,
-          "end_col_offset": 17
-        },
-        "lineno": 65,
-        "end_lineno": 71,
-        "end_col_offset": 58
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 74,
-              "end_lineno": 74,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_custkey",
-              "lineno": 74,
-              "end_lineno": 74,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 74,
-            "end_lineno": 74,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 75,
-              "end_lineno": 75,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_name",
-              "lineno": 75,
-              "end_lineno": 75,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 75,
-            "end_lineno": 75,
-            "col_offset": 4,
-            "end_col_offset": 15
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 76,
-              "end_lineno": 76,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "revenue",
-              "lineno": 76,
-              "end_lineno": 76,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 76,
-            "end_lineno": 76,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 77,
-              "end_lineno": 77,
-              "col_offset": 15,
-              "end_col_offset": 20
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_acctbal",
-              "lineno": 77,
-              "end_lineno": 77,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 77,
-            "end_lineno": 77,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 78,
-              "end_lineno": 78,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n_name",
-              "lineno": 78,
-              "end_lineno": 78,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 78,
-            "end_lineno": 78,
-            "col_offset": 4,
-            "end_col_offset": 15
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 79,
-              "end_lineno": 79,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_address",
-              "lineno": 79,
-              "end_lineno": 79,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 79,
-            "end_lineno": 79,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 80,
-              "end_lineno": 80,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_phone",
-              "lineno": 80,
-              "end_lineno": 80,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 80,
-            "end_lineno": 80,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 81,
-              "end_lineno": 81,
-              "col_offset": 15,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "c_comment",
-              "lineno": 81,
-              "end_lineno": 81,
-              "col_offset": 4,
-              "end_col_offset": 13
-            },
-            "lineno": 81,
-            "end_lineno": 81,
-            "col_offset": 4,
-            "end_col_offset": 18
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 72,
-            "end_lineno": 72,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 73,
-        "end_lineno": 81,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 83,
-            "end_lineno": 83,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 83,
-              "end_lineno": 83,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 17,
-                  "end_col_offset": 22
-                },
-                "attr": "c_custkey",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 17,
-                "end_col_offset": 32
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 34,
-                    "end_col_offset": 35
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 34,
-                  "end_col_offset": 39
-                },
-                "attr": "c_name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 34,
-                "end_col_offset": 46
-              },
-              {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sum",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 48,
-                  "end_col_offset": 51
-                },
-                "args": [
-                  {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "BinOp",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "x",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 83,
-                            "end_lineno": 83,
-                            "col_offset": 53,
-                            "end_col_offset": 54
-                          },
-                          "attr": "l",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 53,
-                          "end_col_offset": 56
-                        },
-                        "attr": "l_extendedprice",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 83,
-                        "end_lineno": 83,
-                        "col_offset": 53,
-                        "end_col_offset": 72
-                      },
-                      "op": {
-                        "_type": "Mult"
-                      },
-                      "right": {
-                        "_type": "BinOp",
-                        "left": {
-                          "_type": "Constant",
-                          "value": 1,
-                          "kind": null,
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 76,
-                          "end_col_offset": 77
-                        },
-                        "op": {
-                          "_type": "Sub"
-                        },
-                        "right": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "x",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 83,
-                              "end_lineno": 83,
-                              "col_offset": 80,
-                              "end_col_offset": 81
-                            },
-                            "attr": "l",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 83,
-                            "end_lineno": 83,
-                            "col_offset": 80,
-                            "end_col_offset": 83
-                          },
-                          "attr": "l_discount",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 80,
-                          "end_col_offset": 94
-                        },
-                        "lineno": 83,
-                        "end_lineno": 83,
-                        "col_offset": 76,
-                        "end_col_offset": 94
-                      },
-                      "lineno": 83,
-                      "end_lineno": 83,
-                      "col_offset": 53,
-                      "end_col_offset": 95
-                    },
-                    "generators": [
-                      {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 100,
-                          "end_col_offset": 101
-                        },
-                        "iter": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "g",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 83,
-                            "end_lineno": 83,
-                            "col_offset": 105,
-                            "end_col_offset": 106
-                          },
-                          "attr": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 105,
-                          "end_col_offset": 112
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 52,
-                    "end_col_offset": 113
-                  }
-                ],
-                "keywords": [],
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 48,
-                "end_col_offset": 114
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 116,
-                    "end_col_offset": 117
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 116,
-                  "end_col_offset": 121
-                },
-                "attr": "c_acctbal",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 116,
-                "end_col_offset": 131
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 133,
-                    "end_col_offset": 134
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 133,
-                  "end_col_offset": 138
-                },
-                "attr": "n_name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 133,
-                "end_col_offset": 145
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 147,
-                    "end_col_offset": 148
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 147,
-                  "end_col_offset": 152
-                },
-                "attr": "c_address",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 147,
-                "end_col_offset": 162
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 164,
-                    "end_col_offset": 165
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 164,
-                  "end_col_offset": 169
-                },
-                "attr": "c_phone",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 164,
-                "end_col_offset": 177
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 179,
-                    "end_col_offset": 180
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 179,
-                  "end_col_offset": 184
-                },
-                "attr": "c_comment",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 179,
-                "end_col_offset": 194
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
               }
-            ],
-            "keywords": [],
-            "lineno": 83,
-            "end_lineno": 83,
-            "col_offset": 10,
-            "end_col_offset": 195
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 200,
-                "end_col_offset": 201
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 83,
-                  "end_lineno": 83,
-                  "col_offset": 205,
-                  "end_col_offset": 211
-                },
-                "args": [
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_result_groups",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 83,
-                        "end_lineno": 83,
-                        "col_offset": 212,
-                        "end_col_offset": 226
-                      },
-                      "attr": "values",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 83,
-                      "end_lineno": 83,
-                      "col_offset": 212,
-                      "end_col_offset": 233
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 212,
-                    "end_col_offset": 235
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
-                          {
-                            "_type": "arg",
-                            "arg": "g",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 83,
-                            "end_lineno": 83,
-                            "col_offset": 248,
-                            "end_col_offset": 249
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Call",
-                        "func": {
-                          "_type": "Name",
-                          "id": "sum",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 83,
-                          "end_lineno": 83,
-                          "col_offset": 251,
-                          "end_col_offset": 254
-                        },
-                        "args": [
-                          {
-                            "_type": "ListComp",
-                            "elt": {
-                              "_type": "BinOp",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "x",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 83,
-                                    "end_lineno": 83,
-                                    "col_offset": 256,
-                                    "end_col_offset": 257
-                                  },
-                                  "attr": "l",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 83,
-                                  "end_lineno": 83,
-                                  "col_offset": 256,
-                                  "end_col_offset": 259
-                                },
-                                "attr": "l_extendedprice",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 83,
-                                "end_lineno": 83,
-                                "col_offset": 256,
-                                "end_col_offset": 275
-                              },
-                              "op": {
-                                "_type": "Mult"
-                              },
-                              "right": {
-                                "_type": "BinOp",
-                                "left": {
-                                  "_type": "Constant",
-                                  "value": 1,
-                                  "kind": null,
-                                  "lineno": 83,
-                                  "end_lineno": 83,
-                                  "col_offset": 279,
-                                  "end_col_offset": 280
-                                },
-                                "op": {
-                                  "_type": "Sub"
-                                },
-                                "right": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Attribute",
-                                    "value": {
-                                      "_type": "Name",
-                                      "id": "x",
-                                      "ctx": {
-                                        "_type": "Load"
-                                      },
-                                      "lineno": 83,
-                                      "end_lineno": 83,
-                                      "col_offset": 283,
-                                      "end_col_offset": 284
-                                    },
-                                    "attr": "l",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 83,
-                                    "end_lineno": 83,
-                                    "col_offset": 283,
-                                    "end_col_offset": 286
-                                  },
-                                  "attr": "l_discount",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 83,
-                                  "end_lineno": 83,
-                                  "col_offset": 283,
-                                  "end_col_offset": 297
-                                },
-                                "lineno": 83,
-                                "end_lineno": 83,
-                                "col_offset": 279,
-                                "end_col_offset": 297
-                              },
-                              "lineno": 83,
-                              "end_lineno": 83,
-                              "col_offset": 256,
-                              "end_col_offset": 298
-                            },
-                            "generators": [
-                              {
-                                "_type": "comprehension",
-                                "target": {
-                                  "_type": "Name",
-                                  "id": "x",
-                                  "ctx": {
-                                    "_type": "Store"
-                                  },
-                                  "lineno": 83,
-                                  "end_lineno": 83,
-                                  "col_offset": 303,
-                                  "end_col_offset": 304
-                                },
-                                "iter": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "g",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 83,
-                                    "end_lineno": 83,
-                                    "col_offset": 308,
-                                    "end_col_offset": 309
-                                  },
-                                  "attr": "items",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 83,
-                                  "end_lineno": 83,
-                                  "col_offset": 308,
-                                  "end_col_offset": 315
-                                },
-                                "ifs": [],
-                                "is_async": 0
-                              }
-                            ],
-                            "lineno": 83,
-                            "end_lineno": 83,
-                            "col_offset": 255,
-                            "end_col_offset": 316
-                          }
-                        ],
-                        "keywords": [],
-                        "lineno": 83,
-                        "end_lineno": 83,
-                        "col_offset": 251,
-                        "end_col_offset": 317
-                      },
-                      "lineno": 83,
-                      "end_lineno": 83,
-                      "col_offset": 241,
-                      "end_col_offset": 317
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 237,
-                    "end_col_offset": 317
-                  },
-                  {
-                    "_type": "keyword",
-                    "arg": "reverse",
-                    "value": {
-                      "_type": "Constant",
-                      "value": true,
-                      "kind": null,
-                      "lineno": 83,
-                      "end_lineno": 83,
-                      "col_offset": 327,
-                      "end_col_offset": 331
-                    },
-                    "lineno": 83,
-                    "end_lineno": 83,
-                    "col_offset": 319,
-                    "end_col_offset": 331
-                  }
-                ],
-                "lineno": 83,
-                "end_lineno": 83,
-                "col_offset": 205,
-                "end_col_offset": 332
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 83,
-          "end_lineno": 83,
-          "col_offset": 9,
-          "end_col_offset": 333
-        },
-        "lineno": 83,
-        "end_lineno": 83,
-        "end_col_offset": 333
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 84,
-            "end_lineno": 84,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 84,
-                    "end_lineno": 84,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 84,
-                  "end_lineno": 84,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 84,
-                    "end_lineno": 84,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 84,
-                "end_lineno": 84,
-                "col_offset": 7,
-                "end_col_offset": 29
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 273,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 273,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 235
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 84,
-                    "end_lineno": 84,
-                    "col_offset": 34,
-                    "end_col_offset": 36
+              {
+                "kind": "block",
+                "start": 241,
+                "end": 273,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 241,
+                    "end": 257,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 241,
+                        "end": 257,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 241,
+                            "end": 252
+                          },
+                          {
+                            "kind": "type",
+                            "start": 254,
+                            "end": 257,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 254,
+                                "end": 257
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "result",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 84,
-                    "end_lineno": 84,
-                    "col_offset": 40,
-                    "end_col_offset": 46
+                  {
+                    "kind": "expression_statement",
+                    "start": 262,
+                    "end": 273,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 262,
+                        "end": 273,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 262,
+                            "end": 268
+                          },
+                          {
+                            "kind": "type",
+                            "start": 270,
+                            "end": 273,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 270,
+                                "end": 273
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 275,
+        "end": 305,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 275,
+            "end": 305,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 275,
+                "end": 281
+              },
+              {
+                "kind": "list",
+                "start": 284,
+                "end": 305,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 285,
+                    "end": 304,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 285,
+                        "end": 291
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 291,
+                        "end": 304,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 292,
+                            "end": 293
+                          },
+                          {
+                            "kind": "string",
+                            "start": 295,
+                            "end": 303,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 295,
+                                "end": 296
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 296,
+                                "end": 302
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 302,
+                                "end": 303
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 306,
+        "end": 464,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 306,
+            "end": 316,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 307,
+                "end": 316
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 317,
+            "end": 464,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 323,
+                "end": 331
+              },
+              {
+                "kind": "block",
+                "start": 337,
+                "end": 464,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 337,
+                    "end": 351,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 337,
+                        "end": 351,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 337,
+                            "end": 346
+                          },
+                          {
+                            "kind": "type",
+                            "start": 348,
+                            "end": 351,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 348,
+                                "end": 351
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 84,
-              "end_lineno": 84,
-              "col_offset": 6,
-              "end_col_offset": 47
-            }
-          ],
-          "keywords": [],
-          "lineno": 84,
-          "end_lineno": 84,
-          "col_offset": 0,
-          "end_col_offset": 48
-        },
-        "lineno": 84,
-        "end_lineno": 84,
-        "end_col_offset": 48
+                  {
+                    "kind": "expression_statement",
+                    "start": 356,
+                    "end": 367,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 356,
+                        "end": 367,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 356,
+                            "end": 362
+                          },
+                          {
+                            "kind": "type",
+                            "start": 364,
+                            "end": 367,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 364,
+                                "end": 367
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 372,
+                    "end": 388,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 372,
+                        "end": 388,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 372,
+                            "end": 381
+                          },
+                          {
+                            "kind": "type",
+                            "start": 383,
+                            "end": 388,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 383,
+                                "end": 388
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 393,
+                    "end": 409,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 393,
+                        "end": 409,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 393,
+                            "end": 404
+                          },
+                          {
+                            "kind": "type",
+                            "start": 406,
+                            "end": 409,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 406,
+                                "end": 409
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 414,
+                    "end": 428,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 414,
+                        "end": 428,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 414,
+                            "end": 423
+                          },
+                          {
+                            "kind": "type",
+                            "start": 425,
+                            "end": 428,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 425,
+                                "end": 428
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 433,
+                    "end": 445,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 433,
+                        "end": 445,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 433,
+                            "end": 440
+                          },
+                          {
+                            "kind": "type",
+                            "start": 442,
+                            "end": 445,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 442,
+                                "end": 445
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 450,
+                    "end": 464,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 450,
+                        "end": 464,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 450,
+                            "end": 459
+                          },
+                          {
+                            "kind": "type",
+                            "start": 461,
+                            "end": 464,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 461,
+                                "end": 464
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 466,
+        "end": 539,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 466,
+            "end": 539,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 466,
+                "end": 474
+              },
+              {
+                "kind": "list",
+                "start": 477,
+                "end": 539,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 478,
+                    "end": 538,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 478,
+                        "end": 486
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 486,
+                        "end": 538,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 487,
+                            "end": 488
+                          },
+                          {
+                            "kind": "string",
+                            "start": 490,
+                            "end": 497,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 490,
+                                "end": 491
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 491,
+                                "end": 496
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 496,
+                                "end": 497
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "float",
+                            "start": 499,
+                            "end": 504
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 506,
+                            "end": 507
+                          },
+                          {
+                            "kind": "string",
+                            "start": 509,
+                            "end": 517,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 509,
+                                "end": 510
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 510,
+                                "end": 516
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 516,
+                                "end": 517
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 519,
+                            "end": 528,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 519,
+                                "end": 520
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 520,
+                                "end": 527
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 527,
+                                "end": 528
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 530,
+                            "end": 537,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 530,
+                                "end": 531
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 531,
+                                "end": 536
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 536,
+                                "end": 537
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 540,
+        "end": 623,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 540,
+            "end": 550,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 541,
+                "end": 550
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 551,
+            "end": 623,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 557,
+                "end": 562
+              },
+              {
+                "kind": "block",
+                "start": 568,
+                "end": 623,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 568,
+                    "end": 583,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 568,
+                        "end": 583,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 568,
+                            "end": 578
+                          },
+                          {
+                            "kind": "type",
+                            "start": 580,
+                            "end": 583,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 580,
+                                "end": 583
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 588,
+                    "end": 602,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 588,
+                        "end": 602,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 588,
+                            "end": 597
+                          },
+                          {
+                            "kind": "type",
+                            "start": 599,
+                            "end": 602,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 599,
+                                "end": 602
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 607,
+                    "end": 623,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 607,
+                        "end": 623,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 607,
+                            "end": 618
+                          },
+                          {
+                            "kind": "type",
+                            "start": 620,
+                            "end": 623,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 620,
+                                "end": 623
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 625,
+        "end": 694,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 625,
+            "end": 694,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 625,
+                "end": 631
+              },
+              {
+                "kind": "list",
+                "start": 634,
+                "end": 694,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 635,
+                    "end": 663,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 635,
+                        "end": 640
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 640,
+                        "end": 663,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 641,
+                            "end": 645
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 647,
+                            "end": 648
+                          },
+                          {
+                            "kind": "string",
+                            "start": 650,
+                            "end": 662,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 650,
+                                "end": 651
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 651,
+                                "end": 661
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 661,
+                                "end": 662
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 665,
+                    "end": 693,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 665,
+                        "end": 670
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 670,
+                        "end": 693,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 671,
+                            "end": 675
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 677,
+                            "end": 678
+                          },
+                          {
+                            "kind": "string",
+                            "start": 680,
+                            "end": 692,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 680,
+                                "end": 681
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 681,
+                                "end": 691
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 691,
+                                "end": 692
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 695,
+        "end": 812,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 695,
+            "end": 705,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 696,
+                "end": 705
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 706,
+            "end": 812,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 712,
+                "end": 720
+              },
+              {
+                "kind": "block",
+                "start": 726,
+                "end": 812,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 726,
+                    "end": 741,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 726,
+                        "end": 741,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 726,
+                            "end": 736
+                          },
+                          {
+                            "kind": "type",
+                            "start": 738,
+                            "end": 741,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 738,
+                                "end": 741
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 746,
+                    "end": 763,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 746,
+                        "end": 763,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 746,
+                            "end": 758
+                          },
+                          {
+                            "kind": "type",
+                            "start": 760,
+                            "end": 763,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 760,
+                                "end": 763
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 768,
+                    "end": 790,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 768,
+                        "end": 790,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 768,
+                            "end": 783
+                          },
+                          {
+                            "kind": "type",
+                            "start": 785,
+                            "end": 790,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 785,
+                                "end": 790
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 795,
+                    "end": 812,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 795,
+                        "end": 812,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 795,
+                            "end": 805
+                          },
+                          {
+                            "kind": "type",
+                            "start": 807,
+                            "end": 812,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 807,
+                                "end": 812
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 814,
+        "end": 892,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 814,
+            "end": 892,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 814,
+                "end": 822
+              },
+              {
+                "kind": "list",
+                "start": 825,
+                "end": 892,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 826,
+                    "end": 858,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 826,
+                        "end": 834
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 834,
+                        "end": 858,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 835,
+                            "end": 839
+                          },
+                          {
+                            "kind": "string",
+                            "start": 841,
+                            "end": 844,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 841,
+                                "end": 842
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 842,
+                                "end": 843
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 843,
+                                "end": 844
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "float",
+                            "start": 846,
+                            "end": 852
+                          },
+                          {
+                            "kind": "float",
+                            "start": 854,
+                            "end": 857
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 860,
+                    "end": 891,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 860,
+                        "end": 868
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 868,
+                        "end": 891,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 869,
+                            "end": 873
+                          },
+                          {
+                            "kind": "string",
+                            "start": 875,
+                            "end": 878,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 875,
+                                "end": 876
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 876,
+                                "end": 877
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 877,
+                                "end": 878
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "float",
+                            "start": 880,
+                            "end": 885
+                          },
+                          {
+                            "kind": "float",
+                            "start": 887,
+                            "end": 890
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 893,
+        "end": 918,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 893,
+            "end": 918,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 893,
+                "end": 903
+              },
+              {
+                "kind": "string",
+                "start": 906,
+                "end": 918,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 906,
+                    "end": 907
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 907,
+                    "end": 917
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 917,
+                    "end": 918
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 919,
+        "end": 942,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 919,
+            "end": 942,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 919,
+                "end": 927
+              },
+              {
+                "kind": "string",
+                "start": 930,
+                "end": 942,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 930,
+                    "end": 931
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 931,
+                    "end": 941
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 941,
+                    "end": 942
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 943,
+        "end": 1092,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 943,
+            "end": 953,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 944,
+                "end": 953
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 954,
+            "end": 1092,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 960,
+                "end": 964
+              },
+              {
+                "kind": "block",
+                "start": 970,
+                "end": 1092,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 970,
+                    "end": 984,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 970,
+                        "end": 984,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 970,
+                            "end": 979
+                          },
+                          {
+                            "kind": "type",
+                            "start": 981,
+                            "end": 984,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 981,
+                                "end": 984
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 989,
+                    "end": 1000,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 989,
+                        "end": 1000,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 989,
+                            "end": 995
+                          },
+                          {
+                            "kind": "type",
+                            "start": 997,
+                            "end": 1000,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 997,
+                                "end": 1000
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1005,
+                    "end": 1021,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1005,
+                        "end": 1021,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1005,
+                            "end": 1014
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1016,
+                            "end": 1021,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1016,
+                                "end": 1021
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1026,
+                    "end": 1040,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1026,
+                        "end": 1040,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1026,
+                            "end": 1035
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1037,
+                            "end": 1040,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1037,
+                                "end": 1040
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1045,
+                    "end": 1057,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1045,
+                        "end": 1057,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1045,
+                            "end": 1052
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1054,
+                            "end": 1057,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1054,
+                                "end": 1057
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1062,
+                    "end": 1076,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1062,
+                        "end": 1076,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1062,
+                            "end": 1071
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1073,
+                            "end": 1076,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1073,
+                                "end": 1076
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1081,
+                    "end": 1092,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1081,
+                        "end": 1092,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1081,
+                            "end": 1087
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1089,
+                            "end": 1092,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1089,
+                                "end": 1092
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 1094,
+        "end": 1153,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 1094,
+            "end": 1104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1095,
+                "end": 1104
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 1105,
+            "end": 1153,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1111,
+                "end": 1122
+              },
+              {
+                "kind": "block",
+                "start": 1128,
+                "end": 1153,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 1128,
+                    "end": 1137,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1128,
+                        "end": 1137,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1128,
+                            "end": 1131
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1133,
+                            "end": 1137,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1133,
+                                "end": 1137
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1142,
+                    "end": 1153,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1142,
+                        "end": 1153,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1142,
+                            "end": 1147
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1149,
+                            "end": 1153,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1149,
+                                "end": 1153
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 1155,
+        "end": 1226,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 1155,
+            "end": 1165,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1156,
+                "end": 1165
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 1166,
+            "end": 1226,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1172,
+                "end": 1181
+              },
+              {
+                "kind": "block",
+                "start": 1187,
+                "end": 1226,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 1187,
+                    "end": 1193,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1187,
+                        "end": 1193,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1187,
+                            "end": 1188
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1190,
+                            "end": 1193,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1190,
+                                "end": 1193
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1198,
+                    "end": 1204,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1198,
+                        "end": 1204,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1198,
+                            "end": 1199
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1201,
+                            "end": 1204,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1201,
+                                "end": 1204
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1209,
+                    "end": 1215,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1209,
+                        "end": 1215,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1209,
+                            "end": 1210
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1212,
+                            "end": 1215,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1212,
+                                "end": 1215
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1220,
+                    "end": 1226,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1220,
+                        "end": 1226,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1220,
+                            "end": 1221
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1223,
+                            "end": 1226,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1223,
+                                "end": 1226
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 1228,
+        "end": 1247,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 1228,
+            "end": 1247,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1228,
+                "end": 1242
+              },
+              {
+                "kind": "dictionary",
+                "start": 1245,
+                "end": 1247
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 1248,
+        "end": 1889,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 1252,
+            "end": 1253
+          },
+          {
+            "kind": "identifier",
+            "start": 1257,
+            "end": 1265
+          },
+          {
+            "kind": "block",
+            "start": 1271,
+            "end": 1889,
+            "children": [
+              {
+                "kind": "for_statement",
+                "start": 1271,
+                "end": 1889,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 1275,
+                    "end": 1276
+                  },
+                  {
+                    "kind": "list_comprehension",
+                    "start": 1280,
+                    "end": 1329,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 1281,
+                        "end": 1282
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 1283,
+                        "end": 1298,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1287,
+                            "end": 1288
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 1292,
+                            "end": 1298
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 1299,
+                        "end": 1328,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 1302,
+                            "end": 1328,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 1302,
+                                "end": 1313,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1302,
+                                    "end": 1303
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1304,
+                                    "end": 1313
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "attribute",
+                                "start": 1317,
+                                "end": 1328,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1317,
+                                    "end": 1318
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1319,
+                                    "end": 1328
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 1339,
+                    "end": 1889,
+                    "children": [
+                      {
+                        "kind": "for_statement",
+                        "start": 1339,
+                        "end": 1889,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1343,
+                            "end": 1344
+                          },
+                          {
+                            "kind": "list_comprehension",
+                            "start": 1348,
+                            "end": 1401,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1349,
+                                "end": 1350
+                              },
+                              {
+                                "kind": "for_in_clause",
+                                "start": 1351,
+                                "end": 1368,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1355,
+                                    "end": 1356
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1360,
+                                    "end": 1368
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "if_clause",
+                                "start": 1369,
+                                "end": 1400,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 1372,
+                                    "end": 1400,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 1372,
+                                        "end": 1384,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1372,
+                                            "end": 1373
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1374,
+                                            "end": 1384
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 1388,
+                                        "end": 1400,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1388,
+                                            "end": 1389
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1390,
+                                            "end": 1400
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "block",
+                            "start": 1415,
+                            "end": 1889,
+                            "children": [
+                              {
+                                "kind": "for_statement",
+                                "start": 1415,
+                                "end": 1889,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1419,
+                                    "end": 1420
+                                  },
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 1424,
+                                    "end": 1477,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 1425,
+                                        "end": 1426
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 1427,
+                                        "end": 1442,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1431,
+                                            "end": 1432
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1436,
+                                            "end": 1442
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "if_clause",
+                                        "start": 1443,
+                                        "end": 1476,
+                                        "children": [
+                                          {
+                                            "kind": "comparison_operator",
+                                            "start": 1446,
+                                            "end": 1476,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1446,
+                                                "end": 1459,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1446,
+                                                    "end": 1447
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1448,
+                                                    "end": 1459
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1463,
+                                                "end": 1476,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1463,
+                                                    "end": 1464
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1465,
+                                                    "end": 1476
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "block",
+                                    "start": 1495,
+                                    "end": 1889,
+                                    "children": [
+                                      {
+                                        "kind": "if_statement",
+                                        "start": 1495,
+                                        "end": 1889,
+                                        "children": [
+                                          {
+                                            "kind": "boolean_operator",
+                                            "start": 1498,
+                                            "end": 1580,
+                                            "children": [
+                                              {
+                                                "kind": "boolean_operator",
+                                                "start": 1498,
+                                                "end": 1554,
+                                                "children": [
+                                                  {
+                                                    "kind": "comparison_operator",
+                                                    "start": 1498,
+                                                    "end": 1525,
+                                                    "children": [
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 1498,
+                                                        "end": 1511,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 1498,
+                                                            "end": 1499
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 1500,
+                                                            "end": 1511
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1515,
+                                                        "end": 1525
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "comparison_operator",
+                                                    "start": 1530,
+                                                    "end": 1554,
+                                                    "children": [
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 1530,
+                                                        "end": 1543,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 1530,
+                                                            "end": 1531
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 1532,
+                                                            "end": 1543
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1546,
+                                                        "end": 1554
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "comparison_operator",
+                                                "start": 1559,
+                                                "end": 1580,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 1559,
+                                                    "end": 1573,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1559,
+                                                        "end": 1560
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1561,
+                                                        "end": 1573
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "string",
+                                                    "start": 1577,
+                                                    "end": 1580,
+                                                    "children": [
+                                                      {
+                                                        "kind": "string_start",
+                                                        "start": 1577,
+                                                        "end": 1578
+                                                      },
+                                                      {
+                                                        "kind": "string_content",
+                                                        "start": 1578,
+                                                        "end": 1579
+                                                      },
+                                                      {
+                                                        "kind": "string_end",
+                                                        "start": 1579,
+                                                        "end": 1580
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "block",
+                                            "start": 1602,
+                                            "end": 1889,
+                                            "children": [
+                                              {
+                                                "kind": "expression_statement",
+                                                "start": 1602,
+                                                "end": 1830,
+                                                "children": [
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 1602,
+                                                    "end": 1830,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1602,
+                                                        "end": 1604
+                                                      },
+                                                      {
+                                                        "kind": "call",
+                                                        "start": 1607,
+                                                        "end": 1830,
+                                                        "children": [
+                                                          {
+                                                            "kind": "attribute",
+                                                            "start": 1607,
+                                                            "end": 1632,
+                                                            "children": [
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 1607,
+                                                                "end": 1621
+                                                              },
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 1622,
+                                                                "end": 1632
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "argument_list",
+                                                            "start": 1632,
+                                                            "end": 1830,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call",
+                                                                "start": 1633,
+                                                                "end": 1723,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1633,
+                                                                    "end": 1638
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "start": 1638,
+                                                                    "end": 1723,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "list",
+                                                                        "start": 1639,
+                                                                        "end": 1722,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1640,
+                                                                            "end": 1651,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1640,
+                                                                                "end": 1641
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1642,
+                                                                                "end": 1651
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1653,
+                                                                            "end": 1661,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1653,
+                                                                                "end": 1654
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1655,
+                                                                                "end": 1661
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1663,
+                                                                            "end": 1674,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1663,
+                                                                                "end": 1664
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1665,
+                                                                                "end": 1674
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1676,
+                                                                            "end": 1687,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1676,
+                                                                                "end": 1677
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1678,
+                                                                                "end": 1687
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1689,
+                                                                            "end": 1698,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1689,
+                                                                                "end": 1690
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1691,
+                                                                                "end": 1698
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1700,
+                                                                            "end": 1711,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1700,
+                                                                                "end": 1701
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1702,
+                                                                                "end": 1711
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "attribute",
+                                                                            "start": 1713,
+                                                                            "end": 1721,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1713,
+                                                                                "end": 1714
+                                                                              },
+                                                                              {
+                                                                                "kind": "identifier",
+                                                                                "start": 1715,
+                                                                                "end": 1721
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "call",
+                                                                "start": 1725,
+                                                                "end": 1829,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1725,
+                                                                    "end": 1736
+                                                                  },
+                                                                  {
+                                                                    "kind": "argument_list",
+                                                                    "start": 1736,
+                                                                    "end": 1829,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "call",
+                                                                        "start": 1737,
+                                                                        "end": 1824,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "identifier",
+                                                                            "start": 1737,
+                                                                            "end": 1741
+                                                                          },
+                                                                          {
+                                                                            "kind": "argument_list",
+                                                                            "start": 1741,
+                                                                            "end": 1824,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1742,
+                                                                                "end": 1753,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1742,
+                                                                                    "end": 1743
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1744,
+                                                                                    "end": 1753
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1755,
+                                                                                "end": 1763,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1755,
+                                                                                    "end": 1756
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1757,
+                                                                                    "end": 1763
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1765,
+                                                                                "end": 1776,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1765,
+                                                                                    "end": 1766
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1767,
+                                                                                    "end": 1776
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1778,
+                                                                                "end": 1789,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1778,
+                                                                                    "end": 1779
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1780,
+                                                                                    "end": 1789
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1791,
+                                                                                "end": 1800,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1791,
+                                                                                    "end": 1792
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1793,
+                                                                                    "end": 1800
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1802,
+                                                                                "end": 1813,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1802,
+                                                                                    "end": 1803
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1804,
+                                                                                    "end": 1813
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "attribute",
+                                                                                "start": 1815,
+                                                                                "end": 1823,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1815,
+                                                                                    "end": 1816
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "identifier",
+                                                                                    "start": 1817,
+                                                                                    "end": 1823
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "list",
+                                                                        "start": 1826,
+                                                                        "end": 1828
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "expression_statement",
+                                                "start": 1851,
+                                                "end": 1889,
+                                                "children": [
+                                                  {
+                                                    "kind": "call",
+                                                    "start": 1851,
+                                                    "end": 1889,
+                                                    "children": [
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 1851,
+                                                        "end": 1866,
+                                                        "children": [
+                                                          {
+                                                            "kind": "attribute",
+                                                            "start": 1851,
+                                                            "end": 1859,
+                                                            "children": [
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 1851,
+                                                                "end": 1853
+                                                              },
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 1854,
+                                                                "end": 1859
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 1860,
+                                                            "end": 1866
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "argument_list",
+                                                        "start": 1866,
+                                                        "end": 1889,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call",
+                                                            "start": 1867,
+                                                            "end": 1888,
+                                                            "children": [
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 1867,
+                                                                "end": 1876
+                                                              },
+                                                              {
+                                                                "kind": "argument_list",
+                                                                "start": 1876,
+                                                                "end": 1888,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1877,
+                                                                    "end": 1878
+                                                                  },
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1880,
+                                                                    "end": 1881
+                                                                  },
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1883,
+                                                                    "end": 1884
+                                                                  },
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 1886,
+                                                                    "end": 1887
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 1890,
+        "end": 2058,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 1890,
+            "end": 1900,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1891,
+                "end": 1900
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 1901,
+            "end": 2058,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 1907,
+                "end": 1913
+              },
+              {
+                "kind": "block",
+                "start": 1919,
+                "end": 2058,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 1919,
+                    "end": 1933,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1919,
+                        "end": 1933,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1919,
+                            "end": 1928
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1930,
+                            "end": 1933,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1930,
+                                "end": 1933
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1938,
+                    "end": 1949,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1938,
+                        "end": 1949,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1938,
+                            "end": 1944
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1946,
+                            "end": 1949,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1946,
+                                "end": 1949
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1954,
+                    "end": 1966,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1954,
+                        "end": 1966,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1954,
+                            "end": 1961
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1963,
+                            "end": 1966,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1963,
+                                "end": 1966
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1971,
+                    "end": 1987,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1971,
+                        "end": 1987,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1971,
+                            "end": 1980
+                          },
+                          {
+                            "kind": "type",
+                            "start": 1982,
+                            "end": 1987,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 1982,
+                                "end": 1987
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 1992,
+                    "end": 2003,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 1992,
+                        "end": 2003,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 1992,
+                            "end": 1998
+                          },
+                          {
+                            "kind": "type",
+                            "start": 2000,
+                            "end": 2003,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2000,
+                                "end": 2003
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 2008,
+                    "end": 2022,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 2008,
+                        "end": 2022,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2008,
+                            "end": 2017
+                          },
+                          {
+                            "kind": "type",
+                            "start": 2019,
+                            "end": 2022,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2019,
+                                "end": 2022
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 2027,
+                    "end": 2039,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 2027,
+                        "end": 2039,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2027,
+                            "end": 2034
+                          },
+                          {
+                            "kind": "type",
+                            "start": 2036,
+                            "end": 2039,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2036,
+                                "end": 2039
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 2044,
+                    "end": 2058,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 2044,
+                        "end": 2058,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2044,
+                            "end": 2053
+                          },
+                          {
+                            "kind": "type",
+                            "start": 2055,
+                            "end": 2058,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2055,
+                                "end": 2058
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 2060,
+        "end": 2393,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 2060,
+            "end": 2393,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 2060,
+                "end": 2066
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 2069,
+                "end": 2393,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 2070,
+                    "end": 2255,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 2070,
+                        "end": 2076
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 2076,
+                        "end": 2255,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 2077,
+                            "end": 2092,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2077,
+                                "end": 2082,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2077,
+                                    "end": 2078
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2079,
+                                    "end": 2082
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2083,
+                                "end": 2092
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2094,
+                            "end": 2106,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2094,
+                                "end": 2099,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2094,
+                                    "end": 2095
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2096,
+                                    "end": 2099
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2100,
+                                "end": 2106
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 2108,
+                            "end": 2174,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2108,
+                                "end": 2111
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 2111,
+                                "end": 2174,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 2112,
+                                    "end": 2173,
+                                    "children": [
+                                      {
+                                        "kind": "binary_operator",
+                                        "start": 2113,
+                                        "end": 2155,
+                                        "children": [
+                                          {
+                                            "kind": "attribute",
+                                            "start": 2113,
+                                            "end": 2132,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 2113,
+                                                "end": 2116,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 2113,
+                                                    "end": 2114
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 2115,
+                                                    "end": 2116
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 2117,
+                                                "end": 2132
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "parenthesized_expression",
+                                            "start": 2135,
+                                            "end": 2155,
+                                            "children": [
+                                              {
+                                                "kind": "binary_operator",
+                                                "start": 2136,
+                                                "end": 2154,
+                                                "children": [
+                                                  {
+                                                    "kind": "integer",
+                                                    "start": 2136,
+                                                    "end": 2137
+                                                  },
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 2140,
+                                                    "end": 2154,
+                                                    "children": [
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 2140,
+                                                        "end": 2143,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2140,
+                                                            "end": 2141
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2142,
+                                                            "end": 2143
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 2144,
+                                                        "end": 2154
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 2156,
+                                        "end": 2172,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2160,
+                                            "end": 2161
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 2165,
+                                            "end": 2172,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 2165,
+                                                "end": 2166
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 2167,
+                                                "end": 2172
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2176,
+                            "end": 2191,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2176,
+                                "end": 2181,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2176,
+                                    "end": 2177
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2178,
+                                    "end": 2181
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2182,
+                                "end": 2191
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2193,
+                            "end": 2205,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2193,
+                                "end": 2198,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2193,
+                                    "end": 2194
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2195,
+                                    "end": 2198
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2199,
+                                "end": 2205
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2207,
+                            "end": 2222,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2207,
+                                "end": 2212,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2207,
+                                    "end": 2208
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2209,
+                                    "end": 2212
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2213,
+                                "end": 2222
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2224,
+                            "end": 2237,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2224,
+                                "end": 2229,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2224,
+                                    "end": 2225
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2226,
+                                    "end": 2229
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2230,
+                                "end": 2237
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 2239,
+                            "end": 2254,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 2239,
+                                "end": 2244,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2239,
+                                    "end": 2240
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2241,
+                                    "end": 2244
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2245,
+                                "end": 2254
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 2256,
+                    "end": 2392,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 2260,
+                        "end": 2261
+                      },
+                      {
+                        "kind": "call",
+                        "start": 2265,
+                        "end": 2392,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2265,
+                            "end": 2271
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 2271,
+                            "end": 2392,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 2272,
+                                "end": 2295,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 2272,
+                                    "end": 2293,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 2272,
+                                        "end": 2286
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 2287,
+                                        "end": 2293
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 2293,
+                                    "end": 2295
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 2297,
+                                "end": 2377,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2297,
+                                    "end": 2300
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 2301,
+                                    "end": 2377,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 2308,
+                                        "end": 2309,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2308,
+                                            "end": 2309
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 2311,
+                                        "end": 2377,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 2311,
+                                            "end": 2314
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 2314,
+                                            "end": 2377,
+                                            "children": [
+                                              {
+                                                "kind": "list_comprehension",
+                                                "start": 2315,
+                                                "end": 2376,
+                                                "children": [
+                                                  {
+                                                    "kind": "binary_operator",
+                                                    "start": 2316,
+                                                    "end": 2358,
+                                                    "children": [
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 2316,
+                                                        "end": 2335,
+                                                        "children": [
+                                                          {
+                                                            "kind": "attribute",
+                                                            "start": 2316,
+                                                            "end": 2319,
+                                                            "children": [
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 2316,
+                                                                "end": 2317
+                                                              },
+                                                              {
+                                                                "kind": "identifier",
+                                                                "start": 2318,
+                                                                "end": 2319
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2320,
+                                                            "end": 2335
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "parenthesized_expression",
+                                                        "start": 2338,
+                                                        "end": 2358,
+                                                        "children": [
+                                                          {
+                                                            "kind": "binary_operator",
+                                                            "start": 2339,
+                                                            "end": 2357,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer",
+                                                                "start": 2339,
+                                                                "end": 2340
+                                                              },
+                                                              {
+                                                                "kind": "attribute",
+                                                                "start": 2343,
+                                                                "end": 2357,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "attribute",
+                                                                    "start": 2343,
+                                                                    "end": 2346,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "identifier",
+                                                                        "start": 2343,
+                                                                        "end": 2344
+                                                                      },
+                                                                      {
+                                                                        "kind": "identifier",
+                                                                        "start": 2345,
+                                                                        "end": 2346
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "identifier",
+                                                                    "start": 2347,
+                                                                    "end": 2357
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "for_in_clause",
+                                                    "start": 2359,
+                                                    "end": 2375,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 2363,
+                                                        "end": 2364
+                                                      },
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 2368,
+                                                        "end": 2375,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2368,
+                                                            "end": 2369
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 2370,
+                                                            "end": 2375
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 2379,
+                                "end": 2391,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 2379,
+                                    "end": 2386
+                                  },
+                                  {
+                                    "kind": "true",
+                                    "start": 2387,
+                                    "end": 2391
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 2394,
+        "end": 2442,
+        "children": [
+          {
+            "kind": "call",
+            "start": 2394,
+            "end": 2442,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 2394,
+                "end": 2399
+              },
+              {
+                "kind": "argument_list",
+                "start": 2399,
+                "end": 2442,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 2400,
+                    "end": 2441,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 2401,
+                        "end": 2423,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 2401,
+                            "end": 2419,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2401,
+                                "end": 2412
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 2413,
+                                "end": 2419
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 2419,
+                            "end": 2423,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 2420,
+                                "end": 2422
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 2424,
+                        "end": 2440,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 2428,
+                            "end": 2430
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 2434,
+                            "end": 2440
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_multi_sort.py.json
+++ b/tests/json-ast/x/py/group_by_multi_sort.py.json
@@ -1,1416 +1,1553 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 889,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "a",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "b",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "val",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 12,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "x",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 14,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 9,
-              "end_col_offset": 24
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 26,
-                "end_col_offset": 30
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "x",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 36,
-                  "end_col_offset": 37
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 39,
-                  "end_col_offset": 40
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 26,
-              "end_col_offset": 41
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 43,
-                "end_col_offset": 47
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "y",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 48,
-                  "end_col_offset": 51
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 53,
-                  "end_col_offset": 54
-                },
-                {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 56,
-                  "end_col_offset": 57
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 43,
-              "end_col_offset": 58
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 60,
-                "end_col_offset": 64
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "y",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 65,
-                  "end_col_offset": 68
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 70,
-                  "end_col_offset": 71
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 73,
-                  "end_col_offset": 74
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 60,
-              "end_col_offset": 75
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 8,
-          "end_col_offset": 76
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 76
-      },
-      {
-        "_type": "ClassDef",
-        "name": "GKey",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "a",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "b",
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 18,
-            "end_lineno": 18,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 16,
-        "end_lineno": 18,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "ClassDef",
-        "name": "GroupedGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "GKey",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 9,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_grouped_groups",
-            "lineno": 25,
-            "end_lineno": 25,
-            "end_col_offset": 15
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 25,
-          "end_lineno": 25,
-          "col_offset": 18,
-          "end_col_offset": 20
-        },
-        "lineno": 25,
-        "end_lineno": 25,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_grouped_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 9,
-                  "end_col_offset": 24
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 9,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "tuple",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 36,
-                    "end_col_offset": 41
-                  },
-                  "args": [
-                    {
-                      "_type": "List",
-                      "elts": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "i",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 27,
-                            "end_lineno": 27,
-                            "col_offset": 43,
-                            "end_col_offset": 44
-                          },
-                          "attr": "a",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 27,
-                          "end_lineno": 27,
-                          "col_offset": 43,
-                          "end_col_offset": 46
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "i",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 27,
-                            "end_lineno": 27,
-                            "col_offset": 48,
-                            "end_col_offset": 49
-                          },
-                          "attr": "b",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 27,
-                          "end_lineno": 27,
-                          "col_offset": 48,
-                          "end_col_offset": 51
-                        }
-                      ],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 27,
-                      "end_lineno": 27,
-                      "col_offset": 42,
-                      "end_col_offset": 52
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 36,
-                  "end_col_offset": 53
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "GroupedGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 55,
-                    "end_col_offset": 67
-                  },
-                  "args": [
-                    {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "GKey",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 27,
-                        "end_lineno": 27,
-                        "col_offset": 68,
-                        "end_col_offset": 72
-                      },
-                      "args": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "i",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 27,
-                            "end_lineno": 27,
-                            "col_offset": 73,
-                            "end_col_offset": 74
-                          },
-                          "attr": "a",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 27,
-                          "end_lineno": 27,
-                          "col_offset": 73,
-                          "end_col_offset": 76
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "i",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 27,
-                            "end_lineno": 27,
-                            "col_offset": 78,
-                            "end_col_offset": 79
-                          },
-                          "attr": "b",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 27,
-                          "end_lineno": 27,
-                          "col_offset": 78,
-                          "end_col_offset": 81
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 27,
-                      "end_lineno": 27,
-                      "col_offset": 68,
-                      "end_col_offset": 82
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 27,
-                      "end_lineno": 27,
-                      "col_offset": 84,
-                      "end_col_offset": 86
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 55,
-                  "end_col_offset": 87
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 9,
-              "end_col_offset": 88
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 88
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 28,
-                  "end_lineno": 28,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 28,
-                  "end_lineno": 28,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "i",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "items",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 26,
-        "end_lineno": 28,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Grouped",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "a",
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 31,
-            "end_lineno": 31,
-            "col_offset": 4,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 32,
-              "end_lineno": 32,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "b",
-              "lineno": 32,
-              "end_lineno": 32,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 32,
-            "end_lineno": 32,
-            "col_offset": 4,
-            "end_col_offset": 10
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 33,
-              "end_lineno": 33,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 33,
-              "end_lineno": 33,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 33,
-            "end_lineno": 33,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 30,
-        "end_lineno": 33,
-        "end_col_offset": 14
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "grouped",
-            "lineno": 35,
-            "end_lineno": 35,
-            "end_col_offset": 7
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Grouped",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 35,
-              "end_lineno": 35,
-              "col_offset": 11,
-              "end_col_offset": 18
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 35,
-                  "end_lineno": 35,
-                  "col_offset": 19,
-                  "end_col_offset": 24
-                },
-                "attr": "a",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 35,
-                "end_lineno": 35,
-                "col_offset": 19,
-                "end_col_offset": 26
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 269,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 269,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 233
               },
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 28,
-                    "end_col_offset": 29
-                  },
-                  "attr": "key",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 35,
-                  "end_lineno": 35,
-                  "col_offset": 28,
-                  "end_col_offset": 33
-                },
-                "attr": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 35,
-                "end_lineno": 35,
-                "col_offset": 28,
-                "end_col_offset": 35
-              },
-              {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sum",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 35,
-                  "end_lineno": 35,
-                  "col_offset": 37,
-                  "end_col_offset": 40
-                },
-                "args": [
+                "kind": "block",
+                "start": 239,
+                "end": 269,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 35,
-                        "end_lineno": 35,
-                        "col_offset": 42,
-                        "end_col_offset": 43
-                      },
-                      "attr": "val",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 35,
-                      "end_lineno": 35,
-                      "col_offset": 42,
-                      "end_col_offset": 47
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 239,
+                    "end": 245,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 35,
-                          "end_lineno": 35,
-                          "col_offset": 52,
-                          "end_col_offset": 53
-                        },
-                        "iter": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "g",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 35,
-                            "end_lineno": 35,
-                            "col_offset": 57,
-                            "end_col_offset": 58
-                          },
-                          "attr": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 35,
-                          "end_lineno": 35,
-                          "col_offset": 57,
-                          "end_col_offset": 64
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 41,
-                    "end_col_offset": 65
-                  }
-                ],
-                "keywords": [],
-                "lineno": 35,
-                "end_lineno": 35,
-                "col_offset": 37,
-                "end_col_offset": 66
-              }
-            ],
-            "keywords": [],
-            "lineno": 35,
-            "end_lineno": 35,
-            "col_offset": 11,
-            "end_col_offset": 67
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 35,
-                "end_lineno": 35,
-                "col_offset": 72,
-                "end_col_offset": 73
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 35,
-                  "end_lineno": 35,
-                  "col_offset": 77,
-                  "end_col_offset": 83
-                },
-                "args": [
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_grouped_groups",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 35,
-                        "end_lineno": 35,
-                        "col_offset": 84,
-                        "end_col_offset": 99
-                      },
-                      "attr": "values",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 35,
-                      "end_lineno": 35,
-                      "col_offset": 84,
-                      "end_col_offset": 106
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 84,
-                    "end_col_offset": 108
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                        "kind": "assignment",
+                        "start": 239,
+                        "end": 245,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "g",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 35,
-                            "end_lineno": 35,
-                            "col_offset": 121,
-                            "end_col_offset": 122
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Call",
-                        "func": {
-                          "_type": "Name",
-                          "id": "sum",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 239,
+                            "end": 240
                           },
-                          "lineno": 35,
-                          "end_lineno": 35,
-                          "col_offset": 124,
-                          "end_col_offset": 127
-                        },
-                        "args": [
                           {
-                            "_type": "ListComp",
-                            "elt": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "x",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 35,
-                                "end_lineno": 35,
-                                "col_offset": 129,
-                                "end_col_offset": 130
-                              },
-                              "attr": "val",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 35,
-                              "end_lineno": 35,
-                              "col_offset": 129,
-                              "end_col_offset": 134
-                            },
-                            "generators": [
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
                               {
-                                "_type": "comprehension",
-                                "target": {
-                                  "_type": "Name",
-                                  "id": "x",
-                                  "ctx": {
-                                    "_type": "Store"
-                                  },
-                                  "lineno": 35,
-                                  "end_lineno": 35,
-                                  "col_offset": 139,
-                                  "end_col_offset": 140
-                                },
-                                "iter": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "g",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 35,
-                                    "end_lineno": 35,
-                                    "col_offset": 144,
-                                    "end_col_offset": 145
-                                  },
-                                  "attr": "items",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 35,
-                                  "end_lineno": 35,
-                                  "col_offset": 144,
-                                  "end_col_offset": 151
-                                },
-                                "ifs": [],
-                                "is_async": 0
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
                               }
-                            ],
-                            "lineno": 35,
-                            "end_lineno": 35,
-                            "col_offset": 128,
-                            "end_col_offset": 152
+                            ]
                           }
-                        ],
-                        "keywords": [],
-                        "lineno": 35,
-                        "end_lineno": 35,
-                        "col_offset": 124,
-                        "end_col_offset": 153
-                      },
-                      "lineno": 35,
-                      "end_lineno": 35,
-                      "col_offset": 114,
-                      "end_col_offset": 153
-                    },
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 110,
-                    "end_col_offset": 153
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "_type": "keyword",
-                    "arg": "reverse",
-                    "value": {
-                      "_type": "Constant",
-                      "value": true,
-                      "kind": null,
-                      "lineno": 35,
-                      "end_lineno": 35,
-                      "col_offset": 163,
-                      "end_col_offset": 167
-                    },
-                    "lineno": 35,
-                    "end_lineno": 35,
-                    "col_offset": 155,
-                    "end_col_offset": 167
+                    "kind": "expression_statement",
+                    "start": 250,
+                    "end": 256,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 250,
+                        "end": 256,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 250,
+                            "end": 251
+                          },
+                          {
+                            "kind": "type",
+                            "start": 253,
+                            "end": 256,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 253,
+                                "end": 256
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 261,
+                    "end": 269,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 261,
+                        "end": 269,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 261,
+                            "end": 264
+                          },
+                          {
+                            "kind": "type",
+                            "start": 266,
+                            "end": 269,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 266,
+                                "end": 269
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 35,
-                "end_lineno": 35,
-                "col_offset": 77,
-                "end_col_offset": 168
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 35,
-          "end_lineno": 35,
-          "col_offset": 10,
-          "end_col_offset": 169
-        },
-        "lineno": 35,
-        "end_lineno": 35,
-        "end_col_offset": 169
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 36,
-            "end_lineno": 36,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 36,
-                    "end_lineno": 36,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 36,
-                  "end_lineno": 36,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 36,
-                    "end_lineno": 36,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 36,
-                "end_lineno": 36,
-                "col_offset": 7,
-                "end_col_offset": 29
+        "kind": "expression_statement",
+        "start": 271,
+        "end": 347,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 271,
+            "end": 347,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 271,
+                "end": 276
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 36,
-                    "end_lineno": 36,
-                    "col_offset": 34,
-                    "end_col_offset": 36
+              {
+                "kind": "list",
+                "start": 279,
+                "end": 347,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 280,
+                    "end": 295,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 280,
+                        "end": 284
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 284,
+                        "end": 295,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 285,
+                            "end": 288,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 285,
+                                "end": 286
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 286,
+                                "end": 287
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 287,
+                                "end": 288
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 290,
+                            "end": 291
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 293,
+                            "end": 294
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "grouped",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 36,
-                    "end_lineno": 36,
-                    "col_offset": 40,
-                    "end_col_offset": 47
+                  {
+                    "kind": "call",
+                    "start": 297,
+                    "end": 312,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 297,
+                        "end": 301
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 301,
+                        "end": 312,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 302,
+                            "end": 305,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 302,
+                                "end": 303
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 303,
+                                "end": 304
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 304,
+                                "end": 305
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 307,
+                            "end": 308
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 310,
+                            "end": 311
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 36,
-              "end_lineno": 36,
-              "col_offset": 6,
-              "end_col_offset": 48
-            }
-          ],
-          "keywords": [],
-          "lineno": 36,
-          "end_lineno": 36,
-          "col_offset": 0,
-          "end_col_offset": 49
-        },
-        "lineno": 36,
-        "end_lineno": 36,
-        "end_col_offset": 49
+                  {
+                    "kind": "call",
+                    "start": 314,
+                    "end": 329,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 314,
+                        "end": 318
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 318,
+                        "end": 329,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 319,
+                            "end": 322,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 319,
+                                "end": 320
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 320,
+                                "end": 321
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 321,
+                                "end": 322
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 324,
+                            "end": 325
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 327,
+                            "end": 328
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 331,
+                    "end": 346,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 331,
+                        "end": 335
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 335,
+                        "end": 346,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 336,
+                            "end": 339,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 336,
+                                "end": 337
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 337,
+                                "end": 338
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 338,
+                                "end": 339
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 341,
+                            "end": 342
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 344,
+                            "end": 345
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 348,
+        "end": 392,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 348,
+            "end": 358,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 349,
+                "end": 358
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 359,
+            "end": 392,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 365,
+                "end": 369
+              },
+              {
+                "kind": "block",
+                "start": 375,
+                "end": 392,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 375,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 375,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 375,
+                            "end": 376
+                          },
+                          {
+                            "kind": "type",
+                            "start": 378,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 378,
+                                "end": 381
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 386,
+                    "end": 392,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 386,
+                        "end": 392,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 386,
+                            "end": 387
+                          },
+                          {
+                            "kind": "type",
+                            "start": 389,
+                            "end": 392,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 389,
+                                "end": 392
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 394,
+        "end": 454,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 394,
+            "end": 404,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 395,
+                "end": 404
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 405,
+            "end": 454,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 411,
+                "end": 423
+              },
+              {
+                "kind": "block",
+                "start": 429,
+                "end": 454,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 429,
+                    "end": 438,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 429,
+                        "end": 438,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 429,
+                            "end": 432
+                          },
+                          {
+                            "kind": "type",
+                            "start": 434,
+                            "end": 438,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 434,
+                                "end": 438
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 443,
+                    "end": 454,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 443,
+                        "end": 454,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 443,
+                            "end": 448
+                          },
+                          {
+                            "kind": "type",
+                            "start": 450,
+                            "end": 454,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 450,
+                                "end": 454
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 456,
+        "end": 476,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 456,
+            "end": 476,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 456,
+                "end": 471
+              },
+              {
+                "kind": "dictionary",
+                "start": 474,
+                "end": 476
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 477,
+        "end": 604,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 481,
+            "end": 482
+          },
+          {
+            "kind": "identifier",
+            "start": 486,
+            "end": 491
+          },
+          {
+            "kind": "block",
+            "start": 497,
+            "end": 604,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 497,
+                "end": 581,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 497,
+                    "end": 581,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 497,
+                        "end": 499
+                      },
+                      {
+                        "kind": "call",
+                        "start": 502,
+                        "end": 581,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 502,
+                            "end": 528,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 502,
+                                "end": 517
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 518,
+                                "end": 528
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 528,
+                            "end": 581,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 529,
+                                "end": 546,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 529,
+                                    "end": 534
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 534,
+                                    "end": 546,
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "start": 535,
+                                        "end": 545,
+                                        "children": [
+                                          {
+                                            "kind": "attribute",
+                                            "start": 536,
+                                            "end": 539,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 536,
+                                                "end": 537
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 538,
+                                                "end": 539
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 541,
+                                            "end": 544,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 541,
+                                                "end": 542
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 543,
+                                                "end": 544
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 548,
+                                "end": 580,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 548,
+                                    "end": 560
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 560,
+                                    "end": 580,
+                                    "children": [
+                                      {
+                                        "kind": "call",
+                                        "start": 561,
+                                        "end": 575,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 561,
+                                            "end": 565
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 565,
+                                            "end": 575,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 566,
+                                                "end": 569,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 566,
+                                                    "end": 567
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 568,
+                                                    "end": 569
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 571,
+                                                "end": 574,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 571,
+                                                    "end": 572
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 573,
+                                                    "end": 574
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 577,
+                                        "end": 579
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 586,
+                "end": 604,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 586,
+                    "end": 604,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 586,
+                        "end": 601,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 586,
+                            "end": 594,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 586,
+                                "end": 588
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 589,
+                                "end": 594
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 595,
+                            "end": 601
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 601,
+                        "end": 604,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 602,
+                            "end": 603
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 605,
+        "end": 667,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 605,
+            "end": 615,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 606,
+                "end": 615
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 616,
+            "end": 667,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 622,
+                "end": 629
+              },
+              {
+                "kind": "block",
+                "start": 635,
+                "end": 667,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 635,
+                    "end": 641,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 635,
+                        "end": 641,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 635,
+                            "end": 636
+                          },
+                          {
+                            "kind": "type",
+                            "start": 638,
+                            "end": 641,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 638,
+                                "end": 641
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 646,
+                    "end": 652,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 646,
+                        "end": 652,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 646,
+                            "end": 647
+                          },
+                          {
+                            "kind": "type",
+                            "start": 649,
+                            "end": 652,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 649,
+                                "end": 652
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 657,
+                    "end": 667,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 657,
+                        "end": 667,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 657,
+                            "end": 662
+                          },
+                          {
+                            "kind": "type",
+                            "start": 664,
+                            "end": 667,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 664,
+                                "end": 667
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 669,
+        "end": 838,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 669,
+            "end": 838,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 669,
+                "end": 676
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 679,
+                "end": 838,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 680,
+                    "end": 736,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 680,
+                        "end": 687
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 687,
+                        "end": 736,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 688,
+                            "end": 695,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 688,
+                                "end": 693,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 688,
+                                    "end": 689
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 690,
+                                    "end": 693
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 694,
+                                "end": 695
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 697,
+                            "end": 704,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 697,
+                                "end": 702,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 697,
+                                    "end": 698
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 699,
+                                    "end": 702
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 703,
+                                "end": 704
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 706,
+                            "end": 735,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 706,
+                                "end": 709
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 709,
+                                "end": 735,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 710,
+                                    "end": 734,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 711,
+                                        "end": 716,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 711,
+                                            "end": 712
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 713,
+                                            "end": 716
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 717,
+                                        "end": 733,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 721,
+                                            "end": 722
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 726,
+                                            "end": 733,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 726,
+                                                "end": 727
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 728,
+                                                "end": 733
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 737,
+                    "end": 837,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 741,
+                        "end": 742
+                      },
+                      {
+                        "kind": "call",
+                        "start": 746,
+                        "end": 837,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 746,
+                            "end": 752
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 752,
+                            "end": 837,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 753,
+                                "end": 777,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 753,
+                                    "end": 775,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 753,
+                                        "end": 768
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 769,
+                                        "end": 775
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 775,
+                                    "end": 777
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 779,
+                                "end": 822,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 779,
+                                    "end": 782
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 783,
+                                    "end": 822,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 790,
+                                        "end": 791,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 790,
+                                            "end": 791
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 793,
+                                        "end": 822,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 793,
+                                            "end": 796
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 796,
+                                            "end": 822,
+                                            "children": [
+                                              {
+                                                "kind": "list_comprehension",
+                                                "start": 797,
+                                                "end": 821,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 798,
+                                                    "end": 803,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 798,
+                                                        "end": 799
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 800,
+                                                        "end": 803
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "for_in_clause",
+                                                    "start": 804,
+                                                    "end": 820,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 808,
+                                                        "end": 809
+                                                      },
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 813,
+                                                        "end": 820,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 813,
+                                                            "end": 814
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 815,
+                                                            "end": 820
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 824,
+                                "end": 836,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 824,
+                                    "end": 831
+                                  },
+                                  {
+                                    "kind": "true",
+                                    "start": 832,
+                                    "end": 836
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 839,
+        "end": 888,
+        "children": [
+          {
+            "kind": "call",
+            "start": 839,
+            "end": 888,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 839,
+                "end": 844
+              },
+              {
+                "kind": "argument_list",
+                "start": 844,
+                "end": 888,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 845,
+                    "end": 887,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 846,
+                        "end": 868,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 846,
+                            "end": 864,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 846,
+                                "end": 857
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 858,
+                                "end": 864
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 864,
+                            "end": 868,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 865,
+                                "end": 867
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 869,
+                        "end": 886,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 873,
+                            "end": 875
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 879,
+                            "end": 886
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_by_sort.py.json
+++ b/tests/json-ast/x/py/group_by_sort.py.json
@@ -1,1123 +1,1251 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 780,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "cat",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "val",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 11,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 14,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 9,
-              "end_col_offset": 21
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 23,
-                "end_col_offset": 27
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 28,
-                  "end_col_offset": 31
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 33,
-                  "end_col_offset": 34
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 23,
-              "end_col_offset": 35
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 37,
-                "end_col_offset": 41
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 42,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 47,
-                  "end_col_offset": 48
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 37,
-              "end_col_offset": 49
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 51,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 51,
-              "end_col_offset": 63
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 8,
-          "end_col_offset": 64
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 64
-      },
-      {
-        "_type": "ClassDef",
-        "name": "GroupedGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 15,
-        "end_lineno": 17,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_grouped_groups",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 15
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 18,
-          "end_col_offset": 20
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 20
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_grouped_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 9,
-                  "end_col_offset": 24
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 9,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "i",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 21,
-                    "end_lineno": 21,
-                    "col_offset": 36,
-                    "end_col_offset": 37
-                  },
-                  "attr": "cat",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 36,
-                  "end_col_offset": 41
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "GroupedGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 21,
-                    "end_lineno": 21,
-                    "col_offset": 43,
-                    "end_col_offset": 55
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "i",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 21,
-                        "end_lineno": 21,
-                        "col_offset": 56,
-                        "end_col_offset": 57
-                      },
-                      "attr": "cat",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 21,
-                      "end_lineno": 21,
-                      "col_offset": 56,
-                      "end_col_offset": 61
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 21,
-                      "end_lineno": 21,
-                      "col_offset": 63,
-                      "end_col_offset": 65
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 43,
-                  "end_col_offset": 66
-                }
-              ],
-              "keywords": [],
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 9,
-              "end_col_offset": 67
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 67
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "i",
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "items",
-          "lineno": 20,
-          "end_lineno": 20,
-          "col_offset": 9,
-          "end_col_offset": 14
-        },
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Grouped",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "cat",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 12
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 24,
-        "end_lineno": 26,
-        "end_col_offset": 14
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "grouped",
-            "lineno": 28,
-            "end_lineno": 28,
-            "end_col_offset": 7
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Grouped",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 11,
-              "end_col_offset": 18
-            },
-            "args": [
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "g",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 28,
-                  "end_lineno": 28,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                "attr": "key",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 19,
-                "end_col_offset": 24
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 260,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 260,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 233
               },
               {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sum",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 28,
-                  "end_lineno": 28,
-                  "col_offset": 26,
-                  "end_col_offset": 29
-                },
-                "args": [
+                "kind": "block",
+                "start": 239,
+                "end": 260,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 31,
-                        "end_col_offset": 32
-                      },
-                      "attr": "val",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 28,
-                      "end_lineno": 28,
-                      "col_offset": 31,
-                      "end_col_offset": 36
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 239,
+                    "end": 247,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 28,
-                          "end_lineno": 28,
-                          "col_offset": 41,
-                          "end_col_offset": 42
-                        },
-                        "iter": {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "g",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 28,
-                            "end_lineno": 28,
-                            "col_offset": 46,
-                            "end_col_offset": 47
-                          },
-                          "attr": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 28,
-                          "end_lineno": 28,
-                          "col_offset": 46,
-                          "end_col_offset": 53
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 30,
-                    "end_col_offset": 54
-                  }
-                ],
-                "keywords": [],
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 26,
-                "end_col_offset": 55
-              }
-            ],
-            "keywords": [],
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 11,
-            "end_col_offset": 56
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 61,
-                "end_col_offset": 62
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 28,
-                  "end_lineno": 28,
-                  "col_offset": 66,
-                  "end_col_offset": 72
-                },
-                "args": [
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "_grouped_groups",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 73,
-                        "end_col_offset": 88
-                      },
-                      "attr": "values",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 28,
-                      "end_lineno": 28,
-                      "col_offset": 73,
-                      "end_col_offset": 95
-                    },
-                    "args": [],
-                    "keywords": [],
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 73,
-                    "end_col_offset": 97
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                        "kind": "assignment",
+                        "start": 239,
+                        "end": 247,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "g",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 28,
-                            "end_lineno": 28,
-                            "col_offset": 110,
-                            "end_col_offset": 111
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Call",
-                        "func": {
-                          "_type": "Name",
-                          "id": "sum",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 239,
+                            "end": 242
                           },
-                          "lineno": 28,
-                          "end_lineno": 28,
-                          "col_offset": 113,
-                          "end_col_offset": 116
-                        },
-                        "args": [
                           {
-                            "_type": "ListComp",
-                            "elt": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "x",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 28,
-                                "end_lineno": 28,
-                                "col_offset": 118,
-                                "end_col_offset": 119
-                              },
-                              "attr": "val",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 28,
-                              "end_lineno": 28,
-                              "col_offset": 118,
-                              "end_col_offset": 123
-                            },
-                            "generators": [
+                            "kind": "type",
+                            "start": 244,
+                            "end": 247,
+                            "children": [
                               {
-                                "_type": "comprehension",
-                                "target": {
-                                  "_type": "Name",
-                                  "id": "x",
-                                  "ctx": {
-                                    "_type": "Store"
-                                  },
-                                  "lineno": 28,
-                                  "end_lineno": 28,
-                                  "col_offset": 128,
-                                  "end_col_offset": 129
-                                },
-                                "iter": {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "g",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 28,
-                                    "end_lineno": 28,
-                                    "col_offset": 133,
-                                    "end_col_offset": 134
-                                  },
-                                  "attr": "items",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 28,
-                                  "end_lineno": 28,
-                                  "col_offset": 133,
-                                  "end_col_offset": 140
-                                },
-                                "ifs": [],
-                                "is_async": 0
+                                "kind": "identifier",
+                                "start": 244,
+                                "end": 247
                               }
-                            ],
-                            "lineno": 28,
-                            "end_lineno": 28,
-                            "col_offset": 117,
-                            "end_col_offset": 141
+                            ]
                           }
-                        ],
-                        "keywords": [],
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 113,
-                        "end_col_offset": 142
-                      },
-                      "lineno": 28,
-                      "end_lineno": 28,
-                      "col_offset": 103,
-                      "end_col_offset": 142
-                    },
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 99,
-                    "end_col_offset": 142
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "_type": "keyword",
-                    "arg": "reverse",
-                    "value": {
-                      "_type": "Constant",
-                      "value": true,
-                      "kind": null,
-                      "lineno": 28,
-                      "end_lineno": 28,
-                      "col_offset": 152,
-                      "end_col_offset": 156
-                    },
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 144,
-                    "end_col_offset": 156
+                    "kind": "expression_statement",
+                    "start": 252,
+                    "end": 260,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 252,
+                        "end": 260,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 252,
+                            "end": 255
+                          },
+                          {
+                            "kind": "type",
+                            "start": 257,
+                            "end": 260,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 257,
+                                "end": 260
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 66,
-                "end_col_offset": 157
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 10,
-          "end_col_offset": 158
-        },
-        "lineno": 28,
-        "end_lineno": 28,
-        "end_col_offset": 158
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 7,
-                "end_col_offset": 29
+        "kind": "expression_statement",
+        "start": 262,
+        "end": 326,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 262,
+            "end": 326,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 262,
+                "end": 267
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 34,
-                    "end_col_offset": 36
+              {
+                "kind": "list",
+                "start": 270,
+                "end": 326,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 271,
+                    "end": 283,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 271,
+                        "end": 275
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 275,
+                        "end": 283,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 276,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 276,
+                                "end": 277
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 277,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 281,
+                            "end": 282
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "grouped",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 40,
-                    "end_col_offset": 47
+                  {
+                    "kind": "call",
+                    "start": 285,
+                    "end": 297,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 285,
+                        "end": 289
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 289,
+                        "end": 297,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 290,
+                            "end": 293,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 290,
+                                "end": 291
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 291,
+                                "end": 292
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 292,
+                                "end": 293
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 295,
+                            "end": 296
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 6,
-              "end_col_offset": 48
-            }
-          ],
-          "keywords": [],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 0,
-          "end_col_offset": 49
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 49
+                  {
+                    "kind": "call",
+                    "start": 299,
+                    "end": 311,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 299,
+                        "end": 303
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 303,
+                        "end": 311,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 304,
+                            "end": 307,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 304,
+                                "end": 305
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 305,
+                                "end": 306
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 306,
+                                "end": 307
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 309,
+                            "end": 310
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 313,
+                    "end": 325,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 313,
+                        "end": 317
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 317,
+                        "end": 325,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 318,
+                            "end": 321,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 318,
+                                "end": 319
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 319,
+                                "end": 320
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 320,
+                                "end": 321
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 323,
+                            "end": 324
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 327,
+        "end": 386,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 327,
+            "end": 337,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 328,
+                "end": 337
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 338,
+            "end": 386,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 344,
+                "end": 356
+              },
+              {
+                "kind": "block",
+                "start": 362,
+                "end": 386,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 362,
+                    "end": 370,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 362,
+                        "end": 370,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 362,
+                            "end": 365
+                          },
+                          {
+                            "kind": "type",
+                            "start": 367,
+                            "end": 370,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 367,
+                                "end": 370
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 375,
+                    "end": 386,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 375,
+                        "end": 386,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 375,
+                            "end": 380
+                          },
+                          {
+                            "kind": "type",
+                            "start": 382,
+                            "end": 386,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 382,
+                                "end": 386
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 388,
+        "end": 408,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 388,
+            "end": 408,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 388,
+                "end": 403
+              },
+              {
+                "kind": "dictionary",
+                "start": 406,
+                "end": 408
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 409,
+        "end": 515,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 413,
+            "end": 414
+          },
+          {
+            "kind": "identifier",
+            "start": 418,
+            "end": 423
+          },
+          {
+            "kind": "block",
+            "start": 429,
+            "end": 515,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 429,
+                "end": 492,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 429,
+                    "end": 492,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 429,
+                        "end": 431
+                      },
+                      {
+                        "kind": "call",
+                        "start": 434,
+                        "end": 492,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 434,
+                            "end": 460,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 434,
+                                "end": 449
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 450,
+                                "end": 460
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 460,
+                            "end": 492,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 461,
+                                "end": 466,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 461,
+                                    "end": 462
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 463,
+                                    "end": 466
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 468,
+                                "end": 491,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 468,
+                                    "end": 480
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 480,
+                                    "end": 491,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 481,
+                                        "end": 486,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 481,
+                                            "end": 482
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 483,
+                                            "end": 486
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 488,
+                                        "end": 490
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 497,
+                "end": 515,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 497,
+                    "end": 515,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 497,
+                        "end": 512,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 497,
+                            "end": 505,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 497,
+                                "end": 499
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 500,
+                                "end": 505
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 506,
+                            "end": 512
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 512,
+                        "end": 515,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 513,
+                            "end": 514
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 516,
+        "end": 569,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 516,
+            "end": 526,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 517,
+                "end": 526
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 527,
+            "end": 569,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 533,
+                "end": 540
+              },
+              {
+                "kind": "block",
+                "start": 546,
+                "end": 569,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 546,
+                    "end": 554,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 546,
+                        "end": 554,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 546,
+                            "end": 549
+                          },
+                          {
+                            "kind": "type",
+                            "start": 551,
+                            "end": 554,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 551,
+                                "end": 554
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 559,
+                    "end": 569,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 559,
+                        "end": 569,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 559,
+                            "end": 564
+                          },
+                          {
+                            "kind": "type",
+                            "start": 566,
+                            "end": 569,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 566,
+                                "end": 569
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 571,
+        "end": 729,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 571,
+            "end": 729,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 571,
+                "end": 578
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 581,
+                "end": 729,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 582,
+                    "end": 627,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 582,
+                        "end": 589
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 589,
+                        "end": 627,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 590,
+                            "end": 595,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 590,
+                                "end": 591
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 592,
+                                "end": 595
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 597,
+                            "end": 626,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 597,
+                                "end": 600
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 600,
+                                "end": 626,
+                                "children": [
+                                  {
+                                    "kind": "list_comprehension",
+                                    "start": 601,
+                                    "end": 625,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 602,
+                                        "end": 607,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 602,
+                                            "end": 603
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 604,
+                                            "end": 607
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "for_in_clause",
+                                        "start": 608,
+                                        "end": 624,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 612,
+                                            "end": 613
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 617,
+                                            "end": 624,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 617,
+                                                "end": 618
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 619,
+                                                "end": 624
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 628,
+                    "end": 728,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 632,
+                        "end": 633
+                      },
+                      {
+                        "kind": "call",
+                        "start": 637,
+                        "end": 728,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 637,
+                            "end": 643
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 643,
+                            "end": 728,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 644,
+                                "end": 668,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 644,
+                                    "end": 666,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 644,
+                                        "end": 659
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 660,
+                                        "end": 666
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 666,
+                                    "end": 668
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 670,
+                                "end": 713,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 670,
+                                    "end": 673
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 674,
+                                    "end": 713,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 681,
+                                        "end": 682,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 681,
+                                            "end": 682
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 684,
+                                        "end": 713,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 684,
+                                            "end": 687
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 687,
+                                            "end": 713,
+                                            "children": [
+                                              {
+                                                "kind": "list_comprehension",
+                                                "start": 688,
+                                                "end": 712,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 689,
+                                                    "end": 694,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 689,
+                                                        "end": 690
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 691,
+                                                        "end": 694
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "for_in_clause",
+                                                    "start": 695,
+                                                    "end": 711,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 699,
+                                                        "end": 700
+                                                      },
+                                                      {
+                                                        "kind": "attribute",
+                                                        "start": 704,
+                                                        "end": 711,
+                                                        "children": [
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 704,
+                                                            "end": 705
+                                                          },
+                                                          {
+                                                            "kind": "identifier",
+                                                            "start": 706,
+                                                            "end": 711
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 715,
+                                "end": 727,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 715,
+                                    "end": 722
+                                  },
+                                  {
+                                    "kind": "true",
+                                    "start": 723,
+                                    "end": 727
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 730,
+        "end": 779,
+        "children": [
+          {
+            "kind": "call",
+            "start": 730,
+            "end": 779,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 730,
+                "end": 735
+              },
+              {
+                "kind": "argument_list",
+                "start": 735,
+                "end": 779,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 736,
+                    "end": 778,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 737,
+                        "end": 759,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 737,
+                            "end": 755,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 737,
+                                "end": 748
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 749,
+                                "end": 755
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 755,
+                            "end": 759,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 756,
+                                "end": 758
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 760,
+                        "end": 777,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 764,
+                            "end": 766
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 770,
+                            "end": 777
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/group_items_iteration.py.json
+++ b/tests/json-ast/x/py/group_items_iteration.py.json
@@ -1,1126 +1,1226 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 749,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Data",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "tag",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "val",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "data",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 8,
-                "end_col_offset": 12
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 13,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 18,
-                  "end_col_offset": 19
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 8,
-              "end_col_offset": 20
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 22,
-                "end_col_offset": 26
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 27,
-                  "end_col_offset": 30
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 32,
-                  "end_col_offset": 33
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 22,
-              "end_col_offset": 34
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 36,
-                "end_col_offset": 40
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 41,
-                  "end_col_offset": 44
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 46,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 36,
-              "end_col_offset": 48
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 7,
-          "end_col_offset": 49
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 49
-      },
-      {
-        "_type": "ClassDef",
-        "name": "GroupsGroup",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "key",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "list",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "items",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 16,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "_groups_groups",
-            "lineno": 18,
-            "end_lineno": 18,
-            "end_col_offset": 14
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [],
-          "values": [],
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 17,
-          "end_col_offset": 19
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_g",
-                "lineno": 20,
-                "end_lineno": 20,
-                "col_offset": 4,
-                "end_col_offset": 6
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "_groups_groups",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 20,
-                  "end_lineno": 20,
-                  "col_offset": 9,
-                  "end_col_offset": 23
-                },
-                "attr": "setdefault",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 20,
-                "end_lineno": 20,
-                "col_offset": 9,
-                "end_col_offset": 34
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "d",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 20,
-                    "end_lineno": 20,
-                    "col_offset": 35,
-                    "end_col_offset": 36
-                  },
-                  "attr": "tag",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 20,
-                  "end_lineno": 20,
-                  "col_offset": 35,
-                  "end_col_offset": 40
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "GroupsGroup",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 20,
-                    "end_lineno": 20,
-                    "col_offset": 42,
-                    "end_col_offset": 53
-                  },
-                  "args": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "d",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 20,
-                        "end_lineno": 20,
-                        "col_offset": 54,
-                        "end_col_offset": 55
-                      },
-                      "attr": "tag",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 20,
-                      "end_lineno": 20,
-                      "col_offset": 54,
-                      "end_col_offset": 59
-                    },
-                    {
-                      "_type": "List",
-                      "elts": [],
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 20,
-                      "end_lineno": 20,
-                      "col_offset": 61,
-                      "end_col_offset": 63
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 20,
-                  "end_lineno": 20,
-                  "col_offset": 42,
-                  "end_col_offset": 64
-                }
-              ],
-              "keywords": [],
-              "lineno": 20,
-              "end_lineno": 20,
-              "col_offset": 9,
-              "end_col_offset": 65
-            },
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 4,
-            "end_col_offset": 65
-          },
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_g",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 21,
-                    "end_lineno": 21,
-                    "col_offset": 4,
-                    "end_col_offset": 6
-                  },
-                  "attr": "items",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 4,
-                  "end_col_offset": 12
-                },
-                "attr": "append",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 4,
-                "end_col_offset": 19
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "d",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "d",
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "data",
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 13
-        },
-        "lineno": 19,
-        "end_lineno": 21,
-        "end_col_offset": 22
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "Name",
-            "id": "groups",
-            "lineno": 22,
-            "end_lineno": 22,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Name",
-            "id": "g",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 10,
-            "end_col_offset": 11
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 16,
-                "end_col_offset": 17
-              },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "_groups_groups",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 22,
-                    "end_lineno": 22,
-                    "col_offset": 21,
-                    "end_col_offset": 35
-                  },
-                  "attr": "values",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 22,
-                  "end_lineno": 22,
-                  "col_offset": 21,
-                  "end_col_offset": 42
-                },
-                "args": [],
-                "keywords": [],
-                "lineno": 22,
-                "end_lineno": 22,
-                "col_offset": 21,
-                "end_col_offset": 44
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 22,
-          "end_lineno": 22,
-          "col_offset": 9,
-          "end_col_offset": 45
-        },
-        "lineno": 22,
-        "end_lineno": 22,
-        "end_col_offset": 45
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "tmp",
-            "lineno": 23,
-            "end_lineno": 23,
-            "end_col_offset": 3
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 23,
-          "end_lineno": 23,
-          "col_offset": 6,
-          "end_col_offset": 8
-        },
-        "lineno": 23,
-        "end_lineno": 23,
-        "end_col_offset": 8
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "Name",
-                "id": "total",
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 4,
-                "end_col_offset": 9
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
               }
-            ],
-            "value": {
-              "_type": "Constant",
-              "value": 0,
-              "kind": null,
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 12,
-              "end_col_offset": 13
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 13
+            ]
           },
           {
-            "_type": "For",
-            "body": [
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Name",
-                    "id": "total",
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 8,
-                    "end_col_offset": 13
-                  }
-                ],
-                "value": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Name",
-                    "id": "total",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 16,
-                    "end_col_offset": 21
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "x",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 27,
-                      "end_lineno": 27,
-                      "col_offset": 24,
-                      "end_col_offset": 25
-                    },
-                    "attr": "val",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 24,
-                    "end_col_offset": 29
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 16,
-                  "end_col_offset": 29
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 8,
-                "end_col_offset": 29
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
               }
-            ],
-            "target": {
-              "_type": "Name",
-              "id": "x",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            "iter": {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "g",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 13,
-                "end_col_offset": 14
-              },
-              "attr": "items",
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 13,
-              "end_col_offset": 20
-            },
-            "lineno": 26,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 29
-          },
-          {
-            "_type": "Assign",
-            "targets": [
-              {
-                "_type": "Name",
-                "id": "tmp",
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 4,
-                "end_col_offset": 7
-              }
-            ],
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "tmp",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 10,
-                "end_col_offset": 13
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "List",
-                "elts": [
-                  {
-                    "_type": "Dict",
-                    "keys": [
-                      {
-                        "_type": "Constant",
-                        "value": "tag",
-                        "kind": null,
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 18,
-                        "end_col_offset": 23
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": "total",
-                        "kind": null,
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 32,
-                        "end_col_offset": 39
-                      }
-                    ],
-                    "values": [
-                      {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "g",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 28,
-                          "end_lineno": 28,
-                          "col_offset": 25,
-                          "end_col_offset": 26
-                        },
-                        "attr": "key",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 25,
-                        "end_col_offset": 30
-                      },
-                      {
-                        "_type": "Name",
-                        "id": "total",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 28,
-                        "end_lineno": 28,
-                        "col_offset": 41,
-                        "end_col_offset": 46
-                      }
-                    ],
-                    "lineno": 28,
-                    "end_lineno": 28,
-                    "col_offset": 17,
-                    "end_col_offset": 47
-                  }
-                ],
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 16,
-                "end_col_offset": 48
-              },
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 10,
-              "end_col_offset": 48
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 4,
-            "end_col_offset": 48
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "g",
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "groups",
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 24,
-        "end_lineno": 28,
-        "end_col_offset": 48
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 29,
-            "end_lineno": 29,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Name",
-            "id": "r",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 10,
-            "end_col_offset": 11
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "r",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 16,
-                "end_col_offset": 17
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 241,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 241,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 214
               },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 21,
-                  "end_col_offset": 27
-                },
-                "args": [
+              {
+                "kind": "block",
+                "start": 220,
+                "end": 241,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "r",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 29,
-                      "end_col_offset": 30
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 220,
+                    "end": 228,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "r",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 35,
-                          "end_col_offset": 36
-                        },
-                        "iter": {
-                          "_type": "Name",
-                          "id": "tmp",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 40,
-                          "end_col_offset": 43
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 28,
-                    "end_col_offset": 44
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                        "kind": "assignment",
+                        "start": 220,
+                        "end": 228,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "r",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 29,
-                            "end_lineno": 29,
-                            "col_offset": 57,
-                            "end_col_offset": 58
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Subscript",
-                        "value": {
-                          "_type": "Name",
-                          "id": "r",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 220,
+                            "end": 223
                           },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 60,
-                          "end_col_offset": 61
-                        },
-                        "slice": {
-                          "_type": "Constant",
-                          "value": "tag",
-                          "kind": null,
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 62,
-                          "end_col_offset": 67
-                        },
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 60,
-                        "end_col_offset": 68
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 50,
-                      "end_col_offset": 68
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 46,
-                    "end_col_offset": 68
+                          {
+                            "kind": "type",
+                            "start": 225,
+                            "end": 228,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 225,
+                                "end": 228
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 233,
+                    "end": 241,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 233,
+                        "end": 241,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 233,
+                            "end": 236
+                          },
+                          {
+                            "kind": "type",
+                            "start": 238,
+                            "end": 241,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 238,
+                                "end": 241
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 21,
-                "end_col_offset": 69
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 9,
-          "end_col_offset": 70
-        },
-        "lineno": 29,
-        "end_lineno": 29,
-        "end_col_offset": 70
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "result",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 243,
+        "end": 292,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 243,
+            "end": 292,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 243,
+                "end": 247
               },
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 13
+              {
+                "kind": "list",
+                "start": 250,
+                "end": 292,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 251,
+                    "end": 263,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 251,
+                        "end": 255
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 255,
+                        "end": 263,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 256,
+                            "end": 259,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 256,
+                                "end": 257
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 257,
+                                "end": 258
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 258,
+                                "end": 259
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 261,
+                            "end": 262
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 265,
+                    "end": 277,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 265,
+                        "end": 269
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 269,
+                        "end": 277,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 270,
+                            "end": 273,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 270,
+                                "end": 271
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 271,
+                                "end": 272
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 272,
+                                "end": 273
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 275,
+                            "end": 276
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 279,
+                    "end": 291,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 279,
+                        "end": 283
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 283,
+                        "end": 291,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 284,
+                            "end": 287,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 284,
+                                "end": 285
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 285,
+                                "end": 286
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 286,
+                                "end": 287
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 289,
+                            "end": 290
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 293,
+        "end": 351,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 293,
+            "end": 303,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 294,
+                "end": 303
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 304,
+            "end": 351,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 310,
+                "end": 321
+              },
+              {
+                "kind": "block",
+                "start": 327,
+                "end": 351,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 327,
+                    "end": 335,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 327,
+                        "end": 335,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 327,
+                            "end": 330
+                          },
+                          {
+                            "kind": "type",
+                            "start": 332,
+                            "end": 335,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 332,
+                                "end": 335
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 340,
+                    "end": 351,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 340,
+                        "end": 351,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 340,
+                            "end": 345
+                          },
+                          {
+                            "kind": "type",
+                            "start": 347,
+                            "end": 351,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 347,
+                                "end": 351
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 353,
+        "end": 372,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 353,
+            "end": 372,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 353,
+                "end": 367
+              },
+              {
+                "kind": "dictionary",
+                "start": 370,
+                "end": 372
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 373,
+        "end": 476,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 377,
+            "end": 378
+          },
+          {
+            "kind": "identifier",
+            "start": 382,
+            "end": 386
+          },
+          {
+            "kind": "block",
+            "start": 392,
+            "end": 476,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 392,
+                "end": 453,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 392,
+                    "end": 453,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 392,
+                        "end": 394
+                      },
+                      {
+                        "kind": "call",
+                        "start": 397,
+                        "end": 453,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 397,
+                            "end": 422,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 397,
+                                "end": 411
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 412,
+                                "end": 422
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 422,
+                            "end": 453,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 423,
+                                "end": 428,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 423,
+                                    "end": 424
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 425,
+                                    "end": 428
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 430,
+                                "end": 452,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 430,
+                                    "end": 441
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 441,
+                                    "end": 452,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 442,
+                                        "end": 447,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 442,
+                                            "end": 443
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 444,
+                                            "end": 447
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "list",
+                                        "start": 449,
+                                        "end": 451
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 458,
+                "end": 476,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 458,
+                    "end": 476,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 458,
+                        "end": 473,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 458,
+                            "end": 466,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 458,
+                                "end": 460
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 461,
+                                "end": 466
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 467,
+                            "end": 473
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 473,
+                        "end": 476,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 474,
+                            "end": 475
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 477,
+        "end": 522,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 477,
+            "end": 522,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 477,
+                "end": 483
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 486,
+                "end": 522,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 487,
+                    "end": 488
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 489,
+                    "end": 521,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 493,
+                        "end": 494
+                      },
+                      {
+                        "kind": "call",
+                        "start": 498,
+                        "end": 521,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 498,
+                            "end": 519,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 498,
+                                "end": 512
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 513,
+                                "end": 519
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 519,
+                            "end": 521
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 523,
+        "end": 531,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 523,
+            "end": 531,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 523,
+                "end": 526
+              },
+              {
+                "kind": "list",
+                "start": 529,
+                "end": 531
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 532,
+        "end": 663,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 536,
+            "end": 537
+          },
+          {
+            "kind": "identifier",
+            "start": 541,
+            "end": 547
+          },
+          {
+            "kind": "block",
+            "start": 553,
+            "end": 663,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 553,
+                "end": 562,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 553,
+                    "end": 562,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 553,
+                        "end": 558
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 561,
+                        "end": 562
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "for_statement",
+                "start": 567,
+                "end": 614,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 571,
+                    "end": 572
+                  },
+                  {
+                    "kind": "attribute",
+                    "start": 576,
+                    "end": 583,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 576,
+                        "end": 577
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 578,
+                        "end": 583
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 593,
+                    "end": 614,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 593,
+                        "end": 614,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 593,
+                            "end": 614,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 593,
+                                "end": 598
+                              },
+                              {
+                                "kind": "binary_operator",
+                                "start": 601,
+                                "end": 614,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 601,
+                                    "end": 606
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 609,
+                                    "end": 614,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 609,
+                                        "end": 610
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 611,
+                                        "end": 614
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 619,
+                "end": 663,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 619,
+                    "end": 663,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 619,
+                        "end": 622
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 625,
+                        "end": 663,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 625,
+                            "end": 628
+                          },
+                          {
+                            "kind": "list",
+                            "start": 631,
+                            "end": 663,
+                            "children": [
+                              {
+                                "kind": "dictionary",
+                                "start": 632,
+                                "end": 662,
+                                "children": [
+                                  {
+                                    "kind": "pair",
+                                    "start": 633,
+                                    "end": 645,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 633,
+                                        "end": 638,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 633,
+                                            "end": 634
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 634,
+                                            "end": 637
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 637,
+                                            "end": 638
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 640,
+                                        "end": 645,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 640,
+                                            "end": 641
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 642,
+                                            "end": 645
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "pair",
+                                    "start": 647,
+                                    "end": 661,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 647,
+                                        "end": 654,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 647,
+                                            "end": 648
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 648,
+                                            "end": 653
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 653,
+                                            "end": 654
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 656,
+                                        "end": 661
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 664,
+        "end": 734,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 664,
+            "end": 734,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 664,
+                "end": 670
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 673,
+                "end": 734,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 674,
+                    "end": 675
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 676,
+                    "end": 733,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 680,
+                        "end": 681
+                      },
+                      {
+                        "kind": "call",
+                        "start": 685,
+                        "end": 733,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 685,
+                            "end": 691
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 691,
+                            "end": 733,
+                            "children": [
+                              {
+                                "kind": "list_comprehension",
+                                "start": 692,
+                                "end": 708,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 693,
+                                    "end": 694
+                                  },
+                                  {
+                                    "kind": "for_in_clause",
+                                    "start": 695,
+                                    "end": 707,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 699,
+                                        "end": 700
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 704,
+                                        "end": 707
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 710,
+                                "end": 732,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 710,
+                                    "end": 713
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 714,
+                                    "end": 732,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 721,
+                                        "end": 722,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 721,
+                                            "end": 722
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "subscript",
+                                        "start": 724,
+                                        "end": 732,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 724,
+                                            "end": 725
+                                          },
+                                          {
+                                            "kind": "string",
+                                            "start": 726,
+                                            "end": 731,
+                                            "children": [
+                                              {
+                                                "kind": "string_start",
+                                                "start": 726,
+                                                "end": 727
+                                              },
+                                              {
+                                                "kind": "string_content",
+                                                "start": 727,
+                                                "end": 730
+                                              },
+                                              {
+                                                "kind": "string_end",
+                                                "start": 730,
+                                                "end": 731
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 735,
+        "end": 748,
+        "children": [
+          {
+            "kind": "call",
+            "start": 735,
+            "end": 748,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 735,
+                "end": 740
+              },
+              {
+                "kind": "argument_list",
+                "start": 740,
+                "end": 748,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 741,
+                    "end": 747
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/if_else.py.json
+++ b/tests/json-ast/x/py/if_else.py.json
@@ -1,144 +1,183 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 151,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 5,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "If",
-        "body": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 4,
-                "end_col_offset": 9
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "big",
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 15
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 4,
-              "end_col_offset": 16
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 16
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
           }
-        ],
-        "test": {
-          "_type": "Compare",
-          "left": {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 3,
-            "end_col_offset": 4
+        ]
+      },
+      {
+        "kind": "if_statement",
+        "start": 99,
+        "end": 150,
+        "children": [
+          {
+            "kind": "comparison_operator",
+            "start": 102,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 102,
+                "end": 103
+              },
+              {
+                "kind": "integer",
+                "start": 106,
+                "end": 107
+              }
+            ]
           },
-          "ops": [
-            {
-              "_type": "Gt"
-            }
-          ],
-          "comparators": [
-            {
-              "_type": "Constant",
-              "value": 3,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 8
-            }
-          ],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 3,
-          "end_col_offset": 8
-        },
-        "orelse": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "small",
-                  "kind": null,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                }
-              ],
-              "keywords": [],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 4,
-              "end_col_offset": 18
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 4,
-            "end_col_offset": 18
+            "kind": "block",
+            "start": 113,
+            "end": 125,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 113,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 113,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 113,
+                        "end": 118
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 118,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 119,
+                            "end": 124,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 119,
+                                "end": 120
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 120,
+                                "end": 123
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 123,
+                                "end": 124
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "else_clause",
+            "start": 126,
+            "end": 150,
+            "children": [
+              {
+                "kind": "block",
+                "start": 136,
+                "end": 150,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 136,
+                    "end": 150,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 136,
+                        "end": 150,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 136,
+                            "end": 141
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 141,
+                            "end": 150,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 142,
+                                "end": 149,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 142,
+                                    "end": 143
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 143,
+                                    "end": 148
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 148,
+                                    "end": 149
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "lineno": 4,
-        "end_lineno": 7,
-        "end_col_offset": 18
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/if_then_else.py.json
+++ b/tests/json-ast/x/py/if_then_else.py.json
@@ -1,142 +1,167 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 145,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 12,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 6
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 6
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "msg",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 3
-          }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 16,
-              "end_col_offset": 17
-            },
-            "ops": [
-              {
-                "_type": "Gt"
-              }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": 10,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 20,
-                "end_col_offset": 22
-              }
-            ],
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 16,
-            "end_col_offset": 22
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "yes",
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 7,
-            "end_col_offset": 12
-          },
-          "orelse": {
-            "_type": "Constant",
-            "value": "no",
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 28,
-            "end_col_offset": 32
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 7,
-          "end_col_offset": 32
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "msg",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 99,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 99,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 9
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 10
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 10
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 99
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 100,
+        "end": 133,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 100,
+            "end": 133,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 100,
+                "end": 103
+              },
+              {
+                "kind": "parenthesized_expression",
+                "start": 106,
+                "end": 133,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 107,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 107,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 108,
+                            "end": 111
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 111,
+                            "end": 112
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 116,
+                        "end": 122,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 116,
+                            "end": 117
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 120,
+                            "end": 122
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "string",
+                        "start": 128,
+                        "end": 132,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 128,
+                            "end": 129
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 129,
+                            "end": 131
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 131,
+                            "end": 132
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 134,
+        "end": 144,
+        "children": [
+          {
+            "kind": "call",
+            "start": 134,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 134,
+                "end": 139
+              },
+              {
+                "kind": "argument_list",
+                "start": 139,
+                "end": 144,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 140,
+                    "end": 143
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/if_then_else_nested.py.json
+++ b/tests/json-ast/x/py/if_then_else_nested.py.json
@@ -1,192 +1,220 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 172,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 8,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "msg",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 3
-          }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 16,
-              "end_col_offset": 17
-            },
-            "ops": [
-              {
-                "_type": "Gt"
-              }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": 10,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 20,
-                "end_col_offset": 22
-              }
-            ],
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 16,
-            "end_col_offset": 22
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "big",
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 7,
-            "end_col_offset": 12
-          },
-          "orelse": {
-            "_type": "IfExp",
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 41,
-                "end_col_offset": 42
-              },
-              "ops": [
-                {
-                  "_type": "Gt"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 45,
-                  "end_col_offset": 46
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 41,
-              "end_col_offset": 46
-            },
-            "body": {
-              "_type": "Constant",
-              "value": "medium",
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 29,
-              "end_col_offset": 37
-            },
-            "orelse": {
-              "_type": "Constant",
-              "value": "small",
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 52,
-              "end_col_offset": 59
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 29,
-            "end_col_offset": 59
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 7,
-          "end_col_offset": 60
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 61
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "msg",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 9
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 10
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 10
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 160,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 99,
+            "end": 160,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 102
+              },
+              {
+                "kind": "parenthesized_expression",
+                "start": 105,
+                "end": 160,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 106,
+                    "end": 159,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 106,
+                        "end": 111,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 107,
+                            "end": 110
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 110,
+                            "end": 111
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 115,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 115,
+                            "end": 116
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 119,
+                            "end": 121
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 127,
+                        "end": 159,
+                        "children": [
+                          {
+                            "kind": "conditional_expression",
+                            "start": 128,
+                            "end": 158,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 128,
+                                "end": 136,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 128,
+                                    "end": 129
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 129,
+                                    "end": 135
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 135,
+                                    "end": 136
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 140,
+                                "end": 145,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 140,
+                                    "end": 141
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 144,
+                                    "end": 145
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 151,
+                                "end": 158,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 151,
+                                    "end": 152
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 152,
+                                    "end": 157
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 157,
+                                    "end": 158
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 161,
+        "end": 171,
+        "children": [
+          {
+            "kind": "call",
+            "start": 161,
+            "end": 171,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 161,
+                "end": 166
+              },
+              {
+                "kind": "argument_list",
+                "start": 166,
+                "end": 171,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 167,
+                    "end": 170
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/in_operator.py.json
+++ b/tests/json-ast/x/py/in_operator.py.json
@@ -1,242 +1,234 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 181,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 107,
+        "children": [
           {
-            "_type": "Name",
-            "id": "xs",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 7
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 9,
-              "end_col_offset": 10
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 12,
-              "end_col_offset": 13
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 5,
-          "end_col_offset": 14
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+            "kind": "assignment",
+            "start": 93,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 95
+              },
+              {
+                "kind": "list",
+                "start": 98,
+                "end": 107,
+                "children": [
                   {
-                    "_type": "In"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "xs",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 17,
-                    "end_col_offset": 19
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 19
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 25,
-                "end_col_offset": 26
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 26
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 28
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 28
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "UnaryOp",
-                "op": {
-                  "_type": "Not"
-                },
-                "operand": {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Constant",
-                    "value": 5,
-                    "kind": null,
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 21,
-                    "end_col_offset": 22
+                    "kind": "integer",
+                    "start": 99,
+                    "end": 100
                   },
-                  "ops": [
-                    {
-                      "_type": "In"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Name",
-                      "id": "xs",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 5,
-                      "end_lineno": 5,
-                      "col_offset": 26,
-                      "end_col_offset": 28
-                    }
-                  ],
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 21,
-                  "end_col_offset": 28
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 17,
-                "end_col_offset": 28
+                  {
+                    "kind": "integer",
+                    "start": 102,
+                    "end": 103
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 105,
+                    "end": 106
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 108,
+        "end": 136,
+        "children": [
+          {
+            "kind": "call",
+            "start": 108,
+            "end": 136,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 108,
+                "end": 113
               },
-              "body": {
-                "_type": "Constant",
-                "value": "true",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 13
+              {
+                "kind": "argument_list",
+                "start": 113,
+                "end": 136,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 114,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 115,
+                        "end": 134,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 115,
+                            "end": 116
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 120,
+                            "end": 127,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 120,
+                                "end": 121
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 125,
+                                "end": 127
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 133,
+                            "end": 134
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 137,
+        "end": 180,
+        "children": [
+          {
+            "kind": "call",
+            "start": 137,
+            "end": 180,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 137,
+                "end": 142
               },
-              "orelse": {
-                "_type": "Constant",
-                "value": "false",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 34,
-                "end_col_offset": 41
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 41
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 43
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 43
+              {
+                "kind": "argument_list",
+                "start": 142,
+                "end": 180,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 143,
+                    "end": 179,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 144,
+                        "end": 178,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 144,
+                            "end": 150,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 144,
+                                "end": 145
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 145,
+                                "end": 149
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 149,
+                                "end": 150
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "not_operator",
+                            "start": 154,
+                            "end": 165,
+                            "children": [
+                              {
+                                "kind": "comparison_operator",
+                                "start": 158,
+                                "end": 165,
+                                "children": [
+                                  {
+                                    "kind": "integer",
+                                    "start": 158,
+                                    "end": 159
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 163,
+                                    "end": 165
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 171,
+                            "end": 178,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 171,
+                                "end": 172
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 172,
+                                "end": 177
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 177,
+                                "end": 178
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/in_operator_extended.py.json
+++ b/tests/json-ast/x/py/in_operator_extended.py.json
@@ -1,760 +1,714 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 350,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "xs",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 7
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 9,
-              "end_col_offset": 10
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 12,
-              "end_col_offset": 13
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 5,
-          "end_col_offset": 14
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 14
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 107,
+        "children": [
           {
-            "_type": "Name",
-            "id": "ys",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Name",
-            "id": "x",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 6,
-            "end_col_offset": 7
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 13
+            "kind": "assignment",
+            "start": 93,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 95
               },
-              "iter": {
-                "_type": "Name",
-                "id": "xs",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 17,
-                "end_col_offset": 19
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "BinOp",
-                    "left": {
-                      "_type": "Name",
-                      "id": "x",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 23,
-                      "end_col_offset": 24
-                    },
-                    "op": {
-                      "_type": "Mod"
-                    },
-                    "right": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 27,
-                      "end_col_offset": 28
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 23,
-                    "end_col_offset": 28
+              {
+                "kind": "list",
+                "start": 98,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 99,
+                    "end": 100
                   },
-                  "ops": [
-                    {
-                      "_type": "Eq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 32,
-                      "end_col_offset": 33
-                    }
-                  ],
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 23,
-                  "end_col_offset": 33
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 5,
-          "end_col_offset": 34
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 34
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
                   {
-                    "_type": "In"
-                  }
-                ],
-                "comparators": [
+                    "kind": "integer",
+                    "start": 102,
+                    "end": 103
+                  },
                   {
-                    "_type": "Name",
-                    "id": "ys",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 17,
-                    "end_col_offset": 19
+                    "kind": "integer",
+                    "start": 105,
+                    "end": 106
                   }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 19
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 25,
-                "end_col_offset": 26
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 26
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 28
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 28
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
-                  {
-                    "_type": "In"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "ys",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 17,
-                    "end_col_offset": 19
-                  }
-                ],
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 19
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 25,
-                "end_col_offset": 26
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 26
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 28
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 28
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 1
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 5,
-              "end_col_offset": 8
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 10,
-              "end_col_offset": 11
-            }
-          ],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 4,
-          "end_col_offset": 12
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 12
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 8,
-                  "end_lineno": 8,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
-                  {
-                    "_type": "In"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 8,
-                    "end_lineno": 8,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  }
-                ],
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 7,
-              "end_col_offset": 27
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 9,
-                  "end_lineno": 9,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
-                  {
-                    "_type": "In"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 9,
-                    "end_lineno": 9,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  }
-                ],
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 7,
-              "end_col_offset": 27
-            }
-          ],
-          "keywords": [],
-          "lineno": 9,
-          "end_lineno": 9,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 9,
-        "end_lineno": 9,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 108,
+        "end": 142,
+        "children": [
           {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 10,
-            "end_lineno": 10,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 108,
+            "end": 142,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 108,
+                "end": 110
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 113,
+                "end": 142,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 114,
+                    "end": 115
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 116,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 120,
+                        "end": 121
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 125,
+                        "end": 127
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 128,
+                    "end": 141,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 131,
+                        "end": 141,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 131,
+                            "end": 136,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 131,
+                                "end": 132
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 135,
+                                "end": 136
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 140,
+                            "end": 141
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "hello",
-          "kind": null,
-          "lineno": 10,
-          "end_lineno": 10,
-          "col_offset": 4,
-          "end_col_offset": 11
-        },
-        "lineno": 10,
-        "end_lineno": 10,
-        "end_col_offset": 11
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "ell",
-                  "kind": null,
-                  "lineno": 11,
-                  "end_lineno": 11,
-                  "col_offset": 12,
-                  "end_col_offset": 17
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 143,
+        "end": 171,
+        "children": [
+          {
+            "kind": "call",
+            "start": 143,
+            "end": 171,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 143,
+                "end": 148
+              },
+              {
+                "kind": "argument_list",
+                "start": 148,
+                "end": 171,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 149,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 150,
+                        "end": 169,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 150,
+                            "end": 151
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 155,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 155,
+                                "end": 156
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 160,
+                                "end": 162
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 168,
+                            "end": 169
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 11,
-                    "end_lineno": 11,
-                    "col_offset": 21,
-                    "end_col_offset": 22
-                  }
-                ],
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 12,
-                "end_col_offset": 22
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 28,
-                "end_col_offset": 29
-              },
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 31
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "foo",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 12,
-                  "end_col_offset": 17
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 172,
+        "end": 200,
+        "children": [
+          {
+            "kind": "call",
+            "start": 172,
+            "end": 200,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 172,
+                "end": 177
+              },
+              {
+                "kind": "argument_list",
+                "start": 177,
+                "end": 200,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 178,
+                    "end": 199,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 179,
+                        "end": 198,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 179,
+                            "end": 180
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 184,
+                            "end": 191,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 184,
+                                "end": 185
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 189,
+                                "end": 191
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 197,
+                            "end": 198
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 201,
+        "end": 213,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 201,
+            "end": 213,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 201,
+                "end": 202
+              },
+              {
+                "kind": "dictionary",
+                "start": 205,
+                "end": 213,
+                "children": [
                   {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 12,
-                    "end_lineno": 12,
-                    "col_offset": 21,
-                    "end_col_offset": 22
+                    "kind": "pair",
+                    "start": 206,
+                    "end": 212,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 206,
+                        "end": 209,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 206,
+                            "end": 207
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 207,
+                            "end": 208
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 208,
+                            "end": 209
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 211,
+                        "end": 212
+                      }
+                    ]
                   }
-                ],
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 12,
-                "end_col_offset": 22
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 214,
+        "end": 243,
+        "children": [
+          {
+            "kind": "call",
+            "start": 214,
+            "end": 243,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 214,
+                "end": 219
               },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 7,
-                "end_col_offset": 8
+              {
+                "kind": "argument_list",
+                "start": 219,
+                "end": 243,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 220,
+                    "end": 242,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 221,
+                        "end": 241,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 221,
+                            "end": 222
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 226,
+                            "end": 234,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 226,
+                                "end": 229,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 226,
+                                    "end": 227
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 227,
+                                    "end": 228
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 228,
+                                    "end": 229
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 233,
+                                "end": 234
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 240,
+                            "end": 241
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 244,
+        "end": 273,
+        "children": [
+          {
+            "kind": "call",
+            "start": 244,
+            "end": 273,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 244,
+                "end": 249
               },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 28,
-                "end_col_offset": 29
+              {
+                "kind": "argument_list",
+                "start": 249,
+                "end": 273,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 250,
+                    "end": 272,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 251,
+                        "end": 271,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 251,
+                            "end": 252
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 256,
+                            "end": 264,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 256,
+                                "end": 259,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 256,
+                                    "end": 257
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 257,
+                                    "end": 258
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 258,
+                                    "end": 259
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 263,
+                                "end": 264
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 270,
+                            "end": 271
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 274,
+        "end": 285,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 274,
+            "end": 285,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 274,
+                "end": 275
               },
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 31
+              {
+                "kind": "string",
+                "start": 278,
+                "end": 285,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 278,
+                    "end": 279
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 279,
+                    "end": 284
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 284,
+                    "end": 285
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 286,
+        "end": 317,
+        "children": [
+          {
+            "kind": "call",
+            "start": 286,
+            "end": 317,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 286,
+                "end": 291
+              },
+              {
+                "kind": "argument_list",
+                "start": 291,
+                "end": 317,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 292,
+                    "end": 316,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 293,
+                        "end": 315,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 293,
+                            "end": 294
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 298,
+                            "end": 308,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 298,
+                                "end": 303,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 298,
+                                    "end": 299
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 299,
+                                    "end": 302
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 302,
+                                    "end": 303
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 307,
+                                "end": 308
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 314,
+                            "end": 315
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 318,
+        "end": 349,
+        "children": [
+          {
+            "kind": "call",
+            "start": 318,
+            "end": 349,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 318,
+                "end": 323
+              },
+              {
+                "kind": "argument_list",
+                "start": 323,
+                "end": 349,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 324,
+                    "end": 348,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 325,
+                        "end": 347,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 325,
+                            "end": 326
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 330,
+                            "end": 340,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 330,
+                                "end": 335,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 330,
+                                    "end": 331
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 331,
+                                    "end": 334
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 334,
+                                    "end": 335
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 339,
+                                "end": 340
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 346,
+                            "end": 347
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/inner_join.py.json
+++ b/tests/json-ast/x/py/inner_join.py.json
@@ -1,1041 +1,1192 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 811,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 78
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 78
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 125,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 50,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 64,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 50,
-              "end_col_offset": 68
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 70,
-                "end_col_offset": 75
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 103,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 76,
-                  "end_col_offset": 79
-                },
-                {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 81,
-                  "end_col_offset": 82
-                },
-                {
-                  "_type": "Constant",
-                  "value": 80,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 84,
-                  "end_col_offset": 86
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 70,
-              "end_col_offset": 87
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 88
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 88
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 18,
-              "end_col_offset": 21
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerName",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 16
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 21
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 24,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 26,
-            "end_lineno": 26,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "id",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 23,
-                  "end_col_offset": 24
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 23,
-                "end_col_offset": 29
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 31,
-                  "end_col_offset": 32
-                },
-                "attr": "total",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 31,
-                "end_col_offset": 38
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 10,
-            "end_col_offset": 39
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 44,
-                "end_col_offset": 45
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 49,
-                "end_col_offset": 55
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 60,
-                "end_col_offset": 61
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "customers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 65,
-                "end_col_offset": 74
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "o",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 26,
-                      "end_lineno": 26,
-                      "col_offset": 78,
-                      "end_col_offset": 79
-                    },
-                    "attr": "customerId",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 26,
-                    "end_lineno": 26,
-                    "col_offset": 78,
-                    "end_col_offset": 90
-                  },
-                  "ops": [
-                    {
-                      "_type": "Eq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "c",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 26,
-                        "end_lineno": 26,
-                        "col_offset": 94,
-                        "end_col_offset": 95
-                      },
-                      "attr": "id",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 26,
-                      "end_lineno": 26,
-                      "col_offset": 94,
-                      "end_col_offset": 98
-                    }
-                  ],
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 78,
-                  "end_col_offset": 98
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 9,
-          "end_col_offset": 99
-        },
-        "lineno": 26,
-        "end_lineno": 26,
-        "end_col_offset": 99
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Orders with customer info ---",
-              "kind": null,
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 6,
-              "end_col_offset": 41
-            }
-          ],
-          "keywords": [],
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 0,
-          "end_col_offset": 42
-        },
-        "lineno": 27,
-        "end_lineno": 27,
-        "end_col_offset": 42
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Order",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 19,
-                    "end_col_offset": 24
-                  },
-                  "attr": "orderId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 19,
-                  "end_col_offset": 32
-                },
-                {
-                  "_type": "Constant",
-                  "value": "by",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 34,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 40,
-                    "end_col_offset": 45
-                  },
-                  "attr": "customerName",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 40,
-                  "end_col_offset": 58
-                },
-                {
-                  "_type": "Constant",
-                  "value": "- $",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 60,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 67,
-                    "end_col_offset": 72
-                  },
-                  "attr": "total",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 67,
-                  "end_col_offset": 78
-                }
-              ],
-              "keywords": [],
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 4,
-              "end_col_offset": 79
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 4,
-            "end_col_offset": 79
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "entry",
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 28,
-        "end_lineno": 29,
-        "end_col_offset": 79
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 325,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 326,
+        "end": 396,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 326,
+            "end": 336,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 327,
+                "end": 336
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 337,
+            "end": 396,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
+              },
+              {
+                "kind": "block",
+                "start": 354,
+                "end": 396,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 354,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 354,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 354,
+                            "end": 356
+                          },
+                          {
+                            "kind": "type",
+                            "start": 358,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 358,
+                                "end": 361
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 366,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 366,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 366,
+                            "end": 376
+                          },
+                          {
+                            "kind": "type",
+                            "start": 378,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 378,
+                                "end": 381
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 386,
+                    "end": 396,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 386,
+                        "end": 396,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 386,
+                            "end": 391
+                          },
+                          {
+                            "kind": "type",
+                            "start": 393,
+                            "end": 396,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 393,
+                                "end": 396
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 398,
+        "end": 486,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 398,
+            "end": 486,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 398,
+                "end": 404
+              },
+              {
+                "kind": "list",
+                "start": 407,
+                "end": 486,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 408,
+                    "end": 426,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 408,
+                        "end": 413
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 413,
+                        "end": 426,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 414,
+                            "end": 417
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 419,
+                            "end": 420
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 422,
+                            "end": 425
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 428,
+                    "end": 446,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 428,
+                        "end": 433
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 433,
+                        "end": 446,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 434,
+                            "end": 437
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 439,
+                            "end": 440
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 442,
+                            "end": 445
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 448,
+                    "end": 466,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 448,
+                        "end": 453
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 453,
+                        "end": 466,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 454,
+                            "end": 457
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 459,
+                            "end": 460
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 462,
+                            "end": 465
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 468,
+                    "end": 485,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 468,
+                        "end": 473
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 473,
+                        "end": 485,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 474,
+                            "end": 477
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 479,
+                            "end": 480
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 482,
+                            "end": 484
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 487,
+        "end": 565,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 487,
+            "end": 497,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 488,
+                "end": 497
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 498,
+            "end": 565,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 504,
+                "end": 510
+              },
+              {
+                "kind": "block",
+                "start": 516,
+                "end": 565,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 516,
+                    "end": 528,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 516,
+                        "end": 528,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 516,
+                            "end": 523
+                          },
+                          {
+                            "kind": "type",
+                            "start": 525,
+                            "end": 528,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 525,
+                                "end": 528
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 533,
+                    "end": 550,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 533,
+                        "end": 550,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 533,
+                            "end": 545
+                          },
+                          {
+                            "kind": "type",
+                            "start": 547,
+                            "end": 550,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 547,
+                                "end": 550
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 555,
+                    "end": 565,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 555,
+                        "end": 565,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 555,
+                            "end": 560
+                          },
+                          {
+                            "kind": "type",
+                            "start": 562,
+                            "end": 565,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 562,
+                                "end": 565
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 567,
+        "end": 666,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 567,
+            "end": 666,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 567,
+                "end": 573
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 576,
+                "end": 666,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 577,
+                    "end": 606,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 577,
+                        "end": 583
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 583,
+                        "end": 606,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 584,
+                            "end": 588,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 584,
+                                "end": 585
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 586,
+                                "end": 588
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 590,
+                            "end": 596,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 590,
+                                "end": 591
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 592,
+                                "end": 596
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 598,
+                            "end": 605,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 598,
+                                "end": 599
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 600,
+                                "end": 605
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 607,
+                    "end": 622,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 611,
+                        "end": 612
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 616,
+                        "end": 622
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 623,
+                    "end": 641,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 627,
+                        "end": 628
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 632,
+                        "end": 641
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 642,
+                    "end": 665,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 645,
+                        "end": 665,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 645,
+                            "end": 657,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 645,
+                                "end": 646
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 647,
+                                "end": 657
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 661,
+                            "end": 665,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 661,
+                                "end": 662
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 663,
+                                "end": 665
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 667,
+        "end": 709,
+        "children": [
+          {
+            "kind": "call",
+            "start": 667,
+            "end": 709,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 667,
+                "end": 672
+              },
+              {
+                "kind": "argument_list",
+                "start": 672,
+                "end": 709,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 673,
+                    "end": 708,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 673,
+                        "end": 674
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 674,
+                        "end": 707
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 707,
+                        "end": 708
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 710,
+        "end": 810,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 714,
+            "end": 719
+          },
+          {
+            "kind": "identifier",
+            "start": 723,
+            "end": 729
+          },
+          {
+            "kind": "block",
+            "start": 735,
+            "end": 810,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 735,
+                "end": 810,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 735,
+                    "end": 810,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 735,
+                        "end": 740
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 740,
+                        "end": 810,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 741,
+                            "end": 748,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 741,
+                                "end": 742
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 742,
+                                "end": 747
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 747,
+                                "end": 748
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 750,
+                            "end": 763,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 750,
+                                "end": 755
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 756,
+                                "end": 763
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 765,
+                            "end": 769,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 765,
+                                "end": 766
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 766,
+                                "end": 768
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 768,
+                                "end": 769
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 771,
+                            "end": 789,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 771,
+                                "end": 776
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 777,
+                                "end": 789
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 791,
+                            "end": 796,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 791,
+                                "end": 792
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 792,
+                                "end": 795
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 795,
+                                "end": 796
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 798,
+                            "end": 809,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 798,
+                                "end": 803
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 804,
+                                "end": 809
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/join_multi.py.json
+++ b/tests/json-ast/x/py/join_multi.py.json
@@ -1,1047 +1,1211 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 761,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 54
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 16,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 18,
-            "end_lineno": 18,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 10,
-              "end_col_offset": 23
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 25,
-                "end_col_offset": 30
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 36,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 25,
-              "end_col_offset": 38
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 9,
-          "end_col_offset": 39
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 39
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "sku",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 24,
-            "end_lineno": 24,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 24,
-                "end_lineno": 24,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 14,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 19,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 9,
-              "end_col_offset": 23
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 24,
-                "end_lineno": 24,
-                "col_offset": 25,
-                "end_col_offset": 29
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 30,
-                  "end_col_offset": 33
-                },
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 35,
-                  "end_col_offset": 38
-                }
-              ],
-              "keywords": [],
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 25,
-              "end_col_offset": 39
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 8,
-          "end_col_offset": 40
-        },
-        "lineno": 24,
-        "end_lineno": 24,
-        "end_col_offset": 40
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "sku",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 26,
-        "end_lineno": 28,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 30,
-            "end_lineno": 30,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 17,
-                "end_col_offset": 23
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                },
-                "attr": "sku",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 25,
-                "end_col_offset": 30
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 10,
-            "end_col_offset": 31
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 36,
-                "end_col_offset": 37
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 41,
-                "end_col_offset": 47
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 52,
-                "end_col_offset": 53
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "customers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 57,
-                "end_col_offset": 66
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 71,
-                "end_col_offset": 72
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "items",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 76,
-                "end_col_offset": 81
-              },
-              "ifs": [
-                {
-                  "_type": "BoolOp",
-                  "op": {
-                    "_type": "And"
-                  },
-                  "values": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 85,
-                          "end_col_offset": 86
-                        },
-                        "attr": "customerId",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 85,
-                        "end_col_offset": 97
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 30,
-                            "end_lineno": 30,
-                            "col_offset": 101,
-                            "end_col_offset": 102
-                          },
-                          "attr": "id",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 101,
-                          "end_col_offset": 105
-                        }
-                      ],
-                      "lineno": 30,
-                      "end_lineno": 30,
-                      "col_offset": 85,
-                      "end_col_offset": 105
-                    },
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 110,
-                          "end_col_offset": 111
-                        },
-                        "attr": "id",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 110,
-                        "end_col_offset": 114
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "i",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 30,
-                            "end_lineno": 30,
-                            "col_offset": 118,
-                            "end_col_offset": 119
-                          },
-                          "attr": "orderId",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 118,
-                          "end_col_offset": 127
-                        }
-                      ],
-                      "lineno": 30,
-                      "end_lineno": 30,
-                      "col_offset": 110,
-                      "end_col_offset": 127
-                    }
-                  ],
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 85,
-                  "end_col_offset": 127
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 30,
-          "end_lineno": 30,
-          "col_offset": 9,
-          "end_col_offset": 128
-        },
-        "lineno": 30,
-        "end_lineno": 30,
-        "end_col_offset": 128
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 31,
-            "end_lineno": 31,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Multi Join ---",
-              "kind": null,
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 6,
-              "end_col_offset": 26
-            }
-          ],
-          "keywords": [],
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 0,
-          "end_col_offset": 27
-        },
-        "lineno": 31,
-        "end_lineno": 31,
-        "end_col_offset": 27
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 33,
-                "end_lineno": 33,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "r",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": "bought item",
-                  "kind": null,
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 18,
-                  "end_col_offset": 31
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "r",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 33,
-                    "end_lineno": 33,
-                    "col_offset": 33,
-                    "end_col_offset": 34
-                  },
-                  "attr": "sku",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 33,
-                  "end_lineno": 33,
-                  "col_offset": 33,
-                  "end_col_offset": 38
-                }
-              ],
-              "keywords": [],
-              "lineno": 33,
-              "end_lineno": 33,
-              "col_offset": 4,
-              "end_col_offset": 39
-            },
-            "lineno": 33,
-            "end_lineno": 33,
-            "col_offset": 4,
-            "end_col_offset": 39
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "r",
-          "lineno": 32,
-          "end_lineno": 32,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 32,
-          "end_lineno": 32,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 32,
-        "end_lineno": 33,
-        "end_col_offset": 39
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 301,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 301,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 301,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 302,
+        "end": 357,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 302,
+            "end": 312,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 303,
+                "end": 312
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 313,
+            "end": 357,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 319,
+                "end": 324
+              },
+              {
+                "kind": "block",
+                "start": 330,
+                "end": 357,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 330,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 330,
+                        "end": 337,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 330,
+                            "end": 332
+                          },
+                          {
+                            "kind": "type",
+                            "start": 334,
+                            "end": 337,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 334,
+                                "end": 337
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 342,
+                    "end": 357,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 342,
+                        "end": 357,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 342,
+                            "end": 352
+                          },
+                          {
+                            "kind": "type",
+                            "start": 354,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 354,
+                                "end": 357
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 359,
+        "end": 398,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 359,
+            "end": 398,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 359,
+                "end": 365
+              },
+              {
+                "kind": "list",
+                "start": 368,
+                "end": 398,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 369,
+                    "end": 382,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 369,
+                        "end": 374
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 374,
+                        "end": 382,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 375,
+                            "end": 378
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 380,
+                            "end": 381
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 384,
+                    "end": 397,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 384,
+                        "end": 389
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 389,
+                        "end": 397,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 390,
+                            "end": 393
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 395,
+                            "end": 396
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 399,
+        "end": 451,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 399,
+            "end": 409,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 400,
+                "end": 409
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 410,
+            "end": 451,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 416,
+                "end": 420
+              },
+              {
+                "kind": "block",
+                "start": 426,
+                "end": 451,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 426,
+                    "end": 438,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 426,
+                        "end": 438,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 426,
+                            "end": 433
+                          },
+                          {
+                            "kind": "type",
+                            "start": 435,
+                            "end": 438,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 435,
+                                "end": 438
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 443,
+                    "end": 451,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 443,
+                        "end": 451,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 443,
+                            "end": 446
+                          },
+                          {
+                            "kind": "type",
+                            "start": 448,
+                            "end": 451,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 448,
+                                "end": 451
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 453,
+        "end": 493,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 453,
+            "end": 493,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 453,
+                "end": 458
+              },
+              {
+                "kind": "list",
+                "start": 461,
+                "end": 493,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 462,
+                    "end": 476,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 462,
+                        "end": 466
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 466,
+                        "end": 476,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 467,
+                            "end": 470
+                          },
+                          {
+                            "kind": "string",
+                            "start": 472,
+                            "end": 475,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 472,
+                                "end": 473
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 473,
+                                "end": 474
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 474,
+                                "end": 475
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 478,
+                    "end": 492,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 478,
+                        "end": 482
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 482,
+                        "end": 492,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 483,
+                            "end": 486
+                          },
+                          {
+                            "kind": "string",
+                            "start": 488,
+                            "end": 491,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 488,
+                                "end": 489
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 489,
+                                "end": 490
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 490,
+                                "end": 491
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 494,
+        "end": 545,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 494,
+            "end": 504,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 495,
+                "end": 504
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 505,
+            "end": 545,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 511,
+                "end": 517
+              },
+              {
+                "kind": "block",
+                "start": 523,
+                "end": 545,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 523,
+                    "end": 532,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 523,
+                        "end": 532,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 523,
+                            "end": 527
+                          },
+                          {
+                            "kind": "type",
+                            "start": 529,
+                            "end": 532,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 529,
+                                "end": 532
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 537,
+                    "end": 545,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 537,
+                        "end": 545,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 537,
+                            "end": 540
+                          },
+                          {
+                            "kind": "type",
+                            "start": 542,
+                            "end": 545,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 542,
+                                "end": 545
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 547,
+        "end": 675,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 547,
+            "end": 675,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 547,
+                "end": 553
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 556,
+                "end": 675,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 557,
+                    "end": 578,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 557,
+                        "end": 563
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 563,
+                        "end": 578,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 564,
+                            "end": 570,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 564,
+                                "end": 565
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 566,
+                                "end": 570
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 572,
+                            "end": 577,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 572,
+                                "end": 573
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 574,
+                                "end": 577
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 579,
+                    "end": 594,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 583,
+                        "end": 584
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 588,
+                        "end": 594
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 595,
+                    "end": 613,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 599,
+                        "end": 600
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 604,
+                        "end": 613
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 614,
+                    "end": 628,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 618,
+                        "end": 619
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 623,
+                        "end": 628
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 629,
+                    "end": 674,
+                    "children": [
+                      {
+                        "kind": "boolean_operator",
+                        "start": 632,
+                        "end": 674,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 632,
+                            "end": 652,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 632,
+                                "end": 644,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 632,
+                                    "end": 633
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 634,
+                                    "end": 644
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "attribute",
+                                "start": 648,
+                                "end": 652,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 648,
+                                    "end": 649
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 650,
+                                    "end": 652
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 657,
+                            "end": 674,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 657,
+                                "end": 661,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 657,
+                                    "end": 658
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 659,
+                                    "end": 661
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "attribute",
+                                "start": 665,
+                                "end": 674,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 665,
+                                    "end": 666
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 667,
+                                    "end": 674
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 676,
+        "end": 703,
+        "children": [
+          {
+            "kind": "call",
+            "start": 676,
+            "end": 703,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 676,
+                "end": 681
+              },
+              {
+                "kind": "argument_list",
+                "start": 681,
+                "end": 703,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 682,
+                    "end": 702,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 682,
+                        "end": 683
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 683,
+                        "end": 701
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 701,
+                        "end": 702
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 704,
+        "end": 760,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 708,
+            "end": 709
+          },
+          {
+            "kind": "identifier",
+            "start": 713,
+            "end": 719
+          },
+          {
+            "kind": "block",
+            "start": 725,
+            "end": 760,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 725,
+                "end": 760,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 725,
+                    "end": 760,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 725,
+                        "end": 730
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 730,
+                        "end": 760,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 731,
+                            "end": 737,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 731,
+                                "end": 732
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 733,
+                                "end": 737
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 739,
+                            "end": 752,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 739,
+                                "end": 740
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 740,
+                                "end": 751
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 751,
+                                "end": 752
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 754,
+                            "end": 759,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 754,
+                                "end": 755
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 756,
+                                "end": 759
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/json_builtin.py.json
+++ b/tests/json-ast/x/py/json_builtin.py.json
@@ -1,162 +1,210 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 158,
+    "children": [
       {
-        "_type": "Import",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "import_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 1
+            "kind": "dotted_name",
+            "start": 100,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 100,
+                "end": 104
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 13,
-              "end_col_offset": 16
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 20
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "json",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "attr": "dumps",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 16
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 126,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 106,
+            "end": 126,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 107
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "m",
-                  "ctx": {
-                    "_type": "Load"
+              {
+                "kind": "dictionary",
+                "start": 110,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 111,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 111,
+                        "end": 114,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 111,
+                            "end": 112
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 112,
+                            "end": 113
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 113,
+                            "end": 114
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 116,
+                        "end": 117
+                      }
+                    ]
                   },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                }
-              ],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "indent",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 27,
-                    "end_col_offset": 28
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 20,
-                  "end_col_offset": 28
-                }
-              ],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 30
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 30
+                  {
+                    "kind": "pair",
+                    "start": 119,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 119,
+                        "end": 122,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 119,
+                            "end": 120
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 120,
+                            "end": 121
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 121,
+                            "end": 122
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 124,
+                        "end": 125
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 127,
+        "end": 157,
+        "children": [
+          {
+            "kind": "call",
+            "start": 127,
+            "end": 157,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 127,
+                "end": 132
+              },
+              {
+                "kind": "argument_list",
+                "start": 132,
+                "end": 157,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 133,
+                    "end": 156,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 133,
+                        "end": 143,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 133,
+                            "end": 137
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 138,
+                            "end": 143
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 143,
+                        "end": 156,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 144,
+                            "end": 145
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 147,
+                            "end": 155,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 147,
+                                "end": 153
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 154,
+                                "end": 155
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/left_join.py.json
+++ b/tests/json-ast/x/py/left_join.py.json
@@ -1,964 +1,1109 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 749,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 54
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 80,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 46
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 47
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 48
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 48
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 14,
-              "end_col_offset": 17
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customer",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 17
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 24,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 26,
-            "end_lineno": 26,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "id",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 23,
-                "end_col_offset": 24
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 26,
-                  "end_lineno": 26,
-                  "col_offset": 26,
-                  "end_col_offset": 27
-                },
-                "attr": "total",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 26,
-                "end_col_offset": 33
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 10,
-            "end_col_offset": 34
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 39,
-                "end_col_offset": 40
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 44,
-                "end_col_offset": 50
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 55,
-                "end_col_offset": 56
-              },
-              "iter": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "Or"
-                },
-                "values": [
-                  {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "c",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 26,
-                      "end_lineno": 26,
-                      "col_offset": 61,
-                      "end_col_offset": 62
-                    },
-                    "generators": [
-                      {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "c",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 26,
-                          "end_lineno": 26,
-                          "col_offset": 67,
-                          "end_col_offset": 68
-                        },
-                        "iter": {
-                          "_type": "Name",
-                          "id": "customers",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 26,
-                          "end_lineno": 26,
-                          "col_offset": 72,
-                          "end_col_offset": 81
-                        },
-                        "ifs": [
-                          {
-                            "_type": "Compare",
-                            "left": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 26,
-                                "end_lineno": 26,
-                                "col_offset": 85,
-                                "end_col_offset": 86
-                              },
-                              "attr": "customerId",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 26,
-                              "end_lineno": 26,
-                              "col_offset": 85,
-                              "end_col_offset": 97
-                            },
-                            "ops": [
-                              {
-                                "_type": "Eq"
-                              }
-                            ],
-                            "comparators": [
-                              {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "c",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 26,
-                                  "end_lineno": 26,
-                                  "col_offset": 101,
-                                  "end_col_offset": 102
-                                },
-                                "attr": "id",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 26,
-                                "end_lineno": 26,
-                                "col_offset": 101,
-                                "end_col_offset": 105
-                              }
-                            ],
-                            "lineno": 26,
-                            "end_lineno": 26,
-                            "col_offset": 85,
-                            "end_col_offset": 105
-                          }
-                        ],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 26,
-                    "end_lineno": 26,
-                    "col_offset": 60,
-                    "end_col_offset": 106
-                  },
-                  {
-                    "_type": "List",
-                    "elts": [
-                      {
-                        "_type": "Constant",
-                        "value": null,
-                        "kind": null,
-                        "lineno": 26,
-                        "end_lineno": 26,
-                        "col_offset": 111,
-                        "end_col_offset": 115
-                      }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 26,
-                    "end_lineno": 26,
-                    "col_offset": 110,
-                    "end_col_offset": 116
-                  }
-                ],
-                "lineno": 26,
-                "end_lineno": 26,
-                "col_offset": 60,
-                "end_col_offset": 116
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 9,
-          "end_col_offset": 117
-        },
-        "lineno": 26,
-        "end_lineno": 26,
-        "end_col_offset": 117
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Left Join ---",
-              "kind": null,
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 6,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 0,
-          "end_col_offset": 26
-        },
-        "lineno": 27,
-        "end_lineno": 27,
-        "end_col_offset": 26
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Order",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 19,
-                    "end_col_offset": 24
-                  },
-                  "attr": "orderId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 19,
-                  "end_col_offset": 32
-                },
-                {
-                  "_type": "Constant",
-                  "value": "customer",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 34,
-                  "end_col_offset": 44
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 46,
-                    "end_col_offset": 51
-                  },
-                  "attr": "customer",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 46,
-                  "end_col_offset": 60
-                },
-                {
-                  "_type": "Constant",
-                  "value": "total",
-                  "kind": null,
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 62,
-                  "end_col_offset": 69
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 71,
-                    "end_col_offset": 76
-                  },
-                  "attr": "total",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 71,
-                  "end_col_offset": 82
-                }
-              ],
-              "keywords": [],
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 4,
-              "end_col_offset": 83
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 4,
-            "end_col_offset": 83
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "entry",
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 28,
-        "end_lineno": 29,
-        "end_col_offset": 83
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 301,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 301,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 301,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 302,
+        "end": 372,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 302,
+            "end": 312,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 303,
+                "end": 312
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 313,
+            "end": 372,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 319,
+                "end": 324
+              },
+              {
+                "kind": "block",
+                "start": 330,
+                "end": 372,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 330,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 330,
+                        "end": 337,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 330,
+                            "end": 332
+                          },
+                          {
+                            "kind": "type",
+                            "start": 334,
+                            "end": 337,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 334,
+                                "end": 337
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 342,
+                    "end": 357,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 342,
+                        "end": 357,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 342,
+                            "end": 352
+                          },
+                          {
+                            "kind": "type",
+                            "start": 354,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 354,
+                                "end": 357
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 362,
+                    "end": 372,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 362,
+                        "end": 372,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 362,
+                            "end": 367
+                          },
+                          {
+                            "kind": "type",
+                            "start": 369,
+                            "end": 372,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 369,
+                                "end": 372
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 374,
+        "end": 422,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 374,
+            "end": 422,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 374,
+                "end": 380
+              },
+              {
+                "kind": "list",
+                "start": 383,
+                "end": 422,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 384,
+                    "end": 402,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 384,
+                        "end": 389
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 389,
+                        "end": 402,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 390,
+                            "end": 393
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 395,
+                            "end": 396
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 398,
+                            "end": 401
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 404,
+                    "end": 421,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 404,
+                        "end": 409
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 409,
+                        "end": 421,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 410,
+                            "end": 413
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 415,
+                            "end": 416
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 418,
+                            "end": 420
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 423,
+        "end": 497,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 423,
+            "end": 433,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 424,
+                "end": 433
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 434,
+            "end": 497,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 440,
+                "end": 446
+              },
+              {
+                "kind": "block",
+                "start": 452,
+                "end": 497,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 452,
+                    "end": 464,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 452,
+                        "end": 464,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 452,
+                            "end": 459
+                          },
+                          {
+                            "kind": "type",
+                            "start": 461,
+                            "end": 464,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 461,
+                                "end": 464
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 469,
+                    "end": 482,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 469,
+                        "end": 482,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 469,
+                            "end": 477
+                          },
+                          {
+                            "kind": "type",
+                            "start": 479,
+                            "end": 482,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 479,
+                                "end": 482
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 487,
+                    "end": 497,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 487,
+                        "end": 497,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 487,
+                            "end": 492
+                          },
+                          {
+                            "kind": "type",
+                            "start": 494,
+                            "end": 497,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 494,
+                                "end": 497
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 499,
+        "end": 616,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 499,
+            "end": 616,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 499,
+                "end": 505
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 508,
+                "end": 616,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 509,
+                    "end": 533,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 509,
+                        "end": 515
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 515,
+                        "end": 533,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 516,
+                            "end": 520,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 516,
+                                "end": 517
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 518,
+                                "end": 520
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 522,
+                            "end": 523
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 525,
+                            "end": 532,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 525,
+                                "end": 526
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 527,
+                                "end": 532
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 534,
+                    "end": 549,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 538,
+                        "end": 539
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 543,
+                        "end": 549
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 550,
+                    "end": 615,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 554,
+                        "end": 555
+                      },
+                      {
+                        "kind": "boolean_operator",
+                        "start": 559,
+                        "end": 615,
+                        "children": [
+                          {
+                            "kind": "list_comprehension",
+                            "start": 559,
+                            "end": 605,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 560,
+                                "end": 561
+                              },
+                              {
+                                "kind": "for_in_clause",
+                                "start": 562,
+                                "end": 580,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 566,
+                                    "end": 567
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 571,
+                                    "end": 580
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "if_clause",
+                                "start": 581,
+                                "end": 604,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 584,
+                                    "end": 604,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 584,
+                                        "end": 596,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 584,
+                                            "end": 585
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 586,
+                                            "end": 596
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 600,
+                                        "end": 604,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 600,
+                                            "end": 601
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 602,
+                                            "end": 604
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "list",
+                            "start": 609,
+                            "end": 615,
+                            "children": [
+                              {
+                                "kind": "none",
+                                "start": 610,
+                                "end": 614
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 617,
+        "end": 643,
+        "children": [
+          {
+            "kind": "call",
+            "start": 617,
+            "end": 643,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 617,
+                "end": 622
+              },
+              {
+                "kind": "argument_list",
+                "start": 622,
+                "end": 643,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 623,
+                    "end": 642,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 623,
+                        "end": 624
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 624,
+                        "end": 641
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 641,
+                        "end": 642
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 644,
+        "end": 748,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 648,
+            "end": 653
+          },
+          {
+            "kind": "identifier",
+            "start": 657,
+            "end": 663
+          },
+          {
+            "kind": "block",
+            "start": 669,
+            "end": 748,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 669,
+                "end": 748,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 669,
+                    "end": 748,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 669,
+                        "end": 674
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 674,
+                        "end": 748,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 675,
+                            "end": 682,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 675,
+                                "end": 676
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 676,
+                                "end": 681
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 681,
+                                "end": 682
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 684,
+                            "end": 697,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 684,
+                                "end": 689
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 690,
+                                "end": 697
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 699,
+                            "end": 709,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 699,
+                                "end": 700
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 700,
+                                "end": 708
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 708,
+                                "end": 709
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 711,
+                            "end": 725,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 711,
+                                "end": 716
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 717,
+                                "end": 725
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 727,
+                            "end": 734,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 727,
+                                "end": 728
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 728,
+                                "end": 733
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 733,
+                                "end": 734
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 736,
+                            "end": 747,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 736,
+                                "end": 741
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 742,
+                                "end": 747
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/left_join_multi.py.json
+++ b/tests/json-ast/x/py/left_join_multi.py.json
@@ -1,1114 +1,1239 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 789,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 54
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 54
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 16,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 18,
-            "end_lineno": 18,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 10,
-              "end_col_offset": 23
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 25,
-                "end_col_offset": 30
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 36,
-                  "end_col_offset": 37
-                }
-              ],
-              "keywords": [],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 25,
-              "end_col_offset": 38
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 9,
-          "end_col_offset": 39
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 39
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "sku",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 19,
-            "end_lineno": 19,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 20,
-        "end_lineno": 22,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 24,
-            "end_lineno": 24,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 24,
-                "end_lineno": 24,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 14,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 24,
-                  "end_lineno": 24,
-                  "col_offset": 19,
-                  "end_col_offset": 22
-                }
-              ],
-              "keywords": [],
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 9,
-              "end_col_offset": 23
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 8,
-          "end_col_offset": 24
-        },
-        "lineno": 24,
-        "end_lineno": 24,
-        "end_col_offset": 24
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "item",
-              "lineno": 29,
-              "end_lineno": 29,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 29,
-            "end_lineno": 29,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 26,
-        "end_lineno": 29,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 31,
-            "end_lineno": 31,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 31,
-              "end_lineno": 31,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "id",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 23,
-                  "end_col_offset": 24
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 23,
-                "end_col_offset": 29
-              },
-              {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 31,
-                "end_col_offset": 32
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 31,
-            "end_lineno": 31,
-            "col_offset": 10,
-            "end_col_offset": 33
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 38,
-                "end_col_offset": 39
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 43,
-                "end_col_offset": 49
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 54,
-                "end_col_offset": 55
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "customers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 59,
-                "end_col_offset": 68
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 73,
-                "end_col_offset": 74
-              },
-              "iter": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "Or"
-                },
-                "values": [
-                  {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "i",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 79,
-                      "end_col_offset": 80
-                    },
-                    "generators": [
-                      {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "i",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 31,
-                          "end_lineno": 31,
-                          "col_offset": 85,
-                          "end_col_offset": 86
-                        },
-                        "iter": {
-                          "_type": "Name",
-                          "id": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 31,
-                          "end_lineno": 31,
-                          "col_offset": 90,
-                          "end_col_offset": 95
-                        },
-                        "ifs": [
-                          {
-                            "_type": "Compare",
-                            "left": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 31,
-                                "end_lineno": 31,
-                                "col_offset": 99,
-                                "end_col_offset": 100
-                              },
-                              "attr": "id",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 31,
-                              "end_lineno": 31,
-                              "col_offset": 99,
-                              "end_col_offset": 103
-                            },
-                            "ops": [
-                              {
-                                "_type": "Eq"
-                              }
-                            ],
-                            "comparators": [
-                              {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "i",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 31,
-                                  "end_lineno": 31,
-                                  "col_offset": 107,
-                                  "end_col_offset": 108
-                                },
-                                "attr": "orderId",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 31,
-                                "end_lineno": 31,
-                                "col_offset": 107,
-                                "end_col_offset": 116
-                              }
-                            ],
-                            "lineno": 31,
-                            "end_lineno": 31,
-                            "col_offset": 99,
-                            "end_col_offset": 116
-                          }
-                        ],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 78,
-                    "end_col_offset": 117
-                  },
-                  {
-                    "_type": "List",
-                    "elts": [
-                      {
-                        "_type": "Constant",
-                        "value": null,
-                        "kind": null,
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 122,
-                        "end_col_offset": 126
-                      }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 121,
-                    "end_col_offset": 127
-                  }
-                ],
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 78,
-                "end_col_offset": 127
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "o",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 131,
-                      "end_col_offset": 132
-                    },
-                    "attr": "customerId",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 131,
-                    "end_col_offset": 143
-                  },
-                  "ops": [
-                    {
-                      "_type": "Eq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "c",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 147,
-                        "end_col_offset": 148
-                      },
-                      "attr": "id",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 147,
-                      "end_col_offset": 151
-                    }
-                  ],
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 131,
-                  "end_col_offset": 151
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 31,
-          "end_lineno": 31,
-          "col_offset": 9,
-          "end_col_offset": 152
-        },
-        "lineno": 31,
-        "end_lineno": 31,
-        "end_col_offset": 152
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 32,
-            "end_lineno": 32,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Left Join Multi ---",
-              "kind": null,
-              "lineno": 32,
-              "end_lineno": 32,
-              "col_offset": 6,
-              "end_col_offset": 31
-            }
-          ],
-          "keywords": [],
-          "lineno": 32,
-          "end_lineno": 32,
-          "col_offset": 0,
-          "end_col_offset": 32
-        },
-        "lineno": 32,
-        "end_lineno": 32,
-        "end_col_offset": 32
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 34,
-                "end_lineno": 34,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "r",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 34,
-                    "end_lineno": 34,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "orderId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 10,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "r",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 34,
-                    "end_lineno": 34,
-                    "col_offset": 21,
-                    "end_col_offset": 22
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 21,
-                  "end_col_offset": 27
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "r",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 34,
-                    "end_lineno": 34,
-                    "col_offset": 29,
-                    "end_col_offset": 30
-                  },
-                  "attr": "item",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 29,
-                  "end_col_offset": 35
-                }
-              ],
-              "keywords": [],
-              "lineno": 34,
-              "end_lineno": 34,
-              "col_offset": 4,
-              "end_col_offset": 36
-            },
-            "lineno": 34,
-            "end_lineno": 34,
-            "col_offset": 4,
-            "end_col_offset": 36
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "r",
-          "lineno": 33,
-          "end_lineno": 33,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 33,
-          "end_lineno": 33,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 33,
-        "end_lineno": 34,
-        "end_col_offset": 36
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 301,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 301,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 301,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 302,
+        "end": 357,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 302,
+            "end": 312,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 303,
+                "end": 312
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 313,
+            "end": 357,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 319,
+                "end": 324
+              },
+              {
+                "kind": "block",
+                "start": 330,
+                "end": 357,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 330,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 330,
+                        "end": 337,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 330,
+                            "end": 332
+                          },
+                          {
+                            "kind": "type",
+                            "start": 334,
+                            "end": 337,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 334,
+                                "end": 337
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 342,
+                    "end": 357,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 342,
+                        "end": 357,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 342,
+                            "end": 352
+                          },
+                          {
+                            "kind": "type",
+                            "start": 354,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 354,
+                                "end": 357
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 359,
+        "end": 398,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 359,
+            "end": 398,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 359,
+                "end": 365
+              },
+              {
+                "kind": "list",
+                "start": 368,
+                "end": 398,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 369,
+                    "end": 382,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 369,
+                        "end": 374
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 374,
+                        "end": 382,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 375,
+                            "end": 378
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 380,
+                            "end": 381
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 384,
+                    "end": 397,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 384,
+                        "end": 389
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 389,
+                        "end": 397,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 390,
+                            "end": 393
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 395,
+                            "end": 396
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 399,
+        "end": 451,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 399,
+            "end": 409,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 400,
+                "end": 409
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 410,
+            "end": 451,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 416,
+                "end": 420
+              },
+              {
+                "kind": "block",
+                "start": 426,
+                "end": 451,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 426,
+                    "end": 438,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 426,
+                        "end": 438,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 426,
+                            "end": 433
+                          },
+                          {
+                            "kind": "type",
+                            "start": 435,
+                            "end": 438,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 435,
+                                "end": 438
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 443,
+                    "end": 451,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 443,
+                        "end": 451,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 443,
+                            "end": 446
+                          },
+                          {
+                            "kind": "type",
+                            "start": 448,
+                            "end": 451,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 448,
+                                "end": 451
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 453,
+        "end": 477,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 453,
+            "end": 477,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 453,
+                "end": 458
+              },
+              {
+                "kind": "list",
+                "start": 461,
+                "end": 477,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 462,
+                    "end": 476,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 462,
+                        "end": 466
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 466,
+                        "end": 476,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 467,
+                            "end": 470
+                          },
+                          {
+                            "kind": "string",
+                            "start": 472,
+                            "end": 475,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 472,
+                                "end": 473
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 473,
+                                "end": 474
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 474,
+                                "end": 475
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 478,
+        "end": 547,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 478,
+            "end": 488,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 479,
+                "end": 488
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 489,
+            "end": 547,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 495,
+                "end": 501
+              },
+              {
+                "kind": "block",
+                "start": 507,
+                "end": 547,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 507,
+                    "end": 519,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 507,
+                        "end": 519,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 507,
+                            "end": 514
+                          },
+                          {
+                            "kind": "type",
+                            "start": 516,
+                            "end": 519,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 516,
+                                "end": 519
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 524,
+                    "end": 533,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 524,
+                        "end": 533,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 524,
+                            "end": 528
+                          },
+                          {
+                            "kind": "type",
+                            "start": 530,
+                            "end": 533,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 530,
+                                "end": 533
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 538,
+                    "end": 547,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 538,
+                        "end": 547,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 538,
+                            "end": 542
+                          },
+                          {
+                            "kind": "type",
+                            "start": 544,
+                            "end": 547,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 544,
+                                "end": 547
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 549,
+        "end": 701,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 549,
+            "end": 701,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 549,
+                "end": 555
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 558,
+                "end": 701,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 559,
+                    "end": 582,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 559,
+                        "end": 565
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 565,
+                        "end": 582,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 566,
+                            "end": 570,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 566,
+                                "end": 567
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 568,
+                                "end": 570
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 572,
+                            "end": 578,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 572,
+                                "end": 573
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 574,
+                                "end": 578
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 580,
+                            "end": 581
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 583,
+                    "end": 598,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 587,
+                        "end": 588
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 592,
+                        "end": 598
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 599,
+                    "end": 617,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 603,
+                        "end": 604
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 608,
+                        "end": 617
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 618,
+                    "end": 676,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 622,
+                        "end": 623
+                      },
+                      {
+                        "kind": "boolean_operator",
+                        "start": 627,
+                        "end": 676,
+                        "children": [
+                          {
+                            "kind": "list_comprehension",
+                            "start": 627,
+                            "end": 666,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 628,
+                                "end": 629
+                              },
+                              {
+                                "kind": "for_in_clause",
+                                "start": 630,
+                                "end": 644,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 634,
+                                    "end": 635
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 639,
+                                    "end": 644
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "if_clause",
+                                "start": 645,
+                                "end": 665,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 648,
+                                    "end": 665,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 648,
+                                        "end": 652,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 648,
+                                            "end": 649
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 650,
+                                            "end": 652
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 656,
+                                        "end": 665,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 656,
+                                            "end": 657
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 658,
+                                            "end": 665
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "list",
+                            "start": 670,
+                            "end": 676,
+                            "children": [
+                              {
+                                "kind": "none",
+                                "start": 671,
+                                "end": 675
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 677,
+                    "end": 700,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 680,
+                        "end": 700,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 680,
+                            "end": 692,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 680,
+                                "end": 681
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 682,
+                                "end": 692
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 696,
+                            "end": 700,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 696,
+                                "end": 697
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 698,
+                                "end": 700
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 702,
+        "end": 734,
+        "children": [
+          {
+            "kind": "call",
+            "start": 702,
+            "end": 734,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 702,
+                "end": 707
+              },
+              {
+                "kind": "argument_list",
+                "start": 707,
+                "end": 734,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 708,
+                    "end": 733,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 708,
+                        "end": 709
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 709,
+                        "end": 732
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 732,
+                        "end": 733
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 735,
+        "end": 788,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 739,
+            "end": 740
+          },
+          {
+            "kind": "identifier",
+            "start": 744,
+            "end": 750
+          },
+          {
+            "kind": "block",
+            "start": 756,
+            "end": 788,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 756,
+                "end": 788,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 756,
+                    "end": 788,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 756,
+                        "end": 761
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 761,
+                        "end": 788,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 762,
+                            "end": 771,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 762,
+                                "end": 763
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 764,
+                                "end": 771
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 773,
+                            "end": 779,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 773,
+                                "end": 774
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 775,
+                                "end": 779
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 781,
+                            "end": 787,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 781,
+                                "end": 782
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 783,
+                                "end": 787
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/len_builtin.py.json
+++ b/tests/json-ast/x/py/len_builtin.py.json
@@ -1,93 +1,85 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 115,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 114,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 114,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "List",
-                  "elts": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 12
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 14,
-                      "end_col_offset": 15
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 3,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 17,
-                      "end_col_offset": 18
-                    }
-                  ],
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 19
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 21
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "list",
+                            "start": 103,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 104,
+                                "end": 105
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 107,
+                                "end": 108
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 110,
+                                "end": 111
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/len_map.py.json
+++ b/tests/json-ast/x/py/len_map.py.json
@@ -1,101 +1,138 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 122,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 121,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 121,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "Dict",
-                  "keys": [
-                    {
-                      "_type": "Constant",
-                      "value": "a",
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 14
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "b",
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 19,
-                      "end_col_offset": 22
-                    }
-                  ],
-                  "values": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 16,
-                      "end_col_offset": 17
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 24,
-                      "end_col_offset": 25
-                    }
-                  ],
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 27
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 28
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 28
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 120,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 120,
+                        "children": [
+                          {
+                            "kind": "dictionary",
+                            "start": 103,
+                            "end": 119,
+                            "children": [
+                              {
+                                "kind": "pair",
+                                "start": 104,
+                                "end": 110,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 104,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 104,
+                                        "end": 105
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 105,
+                                        "end": 106
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 106,
+                                        "end": 107
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 109,
+                                    "end": 110
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "pair",
+                                "start": 112,
+                                "end": 118,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 112,
+                                    "end": 115,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 112,
+                                        "end": 113
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 113,
+                                        "end": 114
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 114,
+                                        "end": 115
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 117,
+                                    "end": 118
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/len_string.py.json
+++ b/tests/json-ast/x/py/len_string.py.json
@@ -1,63 +1,85 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 113,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 112,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 112,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "mochi",
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 18
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 19
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 19
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 111,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 111,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 103,
+                            "end": 110,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 103,
+                                "end": 104
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 104,
+                                "end": 109
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 109,
+                                "end": 110
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/let_and_print.py.json
+++ b/tests/json-ast/x/py/let_and_print.py.json
@@ -1,113 +1,109 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 120,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "a",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 10,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 6
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 6
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "b",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 20,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 6
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 6
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "a",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 99,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 99,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "op": {
-                "_type": "Add"
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 99
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 100,
+        "end": 106,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 100,
+            "end": 106,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 100,
+                "end": 101
               },
-              "right": {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 10,
-                "end_col_offset": 11
+              {
+                "kind": "integer",
+                "start": 104,
+                "end": 106
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 107,
+        "end": 119,
+        "children": [
+          {
+            "kind": "call",
+            "start": 107,
+            "end": 119,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 107,
+                "end": 112
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 12
+              {
+                "kind": "argument_list",
+                "start": 112,
+                "end": 119,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 113,
+                    "end": 118,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 113,
+                        "end": 114
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 117,
+                        "end": 118
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/list_assign.py.json
+++ b/tests/json-ast/x/py/list_assign.py.json
@@ -1,150 +1,133 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 134,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 13
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 13
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Subscript",
-            "value": {
-              "_type": "Name",
-              "id": "nums",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 0,
-              "end_col_offset": 4
-            },
-            "slice": {
-              "_type": "Constant",
-              "value": 1,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 5,
-              "end_col_offset": 6
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 3,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 10,
-          "end_col_offset": 11
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "nums",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 10
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 106,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 106,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 11,
-                "end_col_offset": 12
+              {
+                "kind": "list",
+                "start": 100,
+                "end": 106,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 107,
+        "end": 118,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 107,
+            "end": 118,
+            "children": [
+              {
+                "kind": "subscript",
+                "start": 107,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 107,
+                    "end": 111
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 112,
+                    "end": 113
+                  }
+                ]
               },
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "integer",
+                "start": 117,
+                "end": 118
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 119,
+        "end": 133,
+        "children": [
+          {
+            "kind": "call",
+            "start": 119,
+            "end": 133,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 119,
+                "end": 124
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 13
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 14
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 14
+              {
+                "kind": "argument_list",
+                "start": 124,
+                "end": 133,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 125,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 125,
+                        "end": 129
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 130,
+                        "end": 131
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/list_index.py.json
+++ b/tests/json-ast/x/py/list_index.py.json
@@ -1,117 +1,102 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 124,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "xs",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 10,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": 20,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 30,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 16
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 5,
-          "end_col_offset": 17
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 17
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "xs",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 8
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 110,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 110,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 95
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 9,
-                "end_col_offset": 10
+              {
+                "kind": "list",
+                "start": 98,
+                "end": 110,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 99,
+                    "end": 101
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 103,
+                    "end": 105
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 107,
+                    "end": 109
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 111,
+        "end": 123,
+        "children": [
+          {
+            "kind": "call",
+            "start": 111,
+            "end": 123,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 111,
+                "end": 116
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 12
+              {
+                "kind": "argument_list",
+                "start": 116,
+                "end": 123,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 117,
+                    "end": 122,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 117,
+                        "end": 119
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 120,
+                        "end": 121
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/list_nested_assign.py.json
+++ b/tests/json-ast/x/py/list_nested_assign.py.json
@@ -1,230 +1,181 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 156,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "matrix",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "List",
-              "elts": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                }
-              ],
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            {
-              "_type": "List",
-              "elts": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                }
-              ],
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 24
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 25
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 25
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Subscript",
-            "value": {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "matrix",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 0,
-                "end_col_offset": 6
-              },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 0,
-              "end_col_offset": 9
-            },
-            "slice": {
-              "_type": "Constant",
-              "value": 0,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 5,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 15,
-          "end_col_offset": 16
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Subscript",
-                "value": {
-                  "_type": "Name",
-                  "id": "matrix",
-                  "ctx": {
-                    "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 118,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 118,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 99
+              },
+              {
+                "kind": "list",
+                "start": 102,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "list",
+                    "start": 103,
+                    "end": 109,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 104,
+                        "end": 105
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 107,
+                        "end": 108
+                      }
+                    ]
                   },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 6,
-                  "end_col_offset": 12
-                },
-                "slice": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 13,
-                  "end_col_offset": 14
-                },
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 15
+                  {
+                    "kind": "list",
+                    "start": 111,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 112,
+                        "end": 113
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 115,
+                        "end": 116
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 119,
+        "end": 135,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 119,
+            "end": 135,
+            "children": [
+              {
+                "kind": "subscript",
+                "start": 119,
+                "end": 131,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 119,
+                    "end": 128,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 119,
+                        "end": 125
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 126,
+                        "end": 127
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 129,
+                    "end": 130
+                  }
+                ]
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 16,
-                "end_col_offset": 17
+              {
+                "kind": "integer",
+                "start": 134,
+                "end": 135
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 136,
+        "end": 155,
+        "children": [
+          {
+            "kind": "call",
+            "start": 136,
+            "end": 155,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 136,
+                "end": 141
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 18
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 19
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 19
+              {
+                "kind": "argument_list",
+                "start": 141,
+                "end": 155,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 142,
+                    "end": 154,
+                    "children": [
+                      {
+                        "kind": "subscript",
+                        "start": 142,
+                        "end": 151,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 142,
+                            "end": 148
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 149,
+                            "end": 150
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 152,
+                        "end": 153
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/list_set_ops.py.json
+++ b/tests/json-ast/x/py/list_set_ops.py.json
@@ -1,591 +1,446 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 253,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "list",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 10
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 131,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 131,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "set",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 14
-                    },
-                    "args": [
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 131,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 130,
+                    "children": [
                       {
-                        "_type": "List",
-                        "elts": [
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 103
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 103,
+                        "end": 130,
+                        "children": [
                           {
-                            "_type": "Constant",
-                            "value": 1,
-                            "kind": null,
-                            "lineno": 3,
-                            "end_lineno": 3,
-                            "col_offset": 16,
-                            "end_col_offset": 17
-                          },
-                          {
-                            "_type": "Constant",
-                            "value": 2,
-                            "kind": null,
-                            "lineno": 3,
-                            "end_lineno": 3,
-                            "col_offset": 19,
-                            "end_col_offset": 20
+                            "kind": "binary_operator",
+                            "start": 104,
+                            "end": 129,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 104,
+                                "end": 115,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 104,
+                                    "end": 107
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 107,
+                                    "end": 115,
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "start": 108,
+                                        "end": 114,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 109,
+                                            "end": 110
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 112,
+                                            "end": 113
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call",
+                                "start": 118,
+                                "end": 129,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 118,
+                                    "end": 121
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 121,
+                                    "end": 129,
+                                    "children": [
+                                      {
+                                        "kind": "list",
+                                        "start": 122,
+                                        "end": 128,
+                                        "children": [
+                                          {
+                                            "kind": "integer",
+                                            "start": 123,
+                                            "end": 124
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 126,
+                                            "end": 127
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
-                        ],
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 3,
-                        "end_lineno": 3,
-                        "col_offset": 15,
-                        "end_col_offset": 21
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 11,
-                    "end_col_offset": 22
-                  },
-                  "op": {
-                    "_type": "BitOr"
-                  },
-                  "right": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "set",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 25,
-                      "end_col_offset": 28
-                    },
-                    "args": [
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 132,
+        "end": 177,
+        "children": [
+          {
+            "kind": "call",
+            "start": 132,
+            "end": 177,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 132,
+                "end": 137
+              },
+              {
+                "kind": "argument_list",
+                "start": 137,
+                "end": 177,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 138,
+                    "end": 176,
+                    "children": [
                       {
-                        "_type": "List",
-                        "elts": [
+                        "kind": "identifier",
+                        "start": 139,
+                        "end": 140
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 141,
+                        "end": 159,
+                        "children": [
                           {
-                            "_type": "Constant",
-                            "value": 2,
-                            "kind": null,
-                            "lineno": 3,
-                            "end_lineno": 3,
-                            "col_offset": 30,
-                            "end_col_offset": 31
+                            "kind": "identifier",
+                            "start": 145,
+                            "end": 146
                           },
                           {
-                            "_type": "Constant",
-                            "value": 3,
-                            "kind": null,
-                            "lineno": 3,
-                            "end_lineno": 3,
-                            "col_offset": 33,
-                            "end_col_offset": 34
+                            "kind": "list",
+                            "start": 150,
+                            "end": 159,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 151,
+                                "end": 152
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 154,
+                                "end": 155
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 157,
+                                "end": 158
+                              }
+                            ]
                           }
-                        ],
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 3,
-                        "end_lineno": 3,
-                        "col_offset": 29,
-                        "end_col_offset": 35
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 160,
+                        "end": 175,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 163,
+                            "end": 175,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 163,
+                                "end": 164
+                              },
+                              {
+                                "kind": "list",
+                                "start": 172,
+                                "end": 175,
+                                "children": [
+                                  {
+                                    "kind": "integer",
+                                    "start": 173,
+                                    "end": 174
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 25,
-                    "end_col_offset": 36
-                  },
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 11,
-                  "end_col_offset": 36
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 37
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 38
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 38
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
+        "kind": "expression_statement",
+        "start": 178,
+        "end": 222,
+        "children": [
+          {
+            "kind": "call",
+            "start": 178,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 178,
+                "end": 183
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  },
-                  "iter": {
-                    "_type": "List",
-                    "elts": [
+              {
+                "kind": "argument_list",
+                "start": 183,
+                "end": 222,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 184,
+                    "end": 221,
+                    "children": [
                       {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 19,
-                        "end_col_offset": 20
+                        "kind": "identifier",
+                        "start": 185,
+                        "end": 186
                       },
                       {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 22,
-                        "end_col_offset": 23
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 25,
-                        "end_col_offset": 26
-                      }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 18,
-                    "end_col_offset": 27
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Name",
-                        "id": "x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 31,
-                        "end_col_offset": 32
-                      },
-                      "ops": [
-                        {
-                          "_type": "NotIn"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "List",
-                          "elts": [
-                            {
-                              "_type": "Constant",
-                              "value": 2,
-                              "kind": null,
-                              "lineno": 4,
-                              "end_lineno": 4,
-                              "col_offset": 41,
-                              "end_col_offset": 42
-                            }
-                          ],
-                          "ctx": {
-                            "_type": "Load"
+                        "kind": "for_in_clause",
+                        "start": 187,
+                        "end": 205,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 191,
+                            "end": 192
                           },
-                          "lineno": 4,
-                          "end_lineno": 4,
-                          "col_offset": 40,
-                          "end_col_offset": 43
-                        }
-                      ],
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 31,
-                      "end_col_offset": 43
-                    }
-                  ],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 44
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 45
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 45
+                          {
+                            "kind": "list",
+                            "start": 196,
+                            "end": 205,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 197,
+                                "end": 198
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 200,
+                                "end": 201
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 203,
+                                "end": 204
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 206,
+                        "end": 220,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 209,
+                            "end": 220,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 209,
+                                "end": 210
+                              },
+                              {
+                                "kind": "list",
+                                "start": 214,
+                                "end": 220,
+                                "children": [
+                                  {
+                                    "kind": "integer",
+                                    "start": 215,
+                                    "end": 216
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 218,
+                                    "end": 219
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
+        "kind": "expression_statement",
+        "start": 223,
+        "end": 252,
+        "children": [
+          {
+            "kind": "call",
+            "start": 223,
+            "end": 252,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 223,
+                "end": 228
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  },
-                  "iter": {
-                    "_type": "List",
-                    "elts": [
+              {
+                "kind": "argument_list",
+                "start": 228,
+                "end": 252,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 229,
+                    "end": 251,
+                    "children": [
                       {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 5,
-                        "end_lineno": 5,
-                        "col_offset": 19,
-                        "end_col_offset": 20
+                        "kind": "identifier",
+                        "start": 229,
+                        "end": 232
                       },
                       {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 5,
-                        "end_lineno": 5,
-                        "col_offset": 22,
-                        "end_col_offset": 23
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 5,
-                        "end_lineno": 5,
-                        "col_offset": 25,
-                        "end_col_offset": 26
+                        "kind": "argument_list",
+                        "start": 232,
+                        "end": 251,
+                        "children": [
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 233,
+                            "end": 250,
+                            "children": [
+                              {
+                                "kind": "binary_operator",
+                                "start": 234,
+                                "end": 249,
+                                "children": [
+                                  {
+                                    "kind": "list",
+                                    "start": 234,
+                                    "end": 240,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 235,
+                                        "end": 236
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 238,
+                                        "end": 239
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "list",
+                                    "start": 243,
+                                    "end": 249,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 244,
+                                        "end": 245
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 247,
+                                        "end": 248
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 18,
-                    "end_col_offset": 27
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Name",
-                        "id": "x",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 5,
-                        "end_lineno": 5,
-                        "col_offset": 31,
-                        "end_col_offset": 32
-                      },
-                      "ops": [
-                        {
-                          "_type": "In"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "List",
-                          "elts": [
-                            {
-                              "_type": "Constant",
-                              "value": 2,
-                              "kind": null,
-                              "lineno": 5,
-                              "end_lineno": 5,
-                              "col_offset": 37,
-                              "end_col_offset": 38
-                            },
-                            {
-                              "_type": "Constant",
-                              "value": 4,
-                              "kind": null,
-                              "lineno": 5,
-                              "end_lineno": 5,
-                              "col_offset": 40,
-                              "end_col_offset": 41
-                            }
-                          ],
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 5,
-                          "end_lineno": 5,
-                          "col_offset": 36,
-                          "end_col_offset": 42
-                        }
-                      ],
-                      "lineno": 5,
-                      "end_lineno": 5,
-                      "col_offset": 31,
-                      "end_col_offset": 42
-                    }
-                  ],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 43
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 44
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 44
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "List",
-                    "elts": [
-                      {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 12,
-                        "end_col_offset": 13
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 15,
-                        "end_col_offset": 16
-                      }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 11,
-                    "end_col_offset": 17
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "List",
-                    "elts": [
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 21,
-                        "end_col_offset": 22
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 3,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 24,
-                        "end_col_offset": 25
-                      }
-                    ],
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 20,
-                    "end_col_offset": 26
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 11,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 29
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/load_jsonl.py.json
+++ b/tests/json-ast/x/py/load_jsonl.py.json
@@ -1,702 +1,919 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 636,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Person",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 11,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "float",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 9,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 30.0,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 17,
-                  "end_col_offset": 21
-                },
-                {
-                  "_type": "Constant",
-                  "value": "alice@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 23,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 51
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 52
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 54,
-                "end_col_offset": 60
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 15.0,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "bob@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 67,
-                  "end_col_offset": 84
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 86,
-                  "end_col_offset": 91
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 54,
-              "end_col_offset": 92
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 94,
-                "end_col_offset": 100
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 20.0,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 101,
-                  "end_col_offset": 105
-                },
-                {
-                  "_type": "Constant",
-                  "value": "charlie@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 107,
-                  "end_col_offset": 128
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 130,
-                  "end_col_offset": 139
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 94,
-              "end_col_offset": 140
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 141
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 141
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Adult",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "adults",
-            "lineno": 25,
-            "end_lineno": 25,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Adult",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 10,
-              "end_col_offset": 15
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 16,
-                "end_col_offset": 22
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 24,
-                  "end_col_offset": 25
-                },
-                "attr": "email",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 24,
-                "end_col_offset": 31
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 10,
-            "end_col_offset": 32
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "p",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 37,
-                "end_col_offset": 38
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "people",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 42,
-                "end_col_offset": 48
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "p",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 52,
-                      "end_col_offset": 53
-                    },
-                    "attr": "age",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 52,
-                    "end_col_offset": 57
-                  },
-                  "ops": [
-                    {
-                      "_type": "GtE"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 18,
-                      "kind": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 61,
-                      "end_col_offset": 63
-                    }
-                  ],
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 52,
-                  "end_col_offset": 63
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 25,
-          "end_lineno": 25,
-          "col_offset": 9,
-          "end_col_offset": 64
-        },
-        "lineno": 25,
-        "end_lineno": 25,
-        "end_col_offset": 64
+            ]
+          }
+        ]
       },
       {
-        "_type": "For",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "a",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "a",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 18,
-                    "end_col_offset": 19
-                  },
-                  "attr": "email",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 18,
-                  "end_col_offset": 25
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 26
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 26
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "a",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "adults",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 26,
-        "end_lineno": 27,
-        "end_col_offset": 26
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 259,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 259,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 216
+              },
+              {
+                "kind": "block",
+                "start": 222,
+                "end": 259,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 222,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 222,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 239
+                          },
+                          {
+                            "kind": "type",
+                            "start": 241,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 241,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 249,
+                    "end": 259,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 249,
+                        "end": 259,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 249,
+                            "end": 254
+                          },
+                          {
+                            "kind": "type",
+                            "start": 256,
+                            "end": 259,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 256,
+                                "end": 259
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 261,
+        "end": 329,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 261,
+            "end": 271,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 262,
+                "end": 271
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 272,
+            "end": 329,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 278,
+                "end": 284
+              },
+              {
+                "kind": "block",
+                "start": 290,
+                "end": 329,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 290,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 290,
+                            "end": 293
+                          },
+                          {
+                            "kind": "type",
+                            "start": 295,
+                            "end": 300,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 295,
+                                "end": 300
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 305,
+                    "end": 315,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 305,
+                        "end": 315,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 305,
+                            "end": 310
+                          },
+                          {
+                            "kind": "type",
+                            "start": 312,
+                            "end": 315,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 312,
+                                "end": 315
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 320,
+                    "end": 329,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 320,
+                        "end": 329,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 320,
+                            "end": 324
+                          },
+                          {
+                            "kind": "type",
+                            "start": 326,
+                            "end": 329,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 326,
+                                "end": 329
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 331,
+        "end": 472,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 331,
+            "end": 472,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 331,
+                "end": 337
+              },
+              {
+                "kind": "list",
+                "start": 340,
+                "end": 472,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 341,
+                    "end": 383,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 341,
+                        "end": 347
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 347,
+                        "end": 383,
+                        "children": [
+                          {
+                            "kind": "float",
+                            "start": 348,
+                            "end": 352
+                          },
+                          {
+                            "kind": "string",
+                            "start": 354,
+                            "end": 373,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 354,
+                                "end": 355
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 355,
+                                "end": 372
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 372,
+                                "end": 373
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 375,
+                            "end": 382,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 375,
+                                "end": 376
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 376,
+                                "end": 381
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 381,
+                                "end": 382
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 385,
+                    "end": 423,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 385,
+                        "end": 391
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 391,
+                        "end": 423,
+                        "children": [
+                          {
+                            "kind": "float",
+                            "start": 392,
+                            "end": 396
+                          },
+                          {
+                            "kind": "string",
+                            "start": 398,
+                            "end": 415,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 398,
+                                "end": 399
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 399,
+                                "end": 414
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 414,
+                                "end": 415
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 417,
+                            "end": 422,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 417,
+                                "end": 418
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 418,
+                                "end": 421
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 421,
+                                "end": 422
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 425,
+                    "end": 471,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 425,
+                        "end": 431
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 431,
+                        "end": 471,
+                        "children": [
+                          {
+                            "kind": "float",
+                            "start": 432,
+                            "end": 436
+                          },
+                          {
+                            "kind": "string",
+                            "start": 438,
+                            "end": 459,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 438,
+                                "end": 439
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 439,
+                                "end": 458
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 458,
+                                "end": 459
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 461,
+                            "end": 470,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 461,
+                                "end": 462
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 462,
+                                "end": 469
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 469,
+                                "end": 470
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 473,
+        "end": 525,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 473,
+            "end": 483,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 474,
+                "end": 483
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 484,
+            "end": 525,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 490,
+                "end": 495
+              },
+              {
+                "kind": "block",
+                "start": 501,
+                "end": 525,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 501,
+                    "end": 510,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 501,
+                        "end": 510,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 501,
+                            "end": 505
+                          },
+                          {
+                            "kind": "type",
+                            "start": 507,
+                            "end": 510,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 507,
+                                "end": 510
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 515,
+                    "end": 525,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 515,
+                        "end": 525,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 515,
+                            "end": 520
+                          },
+                          {
+                            "kind": "type",
+                            "start": 522,
+                            "end": 525,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 522,
+                                "end": 525
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 527,
+        "end": 591,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 527,
+            "end": 591,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 527,
+                "end": 533
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 536,
+                "end": 591,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 537,
+                    "end": 559,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 537,
+                        "end": 542
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 542,
+                        "end": 559,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 543,
+                            "end": 549,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 543,
+                                "end": 544
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 545,
+                                "end": 549
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 551,
+                            "end": 558,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 551,
+                                "end": 552
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 553,
+                                "end": 558
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 560,
+                    "end": 575,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 564,
+                        "end": 565
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 569,
+                        "end": 575
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 576,
+                    "end": 590,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 579,
+                        "end": 590,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 579,
+                            "end": 584,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 579,
+                                "end": 580
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 581,
+                                "end": 584
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 588,
+                            "end": 590
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 592,
+        "end": 635,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 596,
+            "end": 597
+          },
+          {
+            "kind": "identifier",
+            "start": 601,
+            "end": 607
+          },
+          {
+            "kind": "block",
+            "start": 613,
+            "end": 635,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 613,
+                "end": 635,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 613,
+                    "end": 635,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 613,
+                        "end": 618
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 618,
+                        "end": 635,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 619,
+                            "end": 625,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 619,
+                                "end": 620
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 621,
+                                "end": 625
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 627,
+                            "end": 634,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 627,
+                                "end": 628
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 629,
+                                "end": 634
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/load_yaml.py.json
+++ b/tests/json-ast/x/py/load_yaml.py.json
@@ -1,702 +1,919 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 628,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Person",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 11,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 30,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 17,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": "alice@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 40
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 42,
-                  "end_col_offset": 49
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 50
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 52,
-                "end_col_offset": 58
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 15,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 59,
-                  "end_col_offset": 61
-                },
-                {
-                  "_type": "Constant",
-                  "value": "bob@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 63,
-                  "end_col_offset": 80
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 82,
-                  "end_col_offset": 87
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 52,
-              "end_col_offset": 88
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 90,
-                "end_col_offset": 96
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 20,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 97,
-                  "end_col_offset": 99
-                },
-                {
-                  "_type": "Constant",
-                  "value": "charlie@example.com",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 101,
-                  "end_col_offset": 122
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 124,
-                  "end_col_offset": 133
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 90,
-              "end_col_offset": 134
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 135
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 135
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Adult",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "email",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "adults",
-            "lineno": 25,
-            "end_lineno": 25,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Adult",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 10,
-              "end_col_offset": 15
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 16,
-                "end_col_offset": 22
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "p",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 24,
-                  "end_col_offset": 25
-                },
-                "attr": "email",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 24,
-                "end_col_offset": 31
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 10,
-            "end_col_offset": 32
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "p",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 37,
-                "end_col_offset": 38
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "people",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 42,
-                "end_col_offset": 48
-              },
-              "ifs": [
-                {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "p",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 52,
-                      "end_col_offset": 53
-                    },
-                    "attr": "age",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 52,
-                    "end_col_offset": 57
-                  },
-                  "ops": [
-                    {
-                      "_type": "GtE"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 18,
-                      "kind": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 61,
-                      "end_col_offset": 63
-                    }
-                  ],
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 52,
-                  "end_col_offset": 63
-                }
-              ],
-              "is_async": 0
-            }
-          ],
-          "lineno": 25,
-          "end_lineno": 25,
-          "col_offset": 9,
-          "end_col_offset": 64
-        },
-        "lineno": 25,
-        "end_lineno": 25,
-        "end_col_offset": 64
+            ]
+          }
+        ]
       },
       {
-        "_type": "For",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "a",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "a",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 27,
-                    "end_lineno": 27,
-                    "col_offset": 18,
-                    "end_col_offset": 19
-                  },
-                  "attr": "email",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 18,
-                  "end_col_offset": 25
-                }
-              ],
-              "keywords": [],
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 4,
-              "end_col_offset": 26
-            },
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 4,
-            "end_col_offset": 26
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "a",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "adults",
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 26,
-        "end_lineno": 27,
-        "end_col_offset": 26
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 259,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 259,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 216
+              },
+              {
+                "kind": "block",
+                "start": 222,
+                "end": 259,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 222,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 222,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 239
+                          },
+                          {
+                            "kind": "type",
+                            "start": 241,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 241,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 249,
+                    "end": 259,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 249,
+                        "end": 259,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 249,
+                            "end": 254
+                          },
+                          {
+                            "kind": "type",
+                            "start": 256,
+                            "end": 259,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 256,
+                                "end": 259
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 261,
+        "end": 327,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 261,
+            "end": 271,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 262,
+                "end": 271
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 272,
+            "end": 327,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 278,
+                "end": 284
+              },
+              {
+                "kind": "block",
+                "start": 290,
+                "end": 327,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 290,
+                    "end": 298,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 290,
+                        "end": 298,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 290,
+                            "end": 293
+                          },
+                          {
+                            "kind": "type",
+                            "start": 295,
+                            "end": 298,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 295,
+                                "end": 298
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 303,
+                    "end": 313,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 303,
+                        "end": 313,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 303,
+                            "end": 308
+                          },
+                          {
+                            "kind": "type",
+                            "start": 310,
+                            "end": 313,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 310,
+                                "end": 313
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 318,
+                    "end": 327,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 318,
+                        "end": 327,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 318,
+                            "end": 322
+                          },
+                          {
+                            "kind": "type",
+                            "start": 324,
+                            "end": 327,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 324,
+                                "end": 327
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 329,
+        "end": 464,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 329,
+            "end": 464,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 329,
+                "end": 335
+              },
+              {
+                "kind": "list",
+                "start": 338,
+                "end": 464,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 339,
+                    "end": 379,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 339,
+                        "end": 345
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 345,
+                        "end": 379,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 346,
+                            "end": 348
+                          },
+                          {
+                            "kind": "string",
+                            "start": 350,
+                            "end": 369,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 350,
+                                "end": 351
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 351,
+                                "end": 368
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 368,
+                                "end": 369
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 371,
+                            "end": 378,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 371,
+                                "end": 372
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 372,
+                                "end": 377
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 377,
+                                "end": 378
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 381,
+                    "end": 417,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 381,
+                        "end": 387
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 387,
+                        "end": 417,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 388,
+                            "end": 390
+                          },
+                          {
+                            "kind": "string",
+                            "start": 392,
+                            "end": 409,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 392,
+                                "end": 393
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 393,
+                                "end": 408
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 408,
+                                "end": 409
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 411,
+                            "end": 416,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 411,
+                                "end": 412
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 412,
+                                "end": 415
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 415,
+                                "end": 416
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 419,
+                    "end": 463,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 419,
+                        "end": 425
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 425,
+                        "end": 463,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 426,
+                            "end": 428
+                          },
+                          {
+                            "kind": "string",
+                            "start": 430,
+                            "end": 451,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 430,
+                                "end": 431
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 431,
+                                "end": 450
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 450,
+                                "end": 451
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 453,
+                            "end": 462,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 453,
+                                "end": 454
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 454,
+                                "end": 461
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 461,
+                                "end": 462
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 465,
+        "end": 517,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 465,
+            "end": 475,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 466,
+                "end": 475
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 476,
+            "end": 517,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 482,
+                "end": 487
+              },
+              {
+                "kind": "block",
+                "start": 493,
+                "end": 517,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 493,
+                    "end": 502,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 493,
+                        "end": 502,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 493,
+                            "end": 497
+                          },
+                          {
+                            "kind": "type",
+                            "start": 499,
+                            "end": 502,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 499,
+                                "end": 502
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 507,
+                    "end": 517,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 507,
+                        "end": 517,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 507,
+                            "end": 512
+                          },
+                          {
+                            "kind": "type",
+                            "start": 514,
+                            "end": 517,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 514,
+                                "end": 517
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 519,
+        "end": 583,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 519,
+            "end": 583,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 519,
+                "end": 525
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 528,
+                "end": 583,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 529,
+                    "end": 551,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 529,
+                        "end": 534
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 534,
+                        "end": 551,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 535,
+                            "end": 541,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 535,
+                                "end": 536
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 537,
+                                "end": 541
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 543,
+                            "end": 550,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 543,
+                                "end": 544
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 545,
+                                "end": 550
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 552,
+                    "end": 567,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 556,
+                        "end": 557
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 561,
+                        "end": 567
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_clause",
+                    "start": 568,
+                    "end": 582,
+                    "children": [
+                      {
+                        "kind": "comparison_operator",
+                        "start": 571,
+                        "end": 582,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 571,
+                            "end": 576,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 571,
+                                "end": 572
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 573,
+                                "end": 576
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 580,
+                            "end": 582
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 584,
+        "end": 627,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 588,
+            "end": 589
+          },
+          {
+            "kind": "identifier",
+            "start": 593,
+            "end": 599
+          },
+          {
+            "kind": "block",
+            "start": 605,
+            "end": 627,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 605,
+                "end": 627,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 605,
+                    "end": 627,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 605,
+                        "end": 610
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 610,
+                        "end": 627,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 611,
+                            "end": 617,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 611,
+                                "end": 612
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 613,
+                                "end": 617
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 619,
+                            "end": 626,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 619,
+                                "end": 620
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 621,
+                                "end": 626
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_assign.py.json
+++ b/tests/json-ast/x/py/map_assign.py.json
@@ -1,149 +1,191 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 154,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "scores",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "alice",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 17
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 19,
-              "end_col_offset": 20
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 21
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 21
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Subscript",
-            "value": {
-              "_type": "Name",
-              "id": "scores",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 0,
-              "end_col_offset": 6
-            },
-            "slice": {
-              "_type": "Constant",
-              "value": "bob",
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 12
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 16,
-          "end_col_offset": 17
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 17
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "scores",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 12
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 114,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 114,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 99
               },
-              "slice": {
-                "_type": "Constant",
-                "value": "bob",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 13,
-                "end_col_offset": 18
+              {
+                "kind": "dictionary",
+                "start": 102,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 103,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 103,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 103,
+                            "end": 104
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 104,
+                            "end": 109
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 109,
+                            "end": 110
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 112,
+                        "end": 113
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 115,
+        "end": 132,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 115,
+            "end": 132,
+            "children": [
+              {
+                "kind": "subscript",
+                "start": 115,
+                "end": 128,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 115,
+                    "end": 121
+                  },
+                  {
+                    "kind": "string",
+                    "start": 122,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 122,
+                        "end": 123
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 123,
+                        "end": 126
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 126,
+                        "end": 127
+                      }
+                    ]
+                  }
+                ]
               },
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "integer",
+                "start": 131,
+                "end": 132
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 133,
+        "end": 153,
+        "children": [
+          {
+            "kind": "call",
+            "start": 133,
+            "end": 153,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 138
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 19
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 20
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 20
+              {
+                "kind": "argument_list",
+                "start": 138,
+                "end": 153,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 139,
+                    "end": 152,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 139,
+                        "end": 145
+                      },
+                      {
+                        "kind": "string",
+                        "start": 146,
+                        "end": 151,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 146,
+                            "end": 147
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 147,
+                            "end": 150
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 150,
+                            "end": 151
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_in_operator.py.json
+++ b/tests/json-ast/x/py/map_in_operator.py.json
@@ -1,240 +1,246 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 170,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 113,
+        "children": [
           {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 98,
+                        "end": 99
+                      },
+                      {
+                        "kind": "string",
+                        "start": 101,
+                        "end": 104,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 101,
+                            "end": 102
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 102,
+                            "end": 103
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 103,
+                            "end": 104
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 106,
+                        "end": 107
+                      },
+                      {
+                        "kind": "string",
+                        "start": 109,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 109,
+                            "end": 110
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 110,
+                            "end": 111
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 111,
+                            "end": 112
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 6
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 14
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 16,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 20
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 141,
+        "children": [
+          {
+            "kind": "call",
+            "start": 114,
+            "end": 141,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 119
+              },
+              {
+                "kind": "argument_list",
+                "start": 119,
+                "end": 141,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 120,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 121,
+                        "end": 139,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 121,
+                            "end": 122
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 126,
+                            "end": 132,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 126,
+                                "end": 127
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 131,
+                                "end": 132
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 138,
+                            "end": 139
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 18
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 24,
-                "end_col_offset": 25
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 27
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 27
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 142,
+        "end": 169,
+        "children": [
+          {
+            "kind": "call",
+            "start": 142,
+            "end": 169,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 142,
+                "end": 147
+              },
+              {
+                "kind": "argument_list",
+                "start": 147,
+                "end": 169,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 148,
+                    "end": 168,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 149,
+                        "end": 167,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 149,
+                            "end": 150
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 154,
+                            "end": 160,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 154,
+                                "end": 155
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 159,
+                                "end": 160
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 166,
+                            "end": 167
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 18
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 24,
-                "end_col_offset": 25
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 27
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 27
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_index.py.json
+++ b/tests/json-ast/x/py/map_index.py.json
@@ -1,125 +1,172 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 128,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 16
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 20
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "m",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 113,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "slice": {
-                "_type": "Constant",
-                "value": "b",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 8,
-                "end_col_offset": 11
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 98,
+                        "end": 101,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 98,
+                            "end": 99
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 100,
+                            "end": 101
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 106,
+                        "end": 109,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 108,
+                            "end": 109
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 111,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 127,
+        "children": [
+          {
+            "kind": "call",
+            "start": 114,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 119
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 13
+              {
+                "kind": "argument_list",
+                "start": 119,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 120,
+                    "end": 126,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 120,
+                        "end": 121
+                      },
+                      {
+                        "kind": "string",
+                        "start": 122,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 122,
+                            "end": 123
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 123,
+                            "end": 124
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 124,
+                            "end": 125
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_int_key.py.json
+++ b/tests/json-ast/x/py/map_int_key.py.json
@@ -1,125 +1,155 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 126,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 6
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 14
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 16,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 20
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "m",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 113,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 8,
-                "end_col_offset": 9
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 98,
+                        "end": 99
+                      },
+                      {
+                        "kind": "string",
+                        "start": 101,
+                        "end": 104,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 101,
+                            "end": 102
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 102,
+                            "end": 103
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 103,
+                            "end": 104
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 106,
+                        "end": 107
+                      },
+                      {
+                        "kind": "string",
+                        "start": 109,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 109,
+                            "end": 110
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 110,
+                            "end": 111
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 111,
+                            "end": 112
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 125,
+        "children": [
+          {
+            "kind": "call",
+            "start": 114,
+            "end": 125,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 119
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 11
+              {
+                "kind": "argument_list",
+                "start": 119,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 120,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 120,
+                        "end": 121
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 122,
+                        "end": 123
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_literal_dynamic.py.json
+++ b/tests/json-ast/x/py/map_literal_dynamic.py.json
@@ -1,207 +1,254 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 148,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 3,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "y",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 4,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
           {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 13,
-              "end_col_offset": 16
-            }
-          ],
-          "values": [
-            {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Name",
-              "id": "y",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 20
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "m",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 104,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 99,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 100
               },
-              "slice": {
-                "_type": "Constant",
-                "value": "a",
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 8,
-                "end_col_offset": 11
+              {
+                "kind": "integer",
+                "start": 103,
+                "end": 104
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 105,
+        "end": 125,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 105,
+            "end": 125,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 106
               },
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "dictionary",
+                "start": 109,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 110,
+                    "end": 116,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 110,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 110,
+                            "end": 111
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 111,
+                            "end": 112
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 112,
+                            "end": 113
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 115,
+                        "end": 116
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 118,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 118,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 118,
+                            "end": 119
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 119,
+                            "end": 120
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 120,
+                            "end": 121
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 123,
+                        "end": 124
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 126,
+        "end": 147,
+        "children": [
+          {
+            "kind": "call",
+            "start": 126,
+            "end": 147,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 126,
+                "end": 131
               },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "m",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "slice": {
-                "_type": "Constant",
-                "value": "b",
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 16,
-                "end_col_offset": 19
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 14,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 21
+              {
+                "kind": "argument_list",
+                "start": 131,
+                "end": 147,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 132,
+                    "end": 138,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 132,
+                        "end": 133
+                      },
+                      {
+                        "kind": "string",
+                        "start": 134,
+                        "end": 137,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 134,
+                            "end": 135
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 135,
+                            "end": 136
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 136,
+                            "end": 137
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "subscript",
+                    "start": 140,
+                    "end": 146,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 140,
+                        "end": 141
+                      },
+                      {
+                        "kind": "string",
+                        "start": 142,
+                        "end": 145,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 142,
+                            "end": 143
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 143,
+                            "end": 144
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 144,
+                            "end": 145
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_membership.py.json
+++ b/tests/json-ast/x/py/map_membership.py.json
@@ -1,240 +1,280 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 174,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 113,
+        "children": [
           {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 98,
+                        "end": 101,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 98,
+                            "end": 99
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 100,
+                            "end": 101
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 106,
+                        "end": 109,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 108,
+                            "end": 109
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 111,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 16
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 19
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 20
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 20
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 143,
+        "children": [
+          {
+            "kind": "call",
+            "start": 114,
+            "end": 143,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 119
+              },
+              {
+                "kind": "argument_list",
+                "start": 119,
+                "end": 143,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 120,
+                    "end": 142,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 121,
+                        "end": 141,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 121,
+                            "end": 122
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 126,
+                            "end": 134,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 126,
+                                "end": 129,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 126,
+                                    "end": 127
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 127,
+                                    "end": 128
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 128,
+                                    "end": 129
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 133,
+                                "end": 134
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 140,
+                            "end": 141
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 27
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 29
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "c",
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 144,
+        "end": 173,
+        "children": [
+          {
+            "kind": "call",
+            "start": 144,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 144,
+                "end": 149
+              },
+              {
+                "kind": "argument_list",
+                "start": 149,
+                "end": 173,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 150,
+                    "end": 172,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 151,
+                        "end": 171,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 151,
+                            "end": 152
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 156,
+                            "end": 164,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 156,
+                                "end": 159,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 156,
+                                    "end": 157
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 157,
+                                    "end": 158
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 158,
+                                    "end": 159
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 163,
+                                "end": 164
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 170,
+                            "end": 171
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "m",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 20
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 27
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/map_nested_assign.py.json
+++ b/tests/json-ast/x/py/map_nested_assign.py.json
@@ -1,207 +1,285 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 181,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "data",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "outer",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 15
-            }
-          ],
-          "values": [
-            {
-              "_type": "Dict",
-              "keys": [
-                {
-                  "_type": "Constant",
-                  "value": "inner",
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 18,
-                  "end_col_offset": 25
-                }
-              ],
-              "values": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 27,
-                  "end_col_offset": 28
-                }
-              ],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 17,
-              "end_col_offset": 29
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 30
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 30
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Subscript",
-            "value": {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 0,
-                "end_col_offset": 4
-              },
-              "slice": {
-                "_type": "Constant",
-                "value": "outer",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 5,
-                "end_col_offset": 12
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 0,
-              "end_col_offset": 13
-            },
-            "slice": {
-              "_type": "Constant",
-              "value": "inner",
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 14,
-              "end_col_offset": 21
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 22
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 25,
-          "end_col_offset": 26
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 26
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Subscript",
-                "value": {
-                  "_type": "Name",
-                  "id": "data",
-                  "ctx": {
-                    "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 123,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 123,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
+              },
+              {
+                "kind": "dictionary",
+                "start": 100,
+                "end": 123,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 101,
+                    "end": 122,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 101,
+                        "end": 108,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 101,
+                            "end": 102
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 102,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 107,
+                            "end": 108
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "dictionary",
+                        "start": 110,
+                        "end": 122,
+                        "children": [
+                          {
+                            "kind": "pair",
+                            "start": 111,
+                            "end": 121,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 111,
+                                "end": 118,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 111,
+                                    "end": 112
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 112,
+                                    "end": 117
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 117,
+                                    "end": 118
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 120,
+                                "end": 121
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 124,
+        "end": 150,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 124,
+            "end": 150,
+            "children": [
+              {
+                "kind": "subscript",
+                "start": 124,
+                "end": 146,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 124,
+                    "end": 137,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 124,
+                        "end": 128
+                      },
+                      {
+                        "kind": "string",
+                        "start": 129,
+                        "end": 136,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 129,
+                            "end": 130
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 130,
+                            "end": 135
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 135,
+                            "end": 136
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "slice": {
-                  "_type": "Constant",
-                  "value": "outer",
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 11,
-                  "end_col_offset": 18
-                },
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 19
+                  {
+                    "kind": "string",
+                    "start": 138,
+                    "end": 145,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 138,
+                        "end": 139
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 139,
+                        "end": 144
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 144,
+                        "end": 145
+                      }
+                    ]
+                  }
+                ]
               },
-              "slice": {
-                "_type": "Constant",
-                "value": "inner",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 20,
-                "end_col_offset": 27
+              {
+                "kind": "integer",
+                "start": 149,
+                "end": 150
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 151,
+        "end": 180,
+        "children": [
+          {
+            "kind": "call",
+            "start": 151,
+            "end": 180,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 151,
+                "end": 156
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
+              {
+                "kind": "argument_list",
+                "start": 156,
+                "end": 180,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 157,
+                    "end": 179,
+                    "children": [
+                      {
+                        "kind": "subscript",
+                        "start": 157,
+                        "end": 170,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 157,
+                            "end": 161
+                          },
+                          {
+                            "kind": "string",
+                            "start": 162,
+                            "end": 169,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 162,
+                                "end": 163
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 163,
+                                "end": 168
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 168,
+                                "end": 169
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "string",
+                        "start": 171,
+                        "end": 178,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 171,
+                            "end": 172
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 172,
+                            "end": 177
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 177,
+                            "end": 178
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/match_expr.py.json
+++ b/tests/json-ast/x/py/match_expr.py.json
@@ -1,242 +1,273 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 201,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "label",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 18,
-              "end_col_offset": 19
-            },
-            "ops": [
-              {
-                "_type": "Eq"
-              }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 23,
-                "end_col_offset": 24
-              }
-            ],
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 18,
-            "end_col_offset": 24
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "one",
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 9,
-            "end_col_offset": 14
-          },
-          "orelse": {
-            "_type": "IfExp",
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 40,
-                "end_col_offset": 41
-              },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 45,
-                  "end_col_offset": 46
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 40,
-              "end_col_offset": 46
-            },
-            "body": {
-              "_type": "Constant",
-              "value": "two",
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 31,
-              "end_col_offset": 36
-            },
-            "orelse": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "x",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                "ops": [
-                  {
-                    "_type": "Eq"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 69,
-                    "end_col_offset": 70
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 64,
-                "end_col_offset": 70
-              },
-              "body": {
-                "_type": "Constant",
-                "value": "three",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 53,
-                "end_col_offset": 60
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": "unknown",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 76,
-                "end_col_offset": 85
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 53,
-              "end_col_offset": 85
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 31,
-            "end_col_offset": 86
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 9,
-          "end_col_offset": 87
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 88
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "label",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 12
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 187,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 99,
+            "end": 187,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 104
+              },
+              {
+                "kind": "parenthesized_expression",
+                "start": 107,
+                "end": 187,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 108,
+                    "end": 186,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 108,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 108,
+                            "end": 109
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 109,
+                            "end": 112
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 112,
+                            "end": 113
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 117,
+                        "end": 123,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 117,
+                            "end": 118
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 122,
+                            "end": 123
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 129,
+                        "end": 186,
+                        "children": [
+                          {
+                            "kind": "conditional_expression",
+                            "start": 130,
+                            "end": 185,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 130,
+                                "end": 135,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 130,
+                                    "end": 131
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 131,
+                                    "end": 134
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 134,
+                                    "end": 135
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 139,
+                                "end": 145,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 139,
+                                    "end": 140
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 144,
+                                    "end": 145
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "parenthesized_expression",
+                                "start": 151,
+                                "end": 185,
+                                "children": [
+                                  {
+                                    "kind": "conditional_expression",
+                                    "start": 152,
+                                    "end": 184,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 152,
+                                        "end": 159,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 152,
+                                            "end": 153
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 153,
+                                            "end": 158
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 158,
+                                            "end": 159
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "comparison_operator",
+                                        "start": 163,
+                                        "end": 169,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 163,
+                                            "end": 164
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 168,
+                                            "end": 169
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 175,
+                                        "end": 184,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 175,
+                                            "end": 176
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 176,
+                                            "end": 183
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 183,
+                                            "end": 184
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 188,
+        "end": 200,
+        "children": [
+          {
+            "kind": "call",
+            "start": 188,
+            "end": 200,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 188,
+                "end": 193
+              },
+              {
+                "kind": "argument_list",
+                "start": 193,
+                "end": 200,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 194,
+                    "end": 199
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/match_full.py.json
+++ b/tests/json-ast/x/py/match_full.py.json
@@ -1,924 +1,1047 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 560,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
           {
-            "_type": "Name",
-            "id": "label",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 5
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 18,
-              "end_col_offset": 19
-            },
-            "ops": [
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 187,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 99,
+            "end": 187,
+            "children": [
               {
-                "_type": "Eq"
-              }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 23,
-                "end_col_offset": 24
-              }
-            ],
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 18,
-            "end_col_offset": 24
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "one",
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 9,
-            "end_col_offset": 14
-          },
-          "orelse": {
-            "_type": "IfExp",
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 40,
-                "end_col_offset": 41
+                "kind": "identifier",
+                "start": 99,
+                "end": 104
               },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 45,
-                  "end_col_offset": 46
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 40,
-              "end_col_offset": 46
-            },
-            "body": {
-              "_type": "Constant",
-              "value": "two",
-              "kind": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 31,
-              "end_col_offset": 36
-            },
-            "orelse": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "x",
-                  "ctx": {
-                    "_type": "Load"
+              {
+                "kind": "parenthesized_expression",
+                "start": 107,
+                "end": 187,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 108,
+                    "end": 186,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 108,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 108,
+                            "end": 109
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 109,
+                            "end": 112
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 112,
+                            "end": 113
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 117,
+                        "end": 123,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 117,
+                            "end": 118
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 122,
+                            "end": 123
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 129,
+                        "end": 186,
+                        "children": [
+                          {
+                            "kind": "conditional_expression",
+                            "start": 130,
+                            "end": 185,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 130,
+                                "end": 135,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 130,
+                                    "end": 131
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 131,
+                                    "end": 134
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 134,
+                                    "end": 135
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 139,
+                                "end": 145,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 139,
+                                    "end": 140
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 144,
+                                    "end": 145
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "parenthesized_expression",
+                                "start": 151,
+                                "end": 185,
+                                "children": [
+                                  {
+                                    "kind": "conditional_expression",
+                                    "start": 152,
+                                    "end": 184,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 152,
+                                        "end": 159,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 152,
+                                            "end": 153
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 153,
+                                            "end": 158
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 158,
+                                            "end": 159
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "comparison_operator",
+                                        "start": 163,
+                                        "end": 169,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 163,
+                                            "end": 164
+                                          },
+                                          {
+                                            "kind": "integer",
+                                            "start": 168,
+                                            "end": 169
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 175,
+                                        "end": 184,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 175,
+                                            "end": 176
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 176,
+                                            "end": 183
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 183,
+                                            "end": 184
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 188,
+        "end": 200,
+        "children": [
+          {
+            "kind": "call",
+            "start": 188,
+            "end": 200,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 188,
+                "end": 193
+              },
+              {
+                "kind": "argument_list",
+                "start": 193,
+                "end": 200,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 194,
+                    "end": 199
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 201,
+        "end": 212,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 201,
+            "end": 212,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 201,
+                "end": 204
+              },
+              {
+                "kind": "string",
+                "start": 207,
+                "end": 212,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 207,
+                    "end": 208
                   },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                "ops": [
                   {
-                    "_type": "Eq"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 69,
-                    "end_col_offset": 70
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 64,
-                "end_col_offset": 70
-              },
-              "body": {
-                "_type": "Constant",
-                "value": "three",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 53,
-                "end_col_offset": 60
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": "unknown",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 76,
-                "end_col_offset": 85
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 53,
-              "end_col_offset": 85
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 31,
-            "end_col_offset": 86
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 9,
-          "end_col_offset": 87
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 88
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "label",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "day",
-            "lineno": 6,
-            "end_lineno": 6,
-            "end_col_offset": 3
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "sun",
-          "kind": null,
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 6,
-          "end_col_offset": 11
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "mood",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "day",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 19,
-              "end_col_offset": 22
-            },
-            "ops": [
-              {
-                "_type": "Eq"
-              }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": "mon",
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 26,
-                "end_col_offset": 31
-              }
-            ],
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 19,
-            "end_col_offset": 31
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "tired",
-            "kind": null,
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 8,
-            "end_col_offset": 15
-          },
-          "orelse": {
-            "_type": "IfExp",
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "day",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 51,
-                "end_col_offset": 54
-              },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": "fri",
-                  "kind": null,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 58,
-                  "end_col_offset": 63
-                }
-              ],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 51,
-              "end_col_offset": 63
-            },
-            "body": {
-              "_type": "Constant",
-              "value": "excited",
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 38,
-              "end_col_offset": 47
-            },
-            "orelse": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "day",
-                  "ctx": {
-                    "_type": "Load"
+                    "kind": "string_content",
+                    "start": 208,
+                    "end": 211
                   },
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 83,
-                  "end_col_offset": 86
-                },
-                "ops": [
                   {
-                    "_type": "Eq"
+                    "kind": "string_end",
+                    "start": 211,
+                    "end": 212
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": "sun",
-                    "kind": null,
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 90,
-                    "end_col_offset": 95
-                  }
-                ],
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 83,
-                "end_col_offset": 95
-              },
-              "body": {
-                "_type": "Constant",
-                "value": "relaxed",
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 70,
-                "end_col_offset": 79
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": "normal",
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 101,
-                "end_col_offset": 109
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 70,
-              "end_col_offset": 109
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 38,
-            "end_col_offset": 110
-          },
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 8,
-          "end_col_offset": 111
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 112
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "mood",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "ok",
-            "lineno": 9,
-            "end_lineno": 9,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": true,
-          "kind": null,
-          "lineno": 9,
-          "end_lineno": 9,
-          "col_offset": 5,
-          "end_col_offset": 9
-        },
-        "lineno": 9,
-        "end_lineno": 9,
-        "end_col_offset": 9
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "status",
-            "lineno": 10,
-            "end_lineno": 10,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "IfExp",
-          "test": {
-            "_type": "Compare",
-            "left": {
-              "_type": "Name",
-              "id": "ok",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 25,
-              "end_col_offset": 27
-            },
-            "ops": [
-              {
-                "_type": "Eq"
+                ]
               }
-            ],
-            "comparators": [
-              {
-                "_type": "Constant",
-                "value": true,
-                "kind": null,
-                "lineno": 10,
-                "end_lineno": 10,
-                "col_offset": 31,
-                "end_col_offset": 35
-              }
-            ],
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 25,
-            "end_col_offset": 35
-          },
-          "body": {
-            "_type": "Constant",
-            "value": "confirmed",
-            "kind": null,
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 10,
-            "end_col_offset": 21
-          },
-          "orelse": {
-            "_type": "IfExp",
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "ok",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 10,
-                "end_lineno": 10,
-                "col_offset": 54,
-                "end_col_offset": 56
-              },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": false,
-                  "kind": null,
-                  "lineno": 10,
-                  "end_lineno": 10,
-                  "col_offset": 60,
-                  "end_col_offset": 65
-                }
-              ],
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 54,
-              "end_col_offset": 65
-            },
-            "body": {
-              "_type": "Constant",
-              "value": "denied",
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 42,
-              "end_col_offset": 50
-            },
-            "orelse": {
-              "_type": "Constant",
-              "value": null,
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 71,
-              "end_col_offset": 75
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 42,
-            "end_col_offset": 75
-          },
-          "lineno": 10,
-          "end_lineno": 10,
-          "col_offset": 10,
-          "end_col_offset": 76
-        },
-        "lineno": 10,
-        "end_lineno": 10,
-        "end_col_offset": 77
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "status",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "FunctionDef",
-        "name": "classify",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                "ops": [
-                  {
-                    "_type": "Eq"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": 0,
-                    "kind": null,
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 27,
-                    "end_col_offset": 28
-                  }
-                ],
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 22,
-                "end_col_offset": 28
-              },
-              "body": {
-                "_type": "Constant",
-                "value": "zero",
-                "kind": null,
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 12,
-                "end_col_offset": 18
-              },
-              "orelse": {
-                "_type": "IfExp",
-                "test": {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Name",
-                    "id": "n",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 44,
-                    "end_col_offset": 45
-                  },
-                  "ops": [
-                    {
-                      "_type": "Eq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 49,
-                      "end_col_offset": 50
-                    }
-                  ],
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 44,
-                  "end_col_offset": 50
-                },
-                "body": {
-                  "_type": "Constant",
-                  "value": "one",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 35,
-                  "end_col_offset": 40
-                },
-                "orelse": {
-                  "_type": "Constant",
-                  "value": "many",
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 56,
-                  "end_col_offset": 62
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 35,
-                "end_col_offset": 62
-              },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 12,
-              "end_col_offset": 63
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 4,
-            "end_col_offset": 64
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "n",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 14
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 12,
-        "end_lineno": 13,
-        "end_col_offset": 64
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "classify",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 6,
-                "end_col_offset": 14
+        "kind": "expression_statement",
+        "start": 213,
+        "end": 325,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 213,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 217
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 18
+              {
+                "kind": "parenthesized_expression",
+                "start": 220,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 221,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 221,
+                        "end": 228,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 221,
+                            "end": 222
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 222,
+                            "end": 227
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 227,
+                            "end": 228
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 232,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 232,
+                            "end": 235
+                          },
+                          {
+                            "kind": "string",
+                            "start": 239,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 239,
+                                "end": 240
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 240,
+                                "end": 243
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 243,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 250,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "conditional_expression",
+                            "start": 251,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 251,
+                                "end": 260,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 251,
+                                    "end": 252
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 252,
+                                    "end": 259
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 259,
+                                    "end": 260
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 264,
+                                "end": 276,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 264,
+                                    "end": 267
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 271,
+                                    "end": 276,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 271,
+                                        "end": 272
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 272,
+                                        "end": 275
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 275,
+                                        "end": 276
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "parenthesized_expression",
+                                "start": 282,
+                                "end": 323,
+                                "children": [
+                                  {
+                                    "kind": "conditional_expression",
+                                    "start": 283,
+                                    "end": 322,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 283,
+                                        "end": 292,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 283,
+                                            "end": 284
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 284,
+                                            "end": 291
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 291,
+                                            "end": 292
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "comparison_operator",
+                                        "start": 296,
+                                        "end": 308,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 296,
+                                            "end": 299
+                                          },
+                                          {
+                                            "kind": "string",
+                                            "start": 303,
+                                            "end": 308,
+                                            "children": [
+                                              {
+                                                "kind": "string_start",
+                                                "start": 303,
+                                                "end": 304
+                                              },
+                                              {
+                                                "kind": "string_content",
+                                                "start": 304,
+                                                "end": 307
+                                              },
+                                              {
+                                                "kind": "string_end",
+                                                "start": 307,
+                                                "end": 308
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 314,
+                                        "end": 322,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 314,
+                                            "end": 315
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 315,
+                                            "end": 321
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 321,
+                                            "end": 322
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "classify",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 15,
-                "end_lineno": 15,
-                "col_offset": 6,
-                "end_col_offset": 14
+        "kind": "expression_statement",
+        "start": 326,
+        "end": 337,
+        "children": [
+          {
+            "kind": "call",
+            "start": 326,
+            "end": 337,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 326,
+                "end": 331
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 15,
-        "end_lineno": 15,
-        "end_col_offset": 18
+              {
+                "kind": "argument_list",
+                "start": 331,
+                "end": 337,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 332,
+                    "end": 336
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 338,
+        "end": 347,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 338,
+            "end": 347,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 338,
+                "end": 340
+              },
+              {
+                "kind": "true",
+                "start": 343,
+                "end": 347
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 348,
+        "end": 425,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 348,
+            "end": 425,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 348,
+                "end": 354
+              },
+              {
+                "kind": "parenthesized_expression",
+                "start": 357,
+                "end": 425,
+                "children": [
+                  {
+                    "kind": "conditional_expression",
+                    "start": 358,
+                    "end": 424,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 358,
+                        "end": 369,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 358,
+                            "end": 359
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 359,
+                            "end": 368
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 368,
+                            "end": 369
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "comparison_operator",
+                        "start": 373,
+                        "end": 383,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 373,
+                            "end": 375
+                          },
+                          {
+                            "kind": "true",
+                            "start": 379,
+                            "end": 383
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "parenthesized_expression",
+                        "start": 389,
+                        "end": 424,
+                        "children": [
+                          {
+                            "kind": "conditional_expression",
+                            "start": 390,
+                            "end": 423,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 390,
+                                "end": 398,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 390,
+                                    "end": 391
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 391,
+                                    "end": 397
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 397,
+                                    "end": 398
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "comparison_operator",
+                                "start": 402,
+                                "end": 413,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 402,
+                                    "end": 404
+                                  },
+                                  {
+                                    "kind": "false",
+                                    "start": 408,
+                                    "end": 413
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "none",
+                                "start": 419,
+                                "end": 423
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 426,
+        "end": 439,
+        "children": [
+          {
+            "kind": "call",
+            "start": 426,
+            "end": 439,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 426,
+                "end": 431
+              },
+              {
+                "kind": "argument_list",
+                "start": 431,
+                "end": 439,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 432,
+                    "end": 438
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_definition",
+        "start": 440,
+        "end": 521,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 444,
+            "end": 452
+          },
+          {
+            "kind": "parameters",
+            "start": 452,
+            "end": 455,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 453,
+                "end": 454
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 461,
+            "end": 521,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 461,
+                "end": 521,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 468,
+                    "end": 521,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 469,
+                        "end": 520,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 469,
+                            "end": 475,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 469,
+                                "end": 470
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 470,
+                                "end": 474
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 474,
+                                "end": 475
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 479,
+                            "end": 485,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 479,
+                                "end": 480
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 484,
+                                "end": 485
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 491,
+                            "end": 520,
+                            "children": [
+                              {
+                                "kind": "conditional_expression",
+                                "start": 492,
+                                "end": 519,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 492,
+                                    "end": 497,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 492,
+                                        "end": 493
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 493,
+                                        "end": 496
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 496,
+                                        "end": 497
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 501,
+                                    "end": 507,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 501,
+                                        "end": 502
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 506,
+                                        "end": 507
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 513,
+                                    "end": 519,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 513,
+                                        "end": 514
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 514,
+                                        "end": 518
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 518,
+                                        "end": 519
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 522,
+        "end": 540,
+        "children": [
+          {
+            "kind": "call",
+            "start": 522,
+            "end": 540,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 522,
+                "end": 527
+              },
+              {
+                "kind": "argument_list",
+                "start": 527,
+                "end": 540,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 528,
+                    "end": 539,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 528,
+                        "end": 536
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 536,
+                        "end": 539,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 537,
+                            "end": 538
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 541,
+        "end": 559,
+        "children": [
+          {
+            "kind": "call",
+            "start": 541,
+            "end": 559,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 541,
+                "end": 546
+              },
+              {
+                "kind": "argument_list",
+                "start": 546,
+                "end": 559,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 547,
+                    "end": 558,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 547,
+                        "end": 555
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 555,
+                        "end": 558,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 556,
+                            "end": 557
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/math_ops.py.json
+++ b/tests/json-ast/x/py/math_ops.py.json
@@ -1,171 +1,147 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 133,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 6,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 7
-              },
-              "op": {
-                "_type": "Mult"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 7,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 10,
-                "end_col_offset": 11
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 12
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 7,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
-              },
-              "op": {
-                "_type": "FloorDiv"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 2,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 12
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 13
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 7,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 105,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 105,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "op": {
-                "_type": "Mod"
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 105,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 99,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 99,
+                        "end": 100
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 119,
+        "children": [
+          {
+            "kind": "call",
+            "start": 106,
+            "end": 119,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 111
               },
-              "right": {
-                "_type": "Constant",
-                "value": 2,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 10,
-                "end_col_offset": 11
+              {
+                "kind": "argument_list",
+                "start": 111,
+                "end": 119,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 112,
+                    "end": 118,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 112,
+                        "end": 113
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 117,
+                        "end": 118
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 120,
+        "end": 132,
+        "children": [
+          {
+            "kind": "call",
+            "start": 120,
+            "end": 132,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 120,
+                "end": 125
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 11
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 12
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 12
+              {
+                "kind": "argument_list",
+                "start": 125,
+                "end": 132,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 126,
+                    "end": 131,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 126,
+                        "end": 127
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 130,
+                        "end": 131
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/membership.py.json
+++ b/tests/json-ast/x/py/membership.py.json
@@ -1,232 +1,193 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 172,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 109,
+        "children": [
           {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
+            "kind": "assignment",
+            "start": 93,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
+              },
+              {
+                "kind": "list",
+                "start": 100,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 107,
+                    "end": 108
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 15
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 16
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 16
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 110,
+        "end": 140,
+        "children": [
+          {
+            "kind": "call",
+            "start": 110,
+            "end": 140,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 110,
+                "end": 115
+              },
+              {
+                "kind": "argument_list",
+                "start": 115,
+                "end": 140,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 116,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 117,
+                        "end": 138,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 117,
+                            "end": 118
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 122,
+                            "end": 131,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 122,
+                                "end": 123
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 127,
+                                "end": 131
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 137,
+                            "end": 138
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "nums",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 17,
-                    "end_col_offset": 21
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 21
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 27,
-                "end_col_offset": 28
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 30
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 30
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 141,
+        "end": 171,
+        "children": [
+          {
+            "kind": "call",
+            "start": 141,
+            "end": 171,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 141,
+                "end": 146
+              },
+              {
+                "kind": "argument_list",
+                "start": 146,
+                "end": 171,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 147,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 148,
+                        "end": 169,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 148,
+                            "end": 149
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 153,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 153,
+                                "end": 154
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 158,
+                                "end": 162
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 168,
+                            "end": 169
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "nums",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 17,
-                    "end_col_offset": 21
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 21
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 27,
-                "end_col_offset": 28
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 30
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 30
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/min_max_builtin.py.json
+++ b/tests/json-ast/x/py/min_max_builtin.py.json
@@ -1,178 +1,159 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 144,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 109,
+        "children": [
           {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
+            "kind": "assignment",
+            "start": 93,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
+              },
+              {
+                "kind": "list",
+                "start": 100,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 107,
+                    "end": 108
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 4,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 15
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 16
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 16
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "min",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "expression_statement",
+        "start": 110,
+        "end": 126,
+        "children": [
+          {
+            "kind": "call",
+            "start": 110,
+            "end": 126,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 110,
+                "end": 115
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "nums",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 10,
-                  "end_col_offset": 14
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 115,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 116,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 116,
+                        "end": 119
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 119,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 120,
+                            "end": 124
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "max",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "expression_statement",
+        "start": 127,
+        "end": 143,
+        "children": [
+          {
+            "kind": "call",
+            "start": 127,
+            "end": 143,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 127,
+                "end": 132
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "nums",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 14
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 132,
+                "end": 143,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 133,
+                    "end": 142,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 133,
+                        "end": 136
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 136,
+                        "end": 142,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 137,
+                            "end": 141
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/mix_go_python.py.json
+++ b/tests/json-ast/x/py/mix_go_python.py.json
@@ -1,358 +1,420 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 301,
+    "children": [
       {
-        "_type": "Import",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "rawName",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 7
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "   alice  ",
-          "kind": null,
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 10,
-          "end_col_offset": 22
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 22
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "radius",
-            "lineno": 6,
-            "end_lineno": 6,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 3.0,
-          "kind": null,
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 9,
-          "end_col_offset": 12
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "name",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "rawName",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 7,
-                  "end_col_offset": 14
-                },
-                "attr": "strip",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 20
-              },
-              "args": [],
-              "keywords": [],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 22
-            },
-            "attr": "upper",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 7,
-            "end_col_offset": 28
-          },
-          "args": [],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 7,
-          "end_col_offset": 30
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 30
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "area",
-            "lineno": 8,
-            "end_lineno": 8,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "math",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 7,
-              "end_col_offset": 11
-            },
-            "attr": "pi",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 7,
-            "end_col_offset": 14
-          },
-          "op": {
-            "_type": "Mult"
-          },
-          "right": {
-            "_type": "Call",
-            "func": {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "math",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              "attr": "pow",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 17,
-              "end_col_offset": 25
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 100,
+            "end": 104,
+            "children": [
               {
-                "_type": "Name",
-                "id": "radius",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 26,
-                "end_col_offset": 32
-              },
-              {
-                "_type": "Constant",
-                "value": 2.0,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 34,
-                "end_col_offset": 37
+                "kind": "identifier",
+                "start": 100,
+                "end": 104
               }
-            ],
-            "keywords": [],
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 17,
-            "end_col_offset": 38
-          },
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 7,
-          "end_col_offset": 38
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 38
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "Hello",
-              "kind": null,
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 6,
-              "end_col_offset": 13
-            },
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 15,
-                "end_col_offset": 19
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 128,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 106,
+            "end": 128,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 113
               },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": "!",
-                "kind": null,
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 22,
-                "end_col_offset": 25
-              },
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 15,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 9,
-          "end_lineno": 9,
-          "col_offset": 0,
-          "end_col_offset": 26
-        },
-        "lineno": 9,
-        "end_lineno": 9,
-        "end_col_offset": 26
+              {
+                "kind": "string",
+                "start": 116,
+                "end": 128,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 116,
+                    "end": 117
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 117,
+                    "end": 127
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 127,
+                    "end": 128
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "The area of a circle with radius",
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 6,
-              "end_col_offset": 40
-            },
-            {
-              "_type": "Name",
-              "id": "radius",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 129,
+        "end": 141,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 129,
+            "end": 141,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 129,
+                "end": 135
               },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 42,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Constant",
-              "value": "is",
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 50,
-              "end_col_offset": 54
-            },
-            {
-              "_type": "Name",
-              "id": "area",
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "float",
+                "start": 138,
+                "end": 141
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 142,
+        "end": 172,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 142,
+            "end": 172,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 142,
+                "end": 146
               },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 56,
-              "end_col_offset": 60
-            }
-          ],
-          "keywords": [],
-          "lineno": 10,
-          "end_lineno": 10,
-          "col_offset": 0,
-          "end_col_offset": 61
-        },
-        "lineno": 10,
-        "end_lineno": 10,
-        "end_col_offset": 61
+              {
+                "kind": "call",
+                "start": 149,
+                "end": 172,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 149,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 149,
+                        "end": 164,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 149,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 149,
+                                "end": 156
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 157,
+                                "end": 162
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 162,
+                            "end": 164
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 165,
+                        "end": 170
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 170,
+                    "end": 172
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 173,
+        "end": 211,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 173,
+            "end": 211,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 173,
+                "end": 177
+              },
+              {
+                "kind": "binary_operator",
+                "start": 180,
+                "end": 211,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 180,
+                    "end": 187,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 180,
+                        "end": 184
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 185,
+                        "end": 187
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 190,
+                    "end": 211,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 190,
+                        "end": 198,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 190,
+                            "end": 194
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 195,
+                            "end": 198
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 198,
+                        "end": 211,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 199,
+                            "end": 205
+                          },
+                          {
+                            "kind": "float",
+                            "start": 207,
+                            "end": 210
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 212,
+        "end": 238,
+        "children": [
+          {
+            "kind": "call",
+            "start": 212,
+            "end": 238,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 212,
+                "end": 217
+              },
+              {
+                "kind": "argument_list",
+                "start": 217,
+                "end": 238,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 218,
+                    "end": 225,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 218,
+                        "end": 219
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 219,
+                        "end": 224
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 224,
+                        "end": 225
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "binary_operator",
+                    "start": 227,
+                    "end": 237,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 227,
+                        "end": 231
+                      },
+                      {
+                        "kind": "string",
+                        "start": 234,
+                        "end": 237,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 234,
+                            "end": 235
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 235,
+                            "end": 236
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 236,
+                            "end": 237
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 239,
+        "end": 300,
+        "children": [
+          {
+            "kind": "call",
+            "start": 239,
+            "end": 300,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 239,
+                "end": 244
+              },
+              {
+                "kind": "argument_list",
+                "start": 244,
+                "end": 300,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 245,
+                    "end": 279,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 245,
+                        "end": 246
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 246,
+                        "end": 278
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 278,
+                        "end": 279
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 281,
+                    "end": 287
+                  },
+                  {
+                    "kind": "string",
+                    "start": 289,
+                    "end": 293,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 289,
+                        "end": 290
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 290,
+                        "end": 292
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 292,
+                        "end": 293
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 295,
+                    "end": 299
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/nested_function.py.json
+++ b/tests/json-ast/x/py/nested_function.py.json
@@ -1,200 +1,185 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 182,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "outer",
-        "body": [
-          {
-            "_type": "FunctionDef",
-            "name": "inner",
-            "body": [
-              {
-                "_type": "Return",
-                "value": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Name",
-                    "id": "x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 15,
-                    "end_col_offset": 16
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Name",
-                    "id": "y",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 15,
-                  "end_col_offset": 20
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 8,
-                "end_col_offset": 20
-              }
-            ],
-            "args": {
-              "_type": "arguments",
-              "posonlyargs": [],
-              "args": [
-                {
-                  "_type": "arg",
-                  "arg": "y",
-                  "annotation": null,
-                  "type_comment": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                }
-              ],
-              "vararg": null,
-              "kwonlyargs": [],
-              "kw_defaults": [],
-              "kwarg": null,
-              "defaults": []
-            },
-            "lineno": 4,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 20
-          },
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "inner",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 11,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 11,
-              "end_col_offset": 19
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "x",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 6,
-        "end_col_offset": 19
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 165,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 102
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "outer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 6,
-                "end_col_offset": 11
+          {
+            "kind": "parameters",
+            "start": 102,
+            "end": 105,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 103,
+                "end": 104
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 111,
+            "end": 165,
+            "children": [
+              {
+                "kind": "function_definition",
+                "start": 111,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 115,
+                    "end": 120
+                  },
+                  {
+                    "kind": "parameters",
+                    "start": 120,
+                    "end": 123,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 121,
+                        "end": 122
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 133,
+                    "end": 145,
+                    "children": [
+                      {
+                        "kind": "return_statement",
+                        "start": 133,
+                        "end": 145,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 140,
+                            "end": 145,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 140,
+                                "end": 141
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 144,
+                                "end": 145
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                }
-              ],
-              "keywords": [],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 6,
-              "end_col_offset": 14
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 15
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 15
+              {
+                "kind": "return_statement",
+                "start": 150,
+                "end": 165,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 157,
+                    "end": 165,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 157,
+                        "end": 162
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 162,
+                        "end": 165,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 163,
+                            "end": 164
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 166,
+        "end": 181,
+        "children": [
+          {
+            "kind": "call",
+            "start": 166,
+            "end": 181,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 166,
+                "end": 171
+              },
+              {
+                "kind": "argument_list",
+                "start": 171,
+                "end": 181,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 172,
+                    "end": 180,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 172,
+                        "end": 177
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 177,
+                        "end": 180,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 178,
+                            "end": 179
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/order_by_map.py.json
+++ b/tests/json-ast/x/py/order_by_map.py.json
@@ -1,580 +1,611 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 432,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Data",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "a",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "b",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 11,
-        "end_col_offset": 10
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "data",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 8,
-                "end_col_offset": 12
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 13,
-                  "end_col_offset": 14
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 8,
-              "end_col_offset": 18
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 20,
-                "end_col_offset": 24
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 28,
-                  "end_col_offset": 29
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 20,
-              "end_col_offset": 30
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Data",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 32,
-                "end_col_offset": 36
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 37,
-                  "end_col_offset": 38
-                },
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 40,
-                  "end_col_offset": 41
-                }
-              ],
-              "keywords": [],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 32,
-              "end_col_offset": 42
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 7,
-          "end_col_offset": 43
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 43
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
           {
-            "_type": "Name",
-            "id": "sorted",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 6
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Name",
-            "id": "x",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 10,
-            "end_col_offset": 11
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 256,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 16,
-                "end_col_offset": 17
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 256,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 233
               },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 21,
-                  "end_col_offset": 27
-                },
-                "args": [
+              {
+                "kind": "block",
+                "start": 239,
+                "end": 256,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "x",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 14,
-                      "end_lineno": 14,
-                      "col_offset": 29,
-                      "end_col_offset": 30
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 239,
+                    "end": 245,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "x",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 14,
-                          "end_lineno": 14,
-                          "col_offset": 35,
-                          "end_col_offset": 36
-                        },
-                        "iter": {
-                          "_type": "Name",
-                          "id": "data",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 14,
-                          "end_lineno": 14,
-                          "col_offset": 40,
-                          "end_col_offset": 44
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 14,
-                    "end_lineno": 14,
-                    "col_offset": 28,
-                    "end_col_offset": 45
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                        "kind": "assignment",
+                        "start": 239,
+                        "end": 245,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "x",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 14,
-                            "end_lineno": 14,
-                            "col_offset": 58,
-                            "end_col_offset": 59
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Call",
-                        "func": {
-                          "_type": "Name",
-                          "id": "tuple",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 239,
+                            "end": 240
                           },
-                          "lineno": 14,
-                          "end_lineno": 14,
-                          "col_offset": 61,
-                          "end_col_offset": 66
-                        },
-                        "args": [
                           {
-                            "_type": "List",
-                            "elts": [
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
                               {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "x",
-                                  "ctx": {
-                                    "_type": "Load"
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 250,
+                    "end": 256,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 250,
+                        "end": 256,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 250,
+                            "end": 251
+                          },
+                          {
+                            "kind": "type",
+                            "start": 253,
+                            "end": 256,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 253,
+                                "end": 256
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 258,
+        "end": 301,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 258,
+            "end": 301,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 258,
+                "end": 262
+              },
+              {
+                "kind": "list",
+                "start": 265,
+                "end": 301,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 266,
+                    "end": 276,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 266,
+                        "end": 270
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 270,
+                        "end": 276,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 271,
+                            "end": 272
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 274,
+                            "end": 275
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 278,
+                    "end": 288,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 278,
+                        "end": 282
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 282,
+                        "end": 288,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 283,
+                            "end": 284
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 286,
+                            "end": 287
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 290,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 290,
+                        "end": 294
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 294,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 295,
+                            "end": 296
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 298,
+                            "end": 299
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 302,
+        "end": 382,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 302,
+            "end": 382,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 302,
+                "end": 308
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 311,
+                "end": 382,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 312,
+                    "end": 313
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 314,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 318,
+                        "end": 319
+                      },
+                      {
+                        "kind": "call",
+                        "start": 323,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 323,
+                            "end": 329
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 329,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "list_comprehension",
+                                "start": 330,
+                                "end": 347,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 331,
+                                    "end": 332
                                   },
-                                  "lineno": 14,
-                                  "end_lineno": 14,
-                                  "col_offset": 68,
-                                  "end_col_offset": 69
-                                },
-                                "attr": "a",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 14,
-                                "end_lineno": 14,
-                                "col_offset": 68,
-                                "end_col_offset": 71
+                                  {
+                                    "kind": "for_in_clause",
+                                    "start": 333,
+                                    "end": 346,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 337,
+                                        "end": 338
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 342,
+                                        "end": 346
+                                      }
+                                    ]
+                                  }
+                                ]
                               },
                               {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "x",
-                                  "ctx": {
-                                    "_type": "Load"
+                                "kind": "keyword_argument",
+                                "start": 349,
+                                "end": 380,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 349,
+                                    "end": 352
                                   },
-                                  "lineno": 14,
-                                  "end_lineno": 14,
-                                  "col_offset": 73,
-                                  "end_col_offset": 74
-                                },
-                                "attr": "b",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 14,
-                                "end_lineno": 14,
-                                "col_offset": 73,
-                                "end_col_offset": 76
+                                  {
+                                    "kind": "lambda",
+                                    "start": 353,
+                                    "end": 380,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 360,
+                                        "end": 361,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 360,
+                                            "end": 361
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 363,
+                                        "end": 380,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 363,
+                                            "end": 368
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 368,
+                                            "end": 380,
+                                            "children": [
+                                              {
+                                                "kind": "list",
+                                                "start": 369,
+                                                "end": 379,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 370,
+                                                    "end": 373,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 370,
+                                                        "end": 371
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 372,
+                                                        "end": 373
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 375,
+                                                    "end": 378,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 375,
+                                                        "end": 376
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 377,
+                                                        "end": 378
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
-                            ],
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 14,
-                            "end_lineno": 14,
-                            "col_offset": 67,
-                            "end_col_offset": 77
+                            ]
                           }
-                        ],
-                        "keywords": [],
-                        "lineno": 14,
-                        "end_lineno": 14,
-                        "col_offset": 61,
-                        "end_col_offset": 78
-                      },
-                      "lineno": 14,
-                      "end_lineno": 14,
-                      "col_offset": 51,
-                      "end_col_offset": 78
-                    },
-                    "lineno": 14,
-                    "end_lineno": 14,
-                    "col_offset": 47,
-                    "end_col_offset": 78
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 21,
-                "end_col_offset": 79
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 9,
-          "end_col_offset": 80
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 80
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 7,
-                    "end_col_offset": 18
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 7,
-                  "end_col_offset": 25
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 26,
-                    "end_col_offset": 28
-                  }
-                ],
-                "keywords": [],
-                "lineno": 15,
-                "end_lineno": 15,
-                "col_offset": 7,
-                "end_col_offset": 29
+        "kind": "expression_statement",
+        "start": 383,
+        "end": 431,
+        "children": [
+          {
+            "kind": "call",
+            "start": 383,
+            "end": 431,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 383,
+                "end": 388
               },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "_x",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 34,
-                    "end_col_offset": 36
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "sorted",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 40,
-                    "end_col_offset": 46
-                  },
-                  "ifs": [],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 6,
-              "end_col_offset": 47
-            }
-          ],
-          "keywords": [],
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 0,
-          "end_col_offset": 48
-        },
-        "lineno": 15,
-        "end_lineno": 15,
-        "end_col_offset": 48
+              {
+                "kind": "argument_list",
+                "start": 388,
+                "end": 431,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 389,
+                    "end": 430,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 390,
+                        "end": 412,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 390,
+                            "end": 408,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 390,
+                                "end": 401
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 402,
+                                "end": 408
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 408,
+                            "end": 412,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 409,
+                                "end": 411
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 413,
+                        "end": 429,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 417,
+                            "end": 419
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 423,
+                            "end": 429
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/outer_join.py.json
+++ b/tests/json-ast/x/py/outer_join.py.json
@@ -1,1834 +1,1969 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 1228,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 79,
-                "end_col_offset": 87
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 88,
-                  "end_col_offset": 89
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Diana",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 91,
-                  "end_col_offset": 98
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 79,
-              "end_col_offset": 99
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 100
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 100
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 125,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 50,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 64,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 50,
-              "end_col_offset": 68
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 70,
-                "end_col_offset": 75
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 103,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 76,
-                  "end_col_offset": 79
-                },
-                {
-                  "_type": "Constant",
-                  "value": 5,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 81,
-                  "end_col_offset": 82
-                },
-                {
-                  "_type": "Constant",
-                  "value": 80,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 84,
-                  "end_col_offset": 86
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 70,
-              "end_col_offset": 87
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 88
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 88
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "order",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 14,
-              "end_col_offset": 17
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customer",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 17
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 17
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 25,
-            "end_lineno": 25,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "BinOp",
-            "left": {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "Result",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                },
-                "args": [
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
                   {
-                    "_type": "Name",
-                    "id": "o",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  },
-                  {
-                    "_type": "Name",
-                    "id": "c",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 20,
-                    "end_col_offset": 21
-                  }
-                ],
-                "keywords": [],
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 10,
-                "end_col_offset": 22
-              },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "o",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 27,
-                    "end_col_offset": 28
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "orders",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 32,
-                    "end_col_offset": 38
-                  },
-                  "ifs": [],
-                  "is_async": 0
-                },
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "c",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 43,
-                    "end_col_offset": 44
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "customers",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 48,
-                    "end_col_offset": 57
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "o",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 61,
-                          "end_col_offset": 62
-                        },
-                        "attr": "customerId",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 61,
-                        "end_col_offset": 73
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "c",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 25,
-                            "end_lineno": 25,
-                            "col_offset": 77,
-                            "end_col_offset": 78
-                          },
-                          "attr": "id",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 77,
-                          "end_col_offset": 81
-                        }
-                      ],
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 61,
-                      "end_col_offset": 81
-                    }
-                  ],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 9,
-              "end_col_offset": 82
-            },
-            "op": {
-              "_type": "Add"
-            },
-            "right": {
-              "_type": "ListComp",
-              "elt": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Lambda",
-                  "args": {
-                    "_type": "arguments",
-                    "posonlyargs": [],
-                    "args": [
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
                       {
-                        "_type": "arg",
-                        "arg": "c",
-                        "annotation": null,
-                        "type_comment": null,
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 94,
-                        "end_col_offset": 95
-                      }
-                    ],
-                    "vararg": null,
-                    "kwonlyargs": [],
-                    "kw_defaults": [],
-                    "kwarg": null,
-                    "defaults": []
-                  },
-                  "body": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "Result",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 97,
-                      "end_col_offset": 103
-                    },
-                    "args": [
-                      {
-                        "_type": "Name",
-                        "id": "o",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 104,
-                        "end_col_offset": 105
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": null,
-                        "kind": null,
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 107,
-                        "end_col_offset": 111
-                      }
-                    ],
-                    "keywords": [],
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 97,
-                    "end_col_offset": 112
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 87,
-                  "end_col_offset": 112
-                },
-                "args": [
-                  {
-                    "_type": "Constant",
-                    "value": null,
-                    "kind": null,
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 114,
-                    "end_col_offset": 118
-                  }
-                ],
-                "keywords": [],
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 86,
-                "end_col_offset": 119
-              },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "o",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 124,
-                    "end_col_offset": 125
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "orders",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 129,
-                    "end_col_offset": 135
-                  },
-                  "ifs": [
-                    {
-                      "_type": "UnaryOp",
-                      "op": {
-                        "_type": "Not"
-                      },
-                      "operand": {
-                        "_type": "Call",
-                        "func": {
-                          "_type": "Name",
-                          "id": "any",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 143,
-                          "end_col_offset": 146
-                        },
-                        "args": [
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
                           {
-                            "_type": "ListComp",
-                            "elt": {
-                              "_type": "Compare",
-                              "left": {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "o",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 148,
-                                  "end_col_offset": 149
-                                },
-                                "attr": "customerId",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 148,
-                                "end_col_offset": 160
-                              },
-                              "ops": [
-                                {
-                                  "_type": "Eq"
-                                }
-                              ],
-                              "comparators": [
-                                {
-                                  "_type": "Attribute",
-                                  "value": {
-                                    "_type": "Name",
-                                    "id": "c",
-                                    "ctx": {
-                                      "_type": "Load"
-                                    },
-                                    "lineno": 25,
-                                    "end_lineno": 25,
-                                    "col_offset": 164,
-                                    "end_col_offset": 165
-                                  },
-                                  "attr": "id",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 164,
-                                  "end_col_offset": 168
-                                }
-                              ],
-                              "lineno": 25,
-                              "end_lineno": 25,
-                              "col_offset": 148,
-                              "end_col_offset": 168
-                            },
-                            "generators": [
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
                               {
-                                "_type": "comprehension",
-                                "target": {
-                                  "_type": "Name",
-                                  "id": "c",
-                                  "ctx": {
-                                    "_type": "Store"
-                                  },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 173,
-                                  "end_col_offset": 174
-                                },
-                                "iter": {
-                                  "_type": "Name",
-                                  "id": "customers",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 178,
-                                  "end_col_offset": 187
-                                },
-                                "ifs": [],
-                                "is_async": 0
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
                               }
-                            ],
-                            "lineno": 25,
-                            "end_lineno": 25,
-                            "col_offset": 147,
-                            "end_col_offset": 188
+                            ]
                           }
-                        ],
-                        "keywords": [],
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 143,
-                        "end_col_offset": 189
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 139,
-                      "end_col_offset": 189
-                    }
-                  ],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 85,
-              "end_col_offset": 190
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 9,
-            "end_col_offset": 190
-          },
-          "op": {
-            "_type": "Add"
-          },
-          "right": {
-            "_type": "ListComp",
-            "elt": {
-              "_type": "Call",
-              "func": {
-                "_type": "Lambda",
-                "args": {
-                  "_type": "arguments",
-                  "posonlyargs": [],
-                  "args": [
-                    {
-                      "_type": "arg",
-                      "arg": "o",
-                      "annotation": null,
-                      "type_comment": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 202,
-                      "end_col_offset": 203
-                    }
-                  ],
-                  "vararg": null,
-                  "kwonlyargs": [],
-                  "kw_defaults": [],
-                  "kwarg": null,
-                  "defaults": []
-                },
-                "body": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Result",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 205,
-                    "end_col_offset": 211
+                        ]
+                      }
+                    ]
                   },
-                  "args": [
-                    {
-                      "_type": "Constant",
-                      "value": null,
-                      "kind": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 212,
-                      "end_col_offset": 216
-                    },
-                    {
-                      "_type": "Name",
-                      "id": "c",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 218,
-                      "end_col_offset": 219
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 205,
-                  "end_col_offset": 220
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 195,
-                "end_col_offset": 220
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": null,
-                  "kind": null,
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 222,
-                  "end_col_offset": 226
-                }
-              ],
-              "keywords": [],
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 194,
-              "end_col_offset": 227
-            },
-            "generators": [
-              {
-                "_type": "comprehension",
-                "target": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Store"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 232,
-                  "end_col_offset": 233
-                },
-                "iter": {
-                  "_type": "Name",
-                  "id": "customers",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 237,
-                  "end_col_offset": 246
-                },
-                "ifs": [
                   {
-                    "_type": "UnaryOp",
-                    "op": {
-                      "_type": "Not"
-                    },
-                    "operand": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "any",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 254,
-                        "end_col_offset": 257
-                      },
-                      "args": [
-                        {
-                          "_type": "ListComp",
-                          "elt": {
-                            "_type": "Compare",
-                            "left": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 259,
-                                "end_col_offset": 260
-                              },
-                              "attr": "customerId",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 25,
-                              "end_lineno": 25,
-                              "col_offset": 259,
-                              "end_col_offset": 271
-                            },
-                            "ops": [
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
                               {
-                                "_type": "Eq"
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
                               }
-                            ],
-                            "comparators": [
-                              {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "c",
-                                  "ctx": {
-                                    "_type": "Load"
-                                  },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 275,
-                                  "end_col_offset": 276
-                                },
-                                "attr": "id",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 275,
-                                "end_col_offset": 279
-                              }
-                            ],
-                            "lineno": 25,
-                            "end_lineno": 25,
-                            "col_offset": 259,
-                            "end_col_offset": 279
-                          },
-                          "generators": [
-                            {
-                              "_type": "comprehension",
-                              "target": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Store"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 284,
-                                "end_col_offset": 285
-                              },
-                              "iter": {
-                                "_type": "Name",
-                                "id": "orders",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 289,
-                                "end_col_offset": 295
-                              },
-                              "ifs": [],
-                              "is_async": 0
-                            }
-                          ],
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 258,
-                          "end_col_offset": 296
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 254,
-                      "end_col_offset": 297
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 250,
-                    "end_col_offset": 297
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "is_async": 0
+                ]
               }
-            ],
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 193,
-            "end_col_offset": 298
-          },
-          "lineno": 25,
-          "end_lineno": 25,
-          "col_offset": 9,
-          "end_col_offset": 298
-        },
-        "lineno": 25,
-        "end_lineno": 25,
-        "end_col_offset": 298
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Outer Join using syntax ---",
-              "kind": null,
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 6,
-              "end_col_offset": 39
-            }
-          ],
-          "keywords": [],
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 0,
-          "end_col_offset": 40
-        },
-        "lineno": 26,
-        "end_lineno": 26,
-        "end_col_offset": 40
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "If",
-            "body": [
-              {
-                "_type": "If",
-                "body": [
-                  {
-                    "_type": "Expr",
-                    "value": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "print",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 30,
-                        "end_lineno": 30,
-                        "col_offset": 12,
-                        "end_col_offset": 17
-                      },
-                      "args": [
-                        {
-                          "_type": "Constant",
-                          "value": "Order",
-                          "kind": null,
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 18,
-                          "end_col_offset": 25
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "row",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 30,
-                              "end_lineno": 30,
-                              "col_offset": 27,
-                              "end_col_offset": 30
-                            },
-                            "attr": "order",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 30,
-                            "end_lineno": 30,
-                            "col_offset": 27,
-                            "end_col_offset": 36
-                          },
-                          "attr": "id",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 27,
-                          "end_col_offset": 39
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": "by",
-                          "kind": null,
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 41,
-                          "end_col_offset": 45
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "row",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 30,
-                              "end_lineno": 30,
-                              "col_offset": 47,
-                              "end_col_offset": 50
-                            },
-                            "attr": "customer",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 30,
-                            "end_lineno": 30,
-                            "col_offset": 47,
-                            "end_col_offset": 59
-                          },
-                          "attr": "name",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 47,
-                          "end_col_offset": 64
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": "- $",
-                          "kind": null,
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 66,
-                          "end_col_offset": 71
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "row",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 30,
-                              "end_lineno": 30,
-                              "col_offset": 73,
-                              "end_col_offset": 76
-                            },
-                            "attr": "order",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 30,
-                            "end_lineno": 30,
-                            "col_offset": 73,
-                            "end_col_offset": 82
-                          },
-                          "attr": "total",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 30,
-                          "end_lineno": 30,
-                          "col_offset": 73,
-                          "end_col_offset": 88
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 30,
-                      "end_lineno": 30,
-                      "col_offset": 12,
-                      "end_col_offset": 89
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 12,
-                    "end_col_offset": 89
-                  }
-                ],
-                "test": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "row",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 11,
-                    "end_col_offset": 14
-                  },
-                  "attr": "customer",
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 11,
-                  "end_col_offset": 23
-                },
-                "orelse": [
-                  {
-                    "_type": "Expr",
-                    "value": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "print",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 32,
-                        "end_lineno": 32,
-                        "col_offset": 12,
-                        "end_col_offset": 17
-                      },
-                      "args": [
-                        {
-                          "_type": "Constant",
-                          "value": "Order",
-                          "kind": null,
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 18,
-                          "end_col_offset": 25
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "row",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 32,
-                              "end_lineno": 32,
-                              "col_offset": 27,
-                              "end_col_offset": 30
-                            },
-                            "attr": "order",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 32,
-                            "end_lineno": 32,
-                            "col_offset": 27,
-                            "end_col_offset": 36
-                          },
-                          "attr": "id",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 27,
-                          "end_col_offset": 39
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": "by",
-                          "kind": null,
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 41,
-                          "end_col_offset": 45
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": "Unknown",
-                          "kind": null,
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 47,
-                          "end_col_offset": 56
-                        },
-                        {
-                          "_type": "Constant",
-                          "value": "- $",
-                          "kind": null,
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 58,
-                          "end_col_offset": 63
-                        },
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Attribute",
-                            "value": {
-                              "_type": "Name",
-                              "id": "row",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 32,
-                              "end_lineno": 32,
-                              "col_offset": 65,
-                              "end_col_offset": 68
-                            },
-                            "attr": "order",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 32,
-                            "end_lineno": 32,
-                            "col_offset": 65,
-                            "end_col_offset": 74
-                          },
-                          "attr": "total",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 32,
-                          "end_lineno": 32,
-                          "col_offset": 65,
-                          "end_col_offset": 80
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 32,
-                      "end_lineno": 32,
-                      "col_offset": 12,
-                      "end_col_offset": 81
-                    },
-                    "lineno": 32,
-                    "end_lineno": 32,
-                    "col_offset": 12,
-                    "end_col_offset": 81
-                  }
-                ],
-                "lineno": 29,
-                "end_lineno": 32,
-                "col_offset": 8,
-                "end_col_offset": 81
-              }
-            ],
-            "test": {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "row",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 7,
-                "end_col_offset": 10
-              },
-              "attr": "order",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 7,
-              "end_col_offset": 16
-            },
-            "orelse": [
-              {
-                "_type": "Expr",
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "print",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 34,
-                    "end_lineno": 34,
-                    "col_offset": 8,
-                    "end_col_offset": 13
-                  },
-                  "args": [
-                    {
-                      "_type": "Constant",
-                      "value": "Customer",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 14,
-                      "end_col_offset": 24
-                    },
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "row",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 34,
-                          "end_lineno": 34,
-                          "col_offset": 26,
-                          "end_col_offset": 29
-                        },
-                        "attr": "customer",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 34,
-                        "end_lineno": 34,
-                        "col_offset": 26,
-                        "end_col_offset": 38
-                      },
-                      "attr": "name",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 26,
-                      "end_col_offset": 43
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "has no orders",
-                      "kind": null,
-                      "lineno": 34,
-                      "end_lineno": 34,
-                      "col_offset": 45,
-                      "end_col_offset": 60
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 34,
-                  "end_lineno": 34,
-                  "col_offset": 8,
-                  "end_col_offset": 61
-                },
-                "lineno": 34,
-                "end_lineno": 34,
-                "col_offset": 8,
-                "end_col_offset": 61
-              }
-            ],
-            "lineno": 28,
-            "end_lineno": 34,
-            "col_offset": 4,
-            "end_col_offset": 61
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "row",
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 4,
-          "end_col_offset": 7
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 11,
-          "end_col_offset": 17
-        },
-        "lineno": 27,
-        "end_lineno": 34,
-        "end_col_offset": 61
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 347,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 347,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 347,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 326,
+                    "end": 346,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 326,
+                        "end": 334
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 334,
+                        "end": 346,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 335,
+                            "end": 336
+                          },
+                          {
+                            "kind": "string",
+                            "start": 338,
+                            "end": 345,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 338,
+                                "end": 339
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 339,
+                                "end": 344
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 344,
+                                "end": 345
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 348,
+        "end": 418,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 348,
+            "end": 358,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 349,
+                "end": 358
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 359,
+            "end": 418,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 365,
+                "end": 370
+              },
+              {
+                "kind": "block",
+                "start": 376,
+                "end": 418,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 376,
+                    "end": 383,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 376,
+                        "end": 383,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 376,
+                            "end": 378
+                          },
+                          {
+                            "kind": "type",
+                            "start": 380,
+                            "end": 383,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 380,
+                                "end": 383
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 388,
+                    "end": 403,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 388,
+                        "end": 403,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 388,
+                            "end": 398
+                          },
+                          {
+                            "kind": "type",
+                            "start": 400,
+                            "end": 403,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 400,
+                                "end": 403
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 408,
+                    "end": 418,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 408,
+                        "end": 418,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 408,
+                            "end": 413
+                          },
+                          {
+                            "kind": "type",
+                            "start": 415,
+                            "end": 418,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 415,
+                                "end": 418
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 420,
+        "end": 508,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 420,
+            "end": 508,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 420,
+                "end": 426
+              },
+              {
+                "kind": "list",
+                "start": 429,
+                "end": 508,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 430,
+                    "end": 448,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 430,
+                        "end": 435
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 435,
+                        "end": 448,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 436,
+                            "end": 439
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 441,
+                            "end": 442
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 444,
+                            "end": 447
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 450,
+                    "end": 468,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 450,
+                        "end": 455
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 455,
+                        "end": 468,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 456,
+                            "end": 459
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 461,
+                            "end": 462
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 464,
+                            "end": 467
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 470,
+                    "end": 488,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 470,
+                        "end": 475
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 475,
+                        "end": 488,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 476,
+                            "end": 479
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 481,
+                            "end": 482
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 484,
+                            "end": 487
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 490,
+                    "end": 507,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 490,
+                        "end": 495
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 495,
+                        "end": 507,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 496,
+                            "end": 499
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 501,
+                            "end": 502
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 504,
+                            "end": 506
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 509,
+        "end": 566,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 509,
+            "end": 519,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 510,
+                "end": 519
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 520,
+            "end": 566,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 526,
+                "end": 532
+              },
+              {
+                "kind": "block",
+                "start": 538,
+                "end": 566,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 538,
+                    "end": 548,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 538,
+                        "end": 548,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 538,
+                            "end": 543
+                          },
+                          {
+                            "kind": "type",
+                            "start": 545,
+                            "end": 548,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 545,
+                                "end": 548
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 553,
+                    "end": 566,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 553,
+                        "end": 566,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 553,
+                            "end": 561
+                          },
+                          {
+                            "kind": "type",
+                            "start": 563,
+                            "end": 566,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 563,
+                                "end": 566
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 568,
+        "end": 866,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 568,
+            "end": 866,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 568,
+                "end": 574
+              },
+              {
+                "kind": "binary_operator",
+                "start": 577,
+                "end": 866,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 577,
+                    "end": 758,
+                    "children": [
+                      {
+                        "kind": "list_comprehension",
+                        "start": 577,
+                        "end": 650,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 578,
+                            "end": 590,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 578,
+                                "end": 584
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 584,
+                                "end": 590,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 585,
+                                    "end": 586
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 588,
+                                    "end": 589
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_in_clause",
+                            "start": 591,
+                            "end": 606,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 595,
+                                "end": 596
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 600,
+                                "end": 606
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_in_clause",
+                            "start": 607,
+                            "end": 625,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 611,
+                                "end": 612
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 616,
+                                "end": 625
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "if_clause",
+                            "start": 626,
+                            "end": 649,
+                            "children": [
+                              {
+                                "kind": "comparison_operator",
+                                "start": 629,
+                                "end": 649,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 629,
+                                    "end": 641,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 629,
+                                        "end": 630
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 631,
+                                        "end": 641
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 645,
+                                    "end": 649,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 645,
+                                        "end": 646
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 647,
+                                        "end": 649
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "list_comprehension",
+                        "start": 653,
+                        "end": 758,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 654,
+                            "end": 687,
+                            "children": [
+                              {
+                                "kind": "parenthesized_expression",
+                                "start": 654,
+                                "end": 681,
+                                "children": [
+                                  {
+                                    "kind": "lambda",
+                                    "start": 655,
+                                    "end": 680,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 662,
+                                        "end": 663,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 662,
+                                            "end": 663
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 665,
+                                        "end": 680,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 665,
+                                            "end": 671
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 671,
+                                            "end": 680,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 672,
+                                                "end": 673
+                                              },
+                                              {
+                                                "kind": "none",
+                                                "start": 675,
+                                                "end": 679
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 681,
+                                "end": 687,
+                                "children": [
+                                  {
+                                    "kind": "none",
+                                    "start": 682,
+                                    "end": 686
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_in_clause",
+                            "start": 688,
+                            "end": 703,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 692,
+                                "end": 693
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 697,
+                                "end": 703
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "if_clause",
+                            "start": 704,
+                            "end": 757,
+                            "children": [
+                              {
+                                "kind": "not_operator",
+                                "start": 707,
+                                "end": 757,
+                                "children": [
+                                  {
+                                    "kind": "call",
+                                    "start": 711,
+                                    "end": 757,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 711,
+                                        "end": 714
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 714,
+                                        "end": 757,
+                                        "children": [
+                                          {
+                                            "kind": "list_comprehension",
+                                            "start": 715,
+                                            "end": 756,
+                                            "children": [
+                                              {
+                                                "kind": "comparison_operator",
+                                                "start": 716,
+                                                "end": 736,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 716,
+                                                    "end": 728,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 716,
+                                                        "end": 717
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 718,
+                                                        "end": 728
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 732,
+                                                    "end": 736,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 732,
+                                                        "end": 733
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 734,
+                                                        "end": 736
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "for_in_clause",
+                                                "start": 737,
+                                                "end": 755,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 741,
+                                                    "end": 742
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 746,
+                                                    "end": 755
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "list_comprehension",
+                    "start": 761,
+                    "end": 866,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 762,
+                        "end": 795,
+                        "children": [
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 762,
+                            "end": 789,
+                            "children": [
+                              {
+                                "kind": "lambda",
+                                "start": 763,
+                                "end": 788,
+                                "children": [
+                                  {
+                                    "kind": "lambda_parameters",
+                                    "start": 770,
+                                    "end": 771,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 770,
+                                        "end": 771
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "call",
+                                    "start": 773,
+                                    "end": 788,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 773,
+                                        "end": 779
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 779,
+                                        "end": 788,
+                                        "children": [
+                                          {
+                                            "kind": "none",
+                                            "start": 780,
+                                            "end": 784
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 786,
+                                            "end": 787
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 789,
+                            "end": 795,
+                            "children": [
+                              {
+                                "kind": "none",
+                                "start": 790,
+                                "end": 794
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 796,
+                        "end": 814,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 800,
+                            "end": 801
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 805,
+                            "end": 814
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 815,
+                        "end": 865,
+                        "children": [
+                          {
+                            "kind": "not_operator",
+                            "start": 818,
+                            "end": 865,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 822,
+                                "end": 865,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 822,
+                                    "end": 825
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 825,
+                                    "end": 865,
+                                    "children": [
+                                      {
+                                        "kind": "list_comprehension",
+                                        "start": 826,
+                                        "end": 864,
+                                        "children": [
+                                          {
+                                            "kind": "comparison_operator",
+                                            "start": 827,
+                                            "end": 847,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 827,
+                                                "end": 839,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 827,
+                                                    "end": 828
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 829,
+                                                    "end": 839
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 843,
+                                                "end": 847,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 843,
+                                                    "end": 844
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 845,
+                                                    "end": 847
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "for_in_clause",
+                                            "start": 848,
+                                            "end": 863,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 852,
+                                                "end": 853
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 857,
+                                                "end": 863
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 867,
+        "end": 907,
+        "children": [
+          {
+            "kind": "call",
+            "start": 867,
+            "end": 907,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 867,
+                "end": 872
+              },
+              {
+                "kind": "argument_list",
+                "start": 872,
+                "end": 907,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 873,
+                    "end": 906,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 873,
+                        "end": 874
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 874,
+                        "end": 905
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 905,
+                        "end": 906
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 908,
+        "end": 1227,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 912,
+            "end": 915
+          },
+          {
+            "kind": "identifier",
+            "start": 919,
+            "end": 925
+          },
+          {
+            "kind": "block",
+            "start": 931,
+            "end": 1227,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 931,
+                "end": 1227,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 934,
+                    "end": 943,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 934,
+                        "end": 937
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 938,
+                        "end": 943
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 953,
+                    "end": 1155,
+                    "children": [
+                      {
+                        "kind": "if_statement",
+                        "start": 953,
+                        "end": 1155,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 956,
+                            "end": 968,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 956,
+                                "end": 959
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 960,
+                                "end": 968
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "block",
+                            "start": 982,
+                            "end": 1059,
+                            "children": [
+                              {
+                                "kind": "expression_statement",
+                                "start": 982,
+                                "end": 1059,
+                                "children": [
+                                  {
+                                    "kind": "call",
+                                    "start": 982,
+                                    "end": 1059,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 982,
+                                        "end": 987
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 987,
+                                        "end": 1059,
+                                        "children": [
+                                          {
+                                            "kind": "string",
+                                            "start": 988,
+                                            "end": 995,
+                                            "children": [
+                                              {
+                                                "kind": "string_start",
+                                                "start": 988,
+                                                "end": 989
+                                              },
+                                              {
+                                                "kind": "string_content",
+                                                "start": 989,
+                                                "end": 994
+                                              },
+                                              {
+                                                "kind": "string_end",
+                                                "start": 994,
+                                                "end": 995
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 997,
+                                            "end": 1009,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 997,
+                                                "end": 1006,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 997,
+                                                    "end": 1000
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1001,
+                                                    "end": 1006
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1007,
+                                                "end": 1009
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "string",
+                                            "start": 1011,
+                                            "end": 1015,
+                                            "children": [
+                                              {
+                                                "kind": "string_start",
+                                                "start": 1011,
+                                                "end": 1012
+                                              },
+                                              {
+                                                "kind": "string_content",
+                                                "start": 1012,
+                                                "end": 1014
+                                              },
+                                              {
+                                                "kind": "string_end",
+                                                "start": 1014,
+                                                "end": 1015
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 1017,
+                                            "end": 1034,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1017,
+                                                "end": 1029,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1017,
+                                                    "end": 1020
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1021,
+                                                    "end": 1029
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1030,
+                                                "end": 1034
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "string",
+                                            "start": 1036,
+                                            "end": 1041,
+                                            "children": [
+                                              {
+                                                "kind": "string_start",
+                                                "start": 1036,
+                                                "end": 1037
+                                              },
+                                              {
+                                                "kind": "string_content",
+                                                "start": 1037,
+                                                "end": 1040
+                                              },
+                                              {
+                                                "kind": "string_end",
+                                                "start": 1040,
+                                                "end": 1041
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 1043,
+                                            "end": 1058,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1043,
+                                                "end": 1052,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1043,
+                                                    "end": 1046
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1047,
+                                                    "end": 1052
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1053,
+                                                "end": 1058
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "else_clause",
+                            "start": 1068,
+                            "end": 1155,
+                            "children": [
+                              {
+                                "kind": "block",
+                                "start": 1086,
+                                "end": 1155,
+                                "children": [
+                                  {
+                                    "kind": "expression_statement",
+                                    "start": 1086,
+                                    "end": 1155,
+                                    "children": [
+                                      {
+                                        "kind": "call",
+                                        "start": 1086,
+                                        "end": 1155,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1086,
+                                            "end": 1091
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 1091,
+                                            "end": 1155,
+                                            "children": [
+                                              {
+                                                "kind": "string",
+                                                "start": 1092,
+                                                "end": 1099,
+                                                "children": [
+                                                  {
+                                                    "kind": "string_start",
+                                                    "start": 1092,
+                                                    "end": 1093
+                                                  },
+                                                  {
+                                                    "kind": "string_content",
+                                                    "start": 1093,
+                                                    "end": 1098
+                                                  },
+                                                  {
+                                                    "kind": "string_end",
+                                                    "start": 1098,
+                                                    "end": 1099
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1101,
+                                                "end": 1113,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 1101,
+                                                    "end": 1110,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1101,
+                                                        "end": 1104
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1105,
+                                                        "end": 1110
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1111,
+                                                    "end": 1113
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "string",
+                                                "start": 1115,
+                                                "end": 1119,
+                                                "children": [
+                                                  {
+                                                    "kind": "string_start",
+                                                    "start": 1115,
+                                                    "end": 1116
+                                                  },
+                                                  {
+                                                    "kind": "string_content",
+                                                    "start": 1116,
+                                                    "end": 1118
+                                                  },
+                                                  {
+                                                    "kind": "string_end",
+                                                    "start": 1118,
+                                                    "end": 1119
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "string",
+                                                "start": 1121,
+                                                "end": 1130,
+                                                "children": [
+                                                  {
+                                                    "kind": "string_start",
+                                                    "start": 1121,
+                                                    "end": 1122
+                                                  },
+                                                  {
+                                                    "kind": "string_content",
+                                                    "start": 1122,
+                                                    "end": 1129
+                                                  },
+                                                  {
+                                                    "kind": "string_end",
+                                                    "start": 1129,
+                                                    "end": 1130
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "string",
+                                                "start": 1132,
+                                                "end": 1137,
+                                                "children": [
+                                                  {
+                                                    "kind": "string_start",
+                                                    "start": 1132,
+                                                    "end": 1133
+                                                  },
+                                                  {
+                                                    "kind": "string_content",
+                                                    "start": 1133,
+                                                    "end": 1136
+                                                  },
+                                                  {
+                                                    "kind": "string_end",
+                                                    "start": 1136,
+                                                    "end": 1137
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 1139,
+                                                "end": 1154,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 1139,
+                                                    "end": 1148,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1139,
+                                                        "end": 1142
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 1143,
+                                                        "end": 1148
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 1149,
+                                                    "end": 1154
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "else_clause",
+                    "start": 1160,
+                    "end": 1227,
+                    "children": [
+                      {
+                        "kind": "block",
+                        "start": 1174,
+                        "end": 1227,
+                        "children": [
+                          {
+                            "kind": "expression_statement",
+                            "start": 1174,
+                            "end": 1227,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 1174,
+                                "end": 1227,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 1174,
+                                    "end": 1179
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 1179,
+                                    "end": 1227,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 1180,
+                                        "end": 1190,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 1180,
+                                            "end": 1181
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1181,
+                                            "end": 1189
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 1189,
+                                            "end": 1190
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 1192,
+                                        "end": 1209,
+                                        "children": [
+                                          {
+                                            "kind": "attribute",
+                                            "start": 1192,
+                                            "end": 1204,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1192,
+                                                "end": 1195
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 1196,
+                                                "end": 1204
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 1205,
+                                            "end": 1209
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 1211,
+                                        "end": 1226,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 1211,
+                                            "end": 1212
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 1212,
+                                            "end": 1225
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 1225,
+                                            "end": 1226
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/partial_application.py.json
+++ b/tests/json-ast/x/py/partial_application.py.json
@@ -1,226 +1,195 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 167,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "add",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "a",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 12
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 15,
-                "end_col_offset": 16
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 11,
-              "end_col_offset": 16
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 16
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "a",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "arg",
-              "arg": "b",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "add5",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Lambda",
-          "args": {
-            "_type": "arguments",
-            "posonlyargs": [],
-            "args": [
-              {
-                "_type": "arg",
-                "arg": "b",
-                "annotation": null,
-                "type_comment": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 14,
-                "end_col_offset": 15
-              }
-            ],
-            "vararg": null,
-            "kwonlyargs": [],
-            "kw_defaults": [],
-            "kwarg": null,
-            "defaults": []
-          },
-          "body": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "add",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 17,
-              "end_col_offset": 20
-            },
-            "args": [
-              {
-                "_type": "Constant",
-                "value": 5,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 21,
-                "end_col_offset": 22
-              },
-              {
-                "_type": "Name",
-                "id": "b",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 24,
-                "end_col_offset": 25
-              }
-            ],
-            "keywords": [],
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 17,
-            "end_col_offset": 26
-          },
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 7,
-          "end_col_offset": 26
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 26
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "function_definition",
+        "start": 93,
+        "end": 124,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 100
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "add5",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 10
+          {
+            "kind": "parameters",
+            "start": 100,
+            "end": 106,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 101,
+                "end": 102
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 13
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 14
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 14
+              {
+                "kind": "identifier",
+                "start": 104,
+                "end": 105
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 112,
+            "end": 124,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 112,
+                "end": 124,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 119,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 119,
+                        "end": 120
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 123,
+                        "end": 124
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 125,
+        "end": 151,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 125,
+            "end": 151,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 125,
+                "end": 129
+              },
+              {
+                "kind": "lambda",
+                "start": 132,
+                "end": 151,
+                "children": [
+                  {
+                    "kind": "lambda_parameters",
+                    "start": 139,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 139,
+                        "end": 140
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 142,
+                    "end": 151,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 142,
+                        "end": 145
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 145,
+                        "end": 151,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 146,
+                            "end": 147
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 149,
+                            "end": 150
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 152,
+        "end": 166,
+        "children": [
+          {
+            "kind": "call",
+            "start": 152,
+            "end": 166,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 157
+              },
+              {
+                "kind": "argument_list",
+                "start": 157,
+                "end": 166,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 158,
+                    "end": 165,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 158,
+                        "end": 162
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 162,
+                        "end": 165,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 163,
+                            "end": 164
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/print_hello.py.json
+++ b/tests/json-ast/x/py/print_hello.py.json
@@ -1,42 +1,66 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 108,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "hello",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 13
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 14
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 14
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 107,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
+              },
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 99,
+                    "end": 106,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 99,
+                        "end": 100
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 100,
+                        "end": 105
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 105,
+                        "end": 106
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/pure_fold.py.json
+++ b/tests/json-ast/x/py/pure_fold.py.json
@@ -1,149 +1,135 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 146,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "triple",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 11,
-                "end_col_offset": 12
-              },
-              "op": {
-                "_type": "Mult"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 3,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 15,
-                "end_col_offset": 16
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 11,
-              "end_col_offset": 16
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 16
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "x",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 4,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 124,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 103
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "triple",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 12
+          {
+            "kind": "parameters",
+            "start": 103,
+            "end": 106,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 104,
+                "end": 105
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 112,
+            "end": 124,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 112,
+                "end": 124,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 119,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 119,
+                        "end": 120
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 123,
+                        "end": 124
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 125,
+        "end": 145,
+        "children": [
+          {
+            "kind": "call",
+            "start": 125,
+            "end": 145,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 125,
+                "end": 130
               },
-              "args": [
-                {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 13,
-                  "end_col_offset": 18
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 19
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 20
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 20
+              {
+                "kind": "argument_list",
+                "start": 130,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 131,
+                    "end": 144,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 131,
+                        "end": 137
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 137,
+                        "end": 144,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 138,
+                            "end": 143,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 138,
+                                "end": 139
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 142,
+                                "end": 143
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/pure_global_fold.py.json
+++ b/tests/json-ast/x/py/pure_global_fold.py.json
@@ -1,156 +1,147 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 142,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "k",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "FunctionDef",
-        "name": "inc",
-        "body": [
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "x",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 11,
-                "end_col_offset": 12
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Name",
-                "id": "k",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 15,
-                "end_col_offset": 16
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 11,
-              "end_col_offset": 16
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 16
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "x",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 8,
-              "end_col_offset": 9
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 4,
-        "end_lineno": 5,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_definition",
+        "start": 99,
+        "end": 127,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 103,
+            "end": 106
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "inc",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 9
+          {
+            "kind": "parameters",
+            "start": 106,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 107,
+                "end": 108
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 115,
+            "end": 127,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 115,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 122,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 122,
+                        "end": 123
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 126,
+                        "end": 127
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 128,
+        "end": 141,
+        "children": [
+          {
+            "kind": "call",
+            "start": 128,
+            "end": 141,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 128,
+                "end": 133
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 13
+              {
+                "kind": "argument_list",
+                "start": 133,
+                "end": 141,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 134,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 134,
+                        "end": 137
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 137,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 138,
+                            "end": 139
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/python_auto.py.json
+++ b/tests/json-ast/x/py/python_auto.py.json
@@ -1,129 +1,142 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 144,
+    "children": [
       {
-        "_type": "Import",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "math",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "attr": "sqrt",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 16.0,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 16,
-                  "end_col_offset": 20
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 21
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 22
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 22
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "math",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 6,
-                "end_col_offset": 10
+        "kind": "import_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 100,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 100,
+                "end": 104
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 128,
+        "children": [
+          {
+            "kind": "call",
+            "start": 106,
+            "end": 128,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 111
               },
-              "attr": "pi",
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "argument_list",
+                "start": 111,
+                "end": 128,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 112,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 112,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 112,
+                            "end": 116
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 117,
+                            "end": 121
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 121,
+                        "end": 127,
+                        "children": [
+                          {
+                            "kind": "float",
+                            "start": 122,
+                            "end": 126
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 129,
+        "end": 143,
+        "children": [
+          {
+            "kind": "call",
+            "start": 129,
+            "end": 143,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 129,
+                "end": 134
               },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 13
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 14
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 14
+              {
+                "kind": "argument_list",
+                "start": 134,
+                "end": 143,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 135,
+                    "end": 142,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 135,
+                        "end": 139
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 140,
+                        "end": 142
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/python_math.py.json
+++ b/tests/json-ast/x/py/python_math.py.json
@@ -1,556 +1,585 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 358,
+    "children": [
       {
-        "_type": "Import",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "r",
-            "lineno": 5,
-            "end_lineno": 5,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 3.0,
-          "kind": null,
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 4,
-          "end_col_offset": 7
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "area",
-            "lineno": 6,
-            "end_lineno": 6,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "math",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 11
-            },
-            "attr": "pi",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 7,
-            "end_col_offset": 14
-          },
-          "op": {
-            "_type": "Mult"
-          },
-          "right": {
-            "_type": "Call",
-            "func": {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "math",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              "attr": "pow",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 17,
-              "end_col_offset": 25
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 100,
+            "end": 104,
+            "children": [
               {
-                "_type": "Name",
-                "id": "r",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              {
-                "_type": "Constant",
-                "value": 2.0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 29,
-                "end_col_offset": 32
+                "kind": "identifier",
+                "start": 100,
+                "end": 104
               }
-            ],
-            "keywords": [],
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 17,
-            "end_col_offset": 33
-          },
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 7,
-          "end_col_offset": 33
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 33
+            ]
+          }
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 106,
+        "end": 113,
+        "children": [
           {
-            "_type": "Name",
-            "id": "root",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "math",
-              "ctx": {
-                "_type": "Load"
+            "kind": "assignment",
+            "start": 106,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 106,
+                "end": 107
               },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 11
-            },
-            "attr": "sqrt",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 7,
-            "end_col_offset": 16
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 49.0,
-              "kind": null,
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 17,
-              "end_col_offset": 21
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 7,
-          "end_col_offset": 22
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 22
+              {
+                "kind": "float",
+                "start": 110,
+                "end": 113
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 114,
+        "end": 147,
+        "children": [
           {
-            "_type": "Name",
-            "id": "sin45",
-            "lineno": 8,
-            "end_lineno": 8,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "math",
-              "ctx": {
-                "_type": "Load"
+            "kind": "assignment",
+            "start": 114,
+            "end": 147,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 114,
+                "end": 118
               },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 8,
-              "end_col_offset": 12
-            },
-            "attr": "sin",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 8,
-            "end_col_offset": 16
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "math",
-                  "ctx": {
-                    "_type": "Load"
+              {
+                "kind": "binary_operator",
+                "start": 121,
+                "end": 147,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 121,
+                    "end": 128,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 121,
+                        "end": 125
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 126,
+                        "end": 128
+                      }
+                    ]
                   },
-                  "lineno": 8,
-                  "end_lineno": 8,
-                  "col_offset": 17,
-                  "end_col_offset": 21
-                },
-                "attr": "pi",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 17,
-                "end_col_offset": 24
-              },
-              "op": {
-                "_type": "Div"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 4.0,
-                "kind": null,
-                "lineno": 8,
-                "end_lineno": 8,
-                "col_offset": 27,
-                "end_col_offset": 30
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 17,
-              "end_col_offset": 30
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 8,
-          "end_col_offset": 31
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 31
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "log_e",
-            "lineno": 9,
-            "end_lineno": 9,
-            "end_col_offset": 5
+                  {
+                    "kind": "call",
+                    "start": 131,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 131,
+                        "end": 139,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 131,
+                            "end": 135
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 136,
+                            "end": 139
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 139,
+                        "end": 147,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 140,
+                            "end": 141
+                          },
+                          {
+                            "kind": "float",
+                            "start": 143,
+                            "end": 146
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "math",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 12
-            },
-            "attr": "log",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 8,
-            "end_col_offset": 16
-          },
-          "args": [
-            {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "math",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 9,
-                "end_lineno": 9,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              "attr": "e",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 17,
-              "end_col_offset": 23
-            }
-          ],
-          "keywords": [],
-          "lineno": 9,
-          "end_lineno": 9,
-          "col_offset": 8,
-          "end_col_offset": 24
-        },
-        "lineno": 9,
-        "end_lineno": 9,
-        "end_col_offset": 24
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "Circle area with r =",
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 6,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Name",
-              "id": "r",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 148,
+        "end": 170,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 148,
+            "end": 170,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 148,
+                "end": 152
               },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 30,
-              "end_col_offset": 31
-            },
-            {
-              "_type": "Constant",
-              "value": "=\u003e",
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 33,
-              "end_col_offset": 37
-            },
-            {
-              "_type": "Name",
-              "id": "area",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 39,
-              "end_col_offset": 43
-            }
-          ],
-          "keywords": [],
-          "lineno": 10,
-          "end_lineno": 10,
-          "col_offset": 0,
-          "end_col_offset": 44
-        },
-        "lineno": 10,
-        "end_lineno": 10,
-        "end_col_offset": 44
+              {
+                "kind": "call",
+                "start": 155,
+                "end": 170,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 155,
+                    "end": 164,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 155,
+                        "end": 159
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 160,
+                        "end": 164
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 164,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "float",
+                        "start": 165,
+                        "end": 169
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "Square root of 49:",
-              "kind": null,
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 6,
-              "end_col_offset": 26
-            },
-            {
-              "_type": "Name",
-              "id": "root",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 171,
+        "end": 202,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 171,
+            "end": 202,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 171,
+                "end": 176
               },
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 28,
-              "end_col_offset": 32
-            }
-          ],
-          "keywords": [],
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 0,
-          "end_col_offset": 33
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 33
+              {
+                "kind": "call",
+                "start": 179,
+                "end": 202,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 179,
+                    "end": 187,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 179,
+                        "end": 183
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 184,
+                        "end": 187
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 187,
+                    "end": 202,
+                    "children": [
+                      {
+                        "kind": "binary_operator",
+                        "start": 188,
+                        "end": 201,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 188,
+                            "end": 195,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 188,
+                                "end": 192
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 193,
+                                "end": 195
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "float",
+                            "start": 198,
+                            "end": 201
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "sin(\u03c0/4):",
-              "kind": null,
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 6,
-              "end_col_offset": 18
-            },
-            {
-              "_type": "Name",
-              "id": "sin45",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 203,
+        "end": 227,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 203,
+            "end": 227,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 203,
+                "end": 208
               },
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 20,
-              "end_col_offset": 25
-            }
-          ],
-          "keywords": [],
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 0,
-          "end_col_offset": 26
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 26
+              {
+                "kind": "call",
+                "start": 211,
+                "end": 227,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 211,
+                    "end": 219,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 211,
+                        "end": 215
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 216,
+                        "end": 219
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 219,
+                    "end": 227,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 220,
+                        "end": 226,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 220,
+                            "end": 224
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 225,
+                            "end": 226
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "log(e):",
-              "kind": null,
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 6,
-              "end_col_offset": 15
-            },
-            {
-              "_type": "Name",
-              "id": "log_e",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 228,
+        "end": 272,
+        "children": [
+          {
+            "kind": "call",
+            "start": 228,
+            "end": 272,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 228,
+                "end": 233
               },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 17,
-              "end_col_offset": 22
-            }
-          ],
-          "keywords": [],
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 0,
-          "end_col_offset": 23
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 23
+              {
+                "kind": "argument_list",
+                "start": 233,
+                "end": 272,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 234,
+                    "end": 256,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 234,
+                        "end": 235
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 235,
+                        "end": 255
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 255,
+                        "end": 256
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 258,
+                    "end": 259
+                  },
+                  {
+                    "kind": "string",
+                    "start": 261,
+                    "end": 265,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 261,
+                        "end": 262
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 262,
+                        "end": 264
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 264,
+                        "end": 265
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 267,
+                    "end": 271
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 273,
+        "end": 306,
+        "children": [
+          {
+            "kind": "call",
+            "start": 273,
+            "end": 306,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 273,
+                "end": 278
+              },
+              {
+                "kind": "argument_list",
+                "start": 278,
+                "end": 306,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 279,
+                    "end": 299,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 279,
+                        "end": 280
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 280,
+                        "end": 298
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 298,
+                        "end": 299
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 301,
+                    "end": 305
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 307,
+        "end": 333,
+        "children": [
+          {
+            "kind": "call",
+            "start": 307,
+            "end": 333,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 307,
+                "end": 312
+              },
+              {
+                "kind": "argument_list",
+                "start": 312,
+                "end": 333,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 313,
+                    "end": 325,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 313,
+                        "end": 314
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 314,
+                        "end": 324
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 324,
+                        "end": 325
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 327,
+                    "end": 332
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 334,
+        "end": 357,
+        "children": [
+          {
+            "kind": "call",
+            "start": 334,
+            "end": 357,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 334,
+                "end": 339
+              },
+              {
+                "kind": "argument_list",
+                "start": 339,
+                "end": 357,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 340,
+                    "end": 349,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 340,
+                        "end": 341
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 341,
+                        "end": 348
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 348,
+                        "end": 349
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 351,
+                    "end": 356
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/query_sum_select.py.json
+++ b/tests/json-ast/x/py/query_sum_select.py.json
@@ -1,216 +1,181 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 165,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "nums",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 12
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 14,
-              "end_col_offset": 15
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 7,
-          "end_col_offset": 16
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 16
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "sum",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 9,
-            "end_col_offset": 12
-          },
-          "args": [
-            {
-              "_type": "GeneratorExp",
-              "elt": {
-                "_type": "Name",
-                "id": "n",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "generators": [
-                {
-                  "_type": "comprehension",
-                  "target": {
-                    "_type": "Name",
-                    "id": "n",
-                    "ctx": {
-                      "_type": "Store"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 20,
-                    "end_col_offset": 21
-                  },
-                  "iter": {
-                    "_type": "Name",
-                    "id": "nums",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 25,
-                    "end_col_offset": 29
-                  },
-                  "ifs": [
-                    {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "Name",
-                        "id": "n",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 4,
-                        "end_lineno": 4,
-                        "col_offset": 33,
-                        "end_col_offset": 34
-                      },
-                      "ops": [
-                        {
-                          "_type": "Gt"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Constant",
-                          "value": 1,
-                          "kind": null,
-                          "lineno": 4,
-                          "end_lineno": 4,
-                          "col_offset": 37,
-                          "end_col_offset": 38
-                        }
-                      ],
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 33,
-                      "end_col_offset": 38
-                    }
-                  ],
-                  "is_async": 0
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 13,
-              "end_col_offset": 39
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 9,
-          "end_col_offset": 40
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 40
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "result",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 109,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 109,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 97
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 13
+              {
+                "kind": "list",
+                "start": 100,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 101,
+                    "end": 102
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 104,
+                    "end": 105
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 107,
+                    "end": 108
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 110,
+        "end": 150,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 110,
+            "end": 150,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 110,
+                "end": 116
+              },
+              {
+                "kind": "call",
+                "start": 119,
+                "end": 150,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 119,
+                    "end": 122
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 122,
+                    "end": 150,
+                    "children": [
+                      {
+                        "kind": "generator_expression",
+                        "start": 123,
+                        "end": 149,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 124,
+                            "end": 125
+                          },
+                          {
+                            "kind": "for_in_clause",
+                            "start": 126,
+                            "end": 139,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 130,
+                                "end": 131
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 135,
+                                "end": 139
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "if_clause",
+                            "start": 140,
+                            "end": 148,
+                            "children": [
+                              {
+                                "kind": "comparison_operator",
+                                "start": 143,
+                                "end": 148,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 143,
+                                    "end": 144
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 147,
+                                    "end": 148
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 151,
+        "end": 164,
+        "children": [
+          {
+            "kind": "call",
+            "start": 151,
+            "end": 164,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 151,
+                "end": 156
+              },
+              {
+                "kind": "argument_list",
+                "start": 156,
+                "end": 164,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 157,
+                    "end": 163
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/record_assign.py.json
+++ b/tests/json-ast/x/py/record_assign.py.json
@@ -1,353 +1,455 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 339,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Counter",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 10
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 10,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "FunctionDef",
-        "name": "inc",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "c",
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 4,
-                "end_col_offset": 5
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "dataclasses",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 8,
-                  "end_col_offset": 19
-                },
-                "attr": "replace",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 8,
-                "end_col_offset": 27
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 28,
-                  "end_col_offset": 29
-                }
-              ],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "n",
-                  "value": {
-                    "_type": "BinOp",
-                    "left": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "c",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 13,
-                        "end_lineno": 13,
-                        "col_offset": 33,
-                        "end_col_offset": 34
-                      },
-                      "attr": "n",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 33,
-                      "end_col_offset": 36
-                    },
-                    "op": {
-                      "_type": "Add"
-                    },
-                    "right": {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 39,
-                      "end_col_offset": 40
-                    },
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 33,
-                    "end_col_offset": 40
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 31,
-                  "end_col_offset": 40
-                }
-              ],
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 8,
-              "end_col_offset": 41
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 4,
-            "end_col_offset": 41
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "c",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 8,
-              "end_col_offset": 9
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 12,
-        "end_lineno": 13,
-        "end_col_offset": 41
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "Name",
-            "id": "c",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 1
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "Counter",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          "args": [],
-          "keywords": [
-            {
-              "_type": "keyword",
-              "arg": "n",
-              "value": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 14,
-                "end_col_offset": 15
-              },
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 12,
-              "end_col_offset": 15
-            }
-          ],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 4,
-          "end_col_offset": 16
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 16
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "inc",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 0,
-            "end_col_offset": 3
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "c",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 5
-            }
-          ],
-          "keywords": [],
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 0,
-          "end_col_offset": 6
-        },
-        "lineno": 15,
-        "end_lineno": 15,
-        "end_col_offset": 6
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 212,
+        "end": 248,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 212,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 213,
+                "end": 222
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 6,
-                "end_col_offset": 7
+          {
+            "kind": "class_definition",
+            "start": 223,
+            "end": 248,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 229,
+                "end": 236
               },
-              "attr": "n",
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "block",
+                "start": 242,
+                "end": 248,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 242,
+                    "end": 248,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 242,
+                        "end": 248,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 242,
+                            "end": 243
+                          },
+                          {
+                            "kind": "type",
+                            "start": 245,
+                            "end": 248,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 245,
+                                "end": 248
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_definition",
+        "start": 250,
+        "end": 303,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 254,
+            "end": 257
+          },
+          {
+            "kind": "parameters",
+            "start": 257,
+            "end": 260,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 258,
+                "end": 259
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 266,
+            "end": 303,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 266,
+                "end": 303,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 266,
+                    "end": 303,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 266,
+                        "end": 267
+                      },
+                      {
+                        "kind": "call",
+                        "start": 270,
+                        "end": 303,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 270,
+                            "end": 289,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 270,
+                                "end": 281
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 282,
+                                "end": 289
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 289,
+                            "end": 303,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 290,
+                                "end": 291
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 293,
+                                "end": 302,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 293,
+                                    "end": 294
+                                  },
+                                  {
+                                    "kind": "binary_operator",
+                                    "start": 295,
+                                    "end": 302,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 295,
+                                        "end": 298,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 295,
+                                            "end": 296
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 297,
+                                            "end": 298
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 301,
+                                        "end": 302
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 304,
+        "end": 320,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 304,
+            "end": 320,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 304,
+                "end": 305
               },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 6,
-              "end_col_offset": 9
-            }
-          ],
-          "keywords": [],
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 0,
-          "end_col_offset": 10
-        },
-        "lineno": 16,
-        "end_lineno": 16,
-        "end_col_offset": 10
+              {
+                "kind": "call",
+                "start": 308,
+                "end": 320,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 308,
+                    "end": 315
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 315,
+                    "end": 320,
+                    "children": [
+                      {
+                        "kind": "keyword_argument",
+                        "start": 316,
+                        "end": 319,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 316,
+                            "end": 317
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 318,
+                            "end": 319
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 321,
+        "end": 327,
+        "children": [
+          {
+            "kind": "call",
+            "start": 321,
+            "end": 327,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 321,
+                "end": 324
+              },
+              {
+                "kind": "argument_list",
+                "start": 324,
+                "end": 327,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 325,
+                    "end": 326
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 328,
+        "end": 338,
+        "children": [
+          {
+            "kind": "call",
+            "start": 328,
+            "end": 338,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 328,
+                "end": 333
+              },
+              {
+                "kind": "argument_list",
+                "start": 333,
+                "end": 338,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 334,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 334,
+                        "end": 335
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 336,
+                        "end": 337
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/right_join.py.json
+++ b/tests/json-ast/x/py/right_join.py.json
@@ -1,1355 +1,1503 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 1005,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 79,
-                "end_col_offset": 87
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 88,
-                  "end_col_offset": 89
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Diana",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 91,
-                  "end_col_offset": 98
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 79,
-              "end_col_offset": 99
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 100
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 100
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 125,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 50,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 64,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 50,
-              "end_col_offset": 68
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 69
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 69
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 18,
-              "end_col_offset": 21
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerName",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 16
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 21
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "any",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "order",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 23,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 25,
-            "end_lineno": 25,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "ListComp",
-            "elt": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Result",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "c",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  },
-                  "attr": "name",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 17,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 25,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 10,
-              "end_col_offset": 27
-            },
-            "generators": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "comprehension",
-                "target": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Store"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 32,
-                  "end_col_offset": 33
-                },
-                "iter": {
-                  "_type": "Name",
-                  "id": "orders",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 37,
-                  "end_col_offset": 43
-                },
-                "ifs": [],
-                "is_async": 0
-              },
-              {
-                "_type": "comprehension",
-                "target": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Store"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 48,
-                  "end_col_offset": 49
-                },
-                "iter": {
-                  "_type": "Name",
-                  "id": "customers",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 53,
-                  "end_col_offset": 62
-                },
-                "ifs": [
-                  {
-                    "_type": "Compare",
-                    "left": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "o",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 66,
-                        "end_col_offset": 67
-                      },
-                      "attr": "customerId",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 66,
-                      "end_col_offset": 78
-                    },
-                    "ops": [
-                      {
-                        "_type": "Eq"
-                      }
-                    ],
-                    "comparators": [
-                      {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "c",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 82,
-                          "end_col_offset": 83
-                        },
-                        "attr": "id",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 82,
-                        "end_col_offset": 86
-                      }
-                    ],
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 66,
-                    "end_col_offset": 86
-                  }
-                ],
-                "is_async": 0
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 9,
-            "end_col_offset": 87
-          },
-          "op": {
-            "_type": "Add"
-          },
-          "right": {
-            "_type": "ListComp",
-            "elt": {
-              "_type": "Call",
-              "func": {
-                "_type": "Lambda",
-                "args": {
-                  "_type": "arguments",
-                  "posonlyargs": [],
-                  "args": [
-                    {
-                      "_type": "arg",
-                      "arg": "c",
-                      "annotation": null,
-                      "type_comment": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 99,
-                      "end_col_offset": 100
-                    }
-                  ],
-                  "vararg": null,
-                  "kwonlyargs": [],
-                  "kw_defaults": [],
-                  "kwarg": null,
-                  "defaults": []
-                },
-                "body": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Result",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 102,
-                    "end_col_offset": 108
-                  },
-                  "args": [
-                    {
-                      "_type": "Constant",
-                      "value": null,
-                      "kind": null,
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 109,
-                      "end_col_offset": 113
-                    },
-                    {
-                      "_type": "Name",
-                      "id": "o",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 115,
-                      "end_col_offset": 116
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 102,
-                  "end_col_offset": 117
-                },
-                "lineno": 25,
-                "end_lineno": 25,
-                "col_offset": 92,
-                "end_col_offset": 117
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": null,
-                  "kind": null,
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 119,
-                  "end_col_offset": 123
-                }
-              ],
-              "keywords": [],
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 91,
-              "end_col_offset": 124
-            },
-            "generators": [
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
               {
-                "_type": "comprehension",
-                "target": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Store"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 129,
-                  "end_col_offset": 130
-                },
-                "iter": {
-                  "_type": "Name",
-                  "id": "orders",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 25,
-                  "end_lineno": 25,
-                  "col_offset": 134,
-                  "end_col_offset": 140
-                },
-                "ifs": [
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
                   {
-                    "_type": "UnaryOp",
-                    "op": {
-                      "_type": "Not"
-                    },
-                    "operand": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "any",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 25,
-                        "end_lineno": 25,
-                        "col_offset": 148,
-                        "end_col_offset": 151
-                      },
-                      "args": [
-                        {
-                          "_type": "ListComp",
-                          "elt": {
-                            "_type": "Compare",
-                            "left": {
-                              "_type": "Attribute",
-                              "value": {
-                                "_type": "Name",
-                                "id": "o",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 153,
-                                "end_col_offset": 154
-                              },
-                              "attr": "customerId",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 25,
-                              "end_lineno": 25,
-                              "col_offset": 153,
-                              "end_col_offset": 165
-                            },
-                            "ops": [
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
                               {
-                                "_type": "Eq"
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
                               }
-                            ],
-                            "comparators": [
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
                               {
-                                "_type": "Attribute",
-                                "value": {
-                                  "_type": "Name",
-                                  "id": "c",
-                                  "ctx": {
-                                    "_type": "Load"
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 347,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 347,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 347,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 326,
+                    "end": 346,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 326,
+                        "end": 334
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 334,
+                        "end": 346,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 335,
+                            "end": 336
+                          },
+                          {
+                            "kind": "string",
+                            "start": 338,
+                            "end": 345,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 338,
+                                "end": 339
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 339,
+                                "end": 344
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 344,
+                                "end": 345
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 348,
+        "end": 418,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 348,
+            "end": 358,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 349,
+                "end": 358
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 359,
+            "end": 418,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 365,
+                "end": 370
+              },
+              {
+                "kind": "block",
+                "start": 376,
+                "end": 418,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 376,
+                    "end": 383,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 376,
+                        "end": 383,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 376,
+                            "end": 378
+                          },
+                          {
+                            "kind": "type",
+                            "start": 380,
+                            "end": 383,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 380,
+                                "end": 383
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 388,
+                    "end": 403,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 388,
+                        "end": 403,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 388,
+                            "end": 398
+                          },
+                          {
+                            "kind": "type",
+                            "start": 400,
+                            "end": 403,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 400,
+                                "end": 403
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 408,
+                    "end": 418,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 408,
+                        "end": 418,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 408,
+                            "end": 413
+                          },
+                          {
+                            "kind": "type",
+                            "start": 415,
+                            "end": 418,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 415,
+                                "end": 418
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 420,
+        "end": 489,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 420,
+            "end": 489,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 420,
+                "end": 426
+              },
+              {
+                "kind": "list",
+                "start": 429,
+                "end": 489,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 430,
+                    "end": 448,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 430,
+                        "end": 435
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 435,
+                        "end": 448,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 436,
+                            "end": 439
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 441,
+                            "end": 442
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 444,
+                            "end": 447
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 450,
+                    "end": 468,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 450,
+                        "end": 455
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 455,
+                        "end": 468,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 456,
+                            "end": 459
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 461,
+                            "end": 462
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 464,
+                            "end": 467
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 470,
+                    "end": 488,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 470,
+                        "end": 475
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 475,
+                        "end": 488,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 476,
+                            "end": 479
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 481,
+                            "end": 482
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 484,
+                            "end": 487
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 490,
+        "end": 551,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 490,
+            "end": 500,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 491,
+                "end": 500
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 501,
+            "end": 551,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 507,
+                "end": 513
+              },
+              {
+                "kind": "block",
+                "start": 519,
+                "end": 551,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 519,
+                    "end": 536,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 519,
+                        "end": 536,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 519,
+                            "end": 531
+                          },
+                          {
+                            "kind": "type",
+                            "start": 533,
+                            "end": 536,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 533,
+                                "end": 536
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 541,
+                    "end": 551,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 541,
+                        "end": 551,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 541,
+                            "end": 546
+                          },
+                          {
+                            "kind": "type",
+                            "start": 548,
+                            "end": 551,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 548,
+                                "end": 551
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 553,
+        "end": 748,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 553,
+            "end": 748,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 553,
+                "end": 559
+              },
+              {
+                "kind": "binary_operator",
+                "start": 562,
+                "end": 748,
+                "children": [
+                  {
+                    "kind": "list_comprehension",
+                    "start": 562,
+                    "end": 640,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 563,
+                        "end": 580,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 563,
+                            "end": 569
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 569,
+                            "end": 580,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 570,
+                                "end": 576,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 570,
+                                    "end": 571
                                   },
-                                  "lineno": 25,
-                                  "end_lineno": 25,
-                                  "col_offset": 169,
-                                  "end_col_offset": 170
-                                },
-                                "attr": "id",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 169,
-                                "end_col_offset": 173
+                                  {
+                                    "kind": "identifier",
+                                    "start": 572,
+                                    "end": 576
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 578,
+                                "end": 579
                               }
-                            ],
-                            "lineno": 25,
-                            "end_lineno": 25,
-                            "col_offset": 153,
-                            "end_col_offset": 173
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 581,
+                        "end": 596,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 585,
+                            "end": 586
                           },
-                          "generators": [
-                            {
-                              "_type": "comprehension",
-                              "target": {
-                                "_type": "Name",
-                                "id": "c",
-                                "ctx": {
-                                  "_type": "Store"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 178,
-                                "end_col_offset": 179
+                          {
+                            "kind": "identifier",
+                            "start": 590,
+                            "end": 596
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 597,
+                        "end": 615,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 601,
+                            "end": 602
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 606,
+                            "end": 615
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 616,
+                        "end": 639,
+                        "children": [
+                          {
+                            "kind": "comparison_operator",
+                            "start": 619,
+                            "end": 639,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 619,
+                                "end": 631,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 619,
+                                    "end": 620
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 621,
+                                    "end": 631
+                                  }
+                                ]
                               },
-                              "iter": {
-                                "_type": "Name",
-                                "id": "customers",
-                                "ctx": {
-                                  "_type": "Load"
-                                },
-                                "lineno": 25,
-                                "end_lineno": 25,
-                                "col_offset": 183,
-                                "end_col_offset": 192
-                              },
-                              "ifs": [],
-                              "is_async": 0
-                            }
-                          ],
-                          "lineno": 25,
-                          "end_lineno": 25,
-                          "col_offset": 152,
-                          "end_col_offset": 193
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 25,
-                      "end_lineno": 25,
-                      "col_offset": 148,
-                      "end_col_offset": 194
-                    },
-                    "lineno": 25,
-                    "end_lineno": 25,
-                    "col_offset": 144,
-                    "end_col_offset": 194
+                              {
+                                "kind": "attribute",
+                                "start": 635,
+                                "end": 639,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 635,
+                                    "end": 636
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 637,
+                                    "end": 639
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "list_comprehension",
+                    "start": 643,
+                    "end": 748,
+                    "children": [
+                      {
+                        "kind": "call",
+                        "start": 644,
+                        "end": 677,
+                        "children": [
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 644,
+                            "end": 671,
+                            "children": [
+                              {
+                                "kind": "lambda",
+                                "start": 645,
+                                "end": 670,
+                                "children": [
+                                  {
+                                    "kind": "lambda_parameters",
+                                    "start": 652,
+                                    "end": 653,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 652,
+                                        "end": 653
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "call",
+                                    "start": 655,
+                                    "end": 670,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 655,
+                                        "end": 661
+                                      },
+                                      {
+                                        "kind": "argument_list",
+                                        "start": 661,
+                                        "end": 670,
+                                        "children": [
+                                          {
+                                            "kind": "none",
+                                            "start": 662,
+                                            "end": 666
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 668,
+                                            "end": 669
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 671,
+                            "end": 677,
+                            "children": [
+                              {
+                                "kind": "none",
+                                "start": 672,
+                                "end": 676
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "for_in_clause",
+                        "start": 678,
+                        "end": 693,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 682,
+                            "end": 683
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 687,
+                            "end": 693
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "if_clause",
+                        "start": 694,
+                        "end": 747,
+                        "children": [
+                          {
+                            "kind": "not_operator",
+                            "start": 697,
+                            "end": 747,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 701,
+                                "end": 747,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 701,
+                                    "end": 704
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 704,
+                                    "end": 747,
+                                    "children": [
+                                      {
+                                        "kind": "list_comprehension",
+                                        "start": 705,
+                                        "end": 746,
+                                        "children": [
+                                          {
+                                            "kind": "comparison_operator",
+                                            "start": 706,
+                                            "end": 726,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 706,
+                                                "end": 718,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 706,
+                                                    "end": 707
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 708,
+                                                    "end": 718
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "attribute",
+                                                "start": 722,
+                                                "end": 726,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 722,
+                                                    "end": 723
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 724,
+                                                    "end": 726
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "for_in_clause",
+                                            "start": 727,
+                                            "end": 745,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 731,
+                                                "end": 732
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 736,
+                                                "end": 745
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "is_async": 0
+                ]
               }
-            ],
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 90,
-            "end_col_offset": 195
-          },
-          "lineno": 25,
-          "end_lineno": 25,
-          "col_offset": 9,
-          "end_col_offset": 195
-        },
-        "lineno": 25,
-        "end_lineno": 25,
-        "end_col_offset": 195
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 26,
-            "end_lineno": 26,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Right Join using syntax ---",
-              "kind": null,
-              "lineno": 26,
-              "end_lineno": 26,
-              "col_offset": 6,
-              "end_col_offset": 39
-            }
-          ],
-          "keywords": [],
-          "lineno": 26,
-          "end_lineno": 26,
-          "col_offset": 0,
-          "end_col_offset": 40
-        },
-        "lineno": 26,
-        "end_lineno": 26,
-        "end_col_offset": 40
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "If",
-            "body": [
-              {
-                "_type": "Expr",
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "print",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 29,
-                    "end_lineno": 29,
-                    "col_offset": 8,
-                    "end_col_offset": 13
-                  },
-                  "args": [
-                    {
-                      "_type": "Constant",
-                      "value": "Customer",
-                      "kind": null,
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 14,
-                      "end_col_offset": 24
-                    },
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "entry",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 26,
-                        "end_col_offset": 31
-                      },
-                      "attr": "customerName",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 26,
-                      "end_col_offset": 44
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "has order",
-                      "kind": null,
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 46,
-                      "end_col_offset": 57
-                    },
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "entry",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 59,
-                          "end_col_offset": 64
-                        },
-                        "attr": "order",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 59,
-                        "end_col_offset": 70
-                      },
-                      "attr": "id",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 59,
-                      "end_col_offset": 73
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "- $",
-                      "kind": null,
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 75,
-                      "end_col_offset": 80
-                    },
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "entry",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 29,
-                          "end_lineno": 29,
-                          "col_offset": 82,
-                          "end_col_offset": 87
-                        },
-                        "attr": "order",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 29,
-                        "end_lineno": 29,
-                        "col_offset": 82,
-                        "end_col_offset": 93
-                      },
-                      "attr": "total",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 29,
-                      "end_lineno": 29,
-                      "col_offset": 82,
-                      "end_col_offset": 99
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 29,
-                  "end_lineno": 29,
-                  "col_offset": 8,
-                  "end_col_offset": 100
-                },
-                "lineno": 29,
-                "end_lineno": 29,
-                "col_offset": 8,
-                "end_col_offset": 100
-              }
-            ],
-            "test": {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Name",
-                "id": "entry",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 28,
-                "end_lineno": 28,
-                "col_offset": 7,
-                "end_col_offset": 12
-              },
-              "attr": "order",
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 7,
-              "end_col_offset": 18
-            },
-            "orelse": [
-              {
-                "_type": "Expr",
-                "value": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "print",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 31,
-                    "end_lineno": 31,
-                    "col_offset": 8,
-                    "end_col_offset": 13
-                  },
-                  "args": [
-                    {
-                      "_type": "Constant",
-                      "value": "Customer",
-                      "kind": null,
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 14,
-                      "end_col_offset": 24
-                    },
-                    {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "entry",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 31,
-                        "end_lineno": 31,
-                        "col_offset": 26,
-                        "end_col_offset": 31
-                      },
-                      "attr": "customerName",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 26,
-                      "end_col_offset": 44
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": "has no orders",
-                      "kind": null,
-                      "lineno": 31,
-                      "end_lineno": 31,
-                      "col_offset": 46,
-                      "end_col_offset": 61
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 31,
-                  "end_lineno": 31,
-                  "col_offset": 8,
-                  "end_col_offset": 62
-                },
-                "lineno": 31,
-                "end_lineno": 31,
-                "col_offset": 8,
-                "end_col_offset": 62
-              }
-            ],
-            "lineno": 28,
-            "end_lineno": 31,
-            "col_offset": 4,
-            "end_col_offset": 62
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "entry",
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 27,
-        "end_lineno": 31,
-        "end_col_offset": 62
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 749,
+        "end": 789,
+        "children": [
+          {
+            "kind": "call",
+            "start": 749,
+            "end": 789,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 749,
+                "end": 754
+              },
+              {
+                "kind": "argument_list",
+                "start": 754,
+                "end": 789,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 755,
+                    "end": 788,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 755,
+                        "end": 756
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 756,
+                        "end": 787
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 787,
+                        "end": 788
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 790,
+        "end": 1004,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 794,
+            "end": 799
+          },
+          {
+            "kind": "identifier",
+            "start": 803,
+            "end": 809
+          },
+          {
+            "kind": "block",
+            "start": 815,
+            "end": 1004,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 815,
+                "end": 1004,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 818,
+                    "end": 829,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 818,
+                        "end": 823
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 824,
+                        "end": 829
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 839,
+                    "end": 931,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 839,
+                        "end": 931,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 839,
+                            "end": 931,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 839,
+                                "end": 844
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 844,
+                                "end": 931,
+                                "children": [
+                                  {
+                                    "kind": "string",
+                                    "start": 845,
+                                    "end": 855,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 845,
+                                        "end": 846
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 846,
+                                        "end": 854
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 854,
+                                        "end": 855
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 857,
+                                    "end": 875,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 857,
+                                        "end": 862
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 863,
+                                        "end": 875
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 877,
+                                    "end": 888,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 877,
+                                        "end": 878
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 878,
+                                        "end": 887
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 887,
+                                        "end": 888
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 890,
+                                    "end": 904,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 890,
+                                        "end": 901,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 890,
+                                            "end": 895
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 896,
+                                            "end": 901
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 902,
+                                        "end": 904
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 906,
+                                    "end": 911,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 906,
+                                        "end": 907
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 907,
+                                        "end": 910
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 910,
+                                        "end": 911
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "attribute",
+                                    "start": 913,
+                                    "end": 930,
+                                    "children": [
+                                      {
+                                        "kind": "attribute",
+                                        "start": 913,
+                                        "end": 924,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 913,
+                                            "end": 918
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 919,
+                                            "end": 924
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 925,
+                                        "end": 930
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "else_clause",
+                    "start": 936,
+                    "end": 1004,
+                    "children": [
+                      {
+                        "kind": "block",
+                        "start": 950,
+                        "end": 1004,
+                        "children": [
+                          {
+                            "kind": "expression_statement",
+                            "start": 950,
+                            "end": 1004,
+                            "children": [
+                              {
+                                "kind": "call",
+                                "start": 950,
+                                "end": 1004,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 950,
+                                    "end": 955
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 955,
+                                    "end": 1004,
+                                    "children": [
+                                      {
+                                        "kind": "string",
+                                        "start": 956,
+                                        "end": 966,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 956,
+                                            "end": 957
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 957,
+                                            "end": 965
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 965,
+                                            "end": 966
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 968,
+                                        "end": 986,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 968,
+                                            "end": 973
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 974,
+                                            "end": 986
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 988,
+                                        "end": 1003,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 988,
+                                            "end": 989
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 989,
+                                            "end": 1002
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 1002,
+                                            "end": 1003
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/save_jsonl_stdout.py.json
+++ b/tests/json-ast/x/py/save_jsonl_stdout.py.json
@@ -1,422 +1,566 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 462,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 18
-      },
-      {
-        "_type": "Import",
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 11
-      },
-      {
-        "_type": "ClassDef",
-        "name": "People",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 12
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 10,
-        "end_lineno": 12,
-        "end_col_offset": 12
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 14,
-            "end_lineno": 14,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 17,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "Constant",
-                  "value": 30,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 26,
-                  "end_col_offset": 28
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 10,
-              "end_col_offset": 29
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "People",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 14,
-                "end_lineno": 14,
-                "col_offset": 31,
-                "end_col_offset": 37
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 38,
-                  "end_col_offset": 43
-                },
-                {
-                  "_type": "Constant",
-                  "value": 25,
-                  "kind": null,
-                  "lineno": 14,
-                  "end_lineno": 14,
-                  "col_offset": 45,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 31,
-              "end_col_offset": 48
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 9,
-          "end_col_offset": 49
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 49
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Name",
-                "id": "_tmp",
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 4,
-                "end_col_offset": 8
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "value": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "hasattr",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 39,
-                  "end_col_offset": 46
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_row",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 47,
-                    "end_col_offset": 51
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": "__dataclass_fields__",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 53,
-                    "end_col_offset": 75
-                  }
-                ],
-                "keywords": [],
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 39,
-                "end_col_offset": 76
-              },
-              "body": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "dataclasses",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 11,
-                    "end_col_offset": 22
-                  },
-                  "attr": "asdict",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 11,
-                  "end_col_offset": 29
-                },
-                "args": [
-                  {
-                    "_type": "Name",
-                    "id": "_row",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 30,
-                    "end_col_offset": 34
-                  }
-                ],
-                "keywords": [],
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 11,
-                "end_col_offset": 35
-              },
-              "orelse": {
-                "_type": "Name",
-                "id": "_row",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 82,
-                "end_col_offset": 86
-              },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 11,
-              "end_col_offset": 86
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 86
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "json",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 17,
-                      "end_lineno": 17,
-                      "col_offset": 10,
-                      "end_col_offset": 14
-                    },
-                    "attr": "dumps",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 10,
-                    "end_col_offset": 20
-                  },
-                  "args": [
-                    {
-                      "_type": "Name",
-                      "id": "_tmp",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 17,
-                      "end_lineno": 17,
-                      "col_offset": 21,
-                      "end_col_offset": 25
-                    }
-                  ],
-                  "keywords": [],
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 10,
-                  "end_col_offset": 26
-                }
-              ],
-              "keywords": [],
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 27
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 27
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "_row",
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 4,
-          "end_col_offset": 8
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "people",
-          "lineno": 15,
-          "end_lineno": 15,
-          "col_offset": 12,
-          "end_col_offset": 18
-        },
-        "lineno": 15,
-        "end_lineno": 17,
-        "end_col_offset": 27
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 192,
+        "end": 210,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 199,
+            "end": 210,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 199,
+                "end": 210
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 211,
+        "end": 222,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 218,
+            "end": 222,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 218,
+                "end": 222
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 224,
+        "end": 275,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 224,
+            "end": 234,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 225,
+                "end": 234
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 235,
+            "end": 275,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 241,
+                "end": 247
+              },
+              {
+                "kind": "block",
+                "start": 253,
+                "end": 275,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 253,
+                    "end": 262,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 253,
+                        "end": 262,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 253,
+                            "end": 257
+                          },
+                          {
+                            "kind": "type",
+                            "start": 259,
+                            "end": 262,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 259,
+                                "end": 262
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 267,
+                    "end": 275,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 267,
+                        "end": 275,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 267,
+                            "end": 270
+                          },
+                          {
+                            "kind": "type",
+                            "start": 272,
+                            "end": 275,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 272,
+                                "end": 275
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 277,
+        "end": 326,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 277,
+            "end": 326,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 277,
+                "end": 283
+              },
+              {
+                "kind": "list",
+                "start": 286,
+                "end": 326,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 287,
+                    "end": 306,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 287,
+                        "end": 293
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 293,
+                        "end": 306,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 301,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 300
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 300,
+                                "end": 301
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 303,
+                            "end": 305
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 308,
+                    "end": 325,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 308,
+                        "end": 314
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 314,
+                        "end": 325,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 315,
+                            "end": 320,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 315,
+                                "end": 316
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 316,
+                                "end": 319
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 319,
+                                "end": 320
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 322,
+                            "end": 324
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 327,
+        "end": 461,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 331,
+            "end": 335
+          },
+          {
+            "kind": "identifier",
+            "start": 339,
+            "end": 345
+          },
+          {
+            "kind": "block",
+            "start": 351,
+            "end": 461,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 351,
+                "end": 433,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 351,
+                    "end": 433,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 351,
+                        "end": 355
+                      },
+                      {
+                        "kind": "conditional_expression",
+                        "start": 358,
+                        "end": 433,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 358,
+                            "end": 382,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 358,
+                                "end": 376,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 358,
+                                    "end": 369
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 370,
+                                    "end": 376
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 376,
+                                "end": 382,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 377,
+                                    "end": 381
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call",
+                            "start": 386,
+                            "end": 423,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 386,
+                                "end": 393
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 393,
+                                "end": 423,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 394,
+                                    "end": 398
+                                  },
+                                  {
+                                    "kind": "string",
+                                    "start": 400,
+                                    "end": 422,
+                                    "children": [
+                                      {
+                                        "kind": "string_start",
+                                        "start": 400,
+                                        "end": 401
+                                      },
+                                      {
+                                        "kind": "string_content",
+                                        "start": 401,
+                                        "end": 421
+                                      },
+                                      {
+                                        "kind": "string_end",
+                                        "start": 421,
+                                        "end": 422
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 429,
+                            "end": 433
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 438,
+                "end": 461,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 438,
+                    "end": 461,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 438,
+                        "end": 443
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 443,
+                        "end": 461,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 444,
+                            "end": 460,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 444,
+                                "end": 454,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 444,
+                                    "end": 448
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 449,
+                                    "end": 454
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 454,
+                                "end": 460,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 455,
+                                    "end": 459
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/short_circuit.py.json
+++ b/tests/json-ast/x/py/short_circuit.py.json
@@ -1,323 +1,296 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 225,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "boom",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 142,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "boom",
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 10,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 4,
-              "end_col_offset": 17
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 17
+            "kind": "identifier",
+            "start": 97,
+            "end": 101
           },
           {
-            "_type": "Return",
-            "value": {
-              "_type": "Constant",
-              "value": true,
-              "kind": null,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 15
+            "kind": "parameters",
+            "start": 101,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 102,
+                "end": 103
+              },
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 106
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 113,
+            "end": 142,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 113,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 113,
+                    "end": 126,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 113,
+                        "end": 118
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 118,
+                        "end": 126,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 119,
+                            "end": 125,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 119,
+                                "end": 120
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 120,
+                                "end": 124
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 124,
+                                "end": 125
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "return_statement",
+                "start": 131,
+                "end": 142,
+                "children": [
+                  {
+                    "kind": "true",
+                    "start": 138,
+                    "end": 142
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "a",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 9,
-              "end_col_offset": 10
-            },
-            {
-              "_type": "arg",
-              "arg": "b",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 12,
-              "end_col_offset": 13
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 5,
-        "end_col_offset": 15
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "And"
-                },
-                "values": [
+        "kind": "expression_statement",
+        "start": 143,
+        "end": 184,
+        "children": [
+          {
+            "kind": "call",
+            "start": 143,
+            "end": 184,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 143,
+                "end": 148
+              },
+              {
+                "kind": "argument_list",
+                "start": 148,
+                "end": 184,
+                "children": [
                   {
-                    "_type": "Constant",
-                    "value": false,
-                    "kind": null,
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 12,
-                    "end_col_offset": 17
-                  },
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "boom",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 22,
-                      "end_col_offset": 26
-                    },
-                    "args": [
+                    "kind": "parenthesized_expression",
+                    "start": 149,
+                    "end": 183,
+                    "children": [
                       {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 27,
-                        "end_col_offset": 28
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 30,
-                        "end_col_offset": 31
+                        "kind": "conditional_expression",
+                        "start": 150,
+                        "end": 182,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 150,
+                            "end": 151
+                          },
+                          {
+                            "kind": "boolean_operator",
+                            "start": 155,
+                            "end": 175,
+                            "children": [
+                              {
+                                "kind": "false",
+                                "start": 155,
+                                "end": 160
+                              },
+                              {
+                                "kind": "call",
+                                "start": 165,
+                                "end": 175,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 165,
+                                    "end": 169
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 169,
+                                    "end": 175,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 170,
+                                        "end": 171
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 173,
+                                        "end": 174
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 181,
+                            "end": 182
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 22,
-                    "end_col_offset": 32
+                    ]
                   }
-                ],
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 32
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 38,
-                "end_col_offset": 39
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 39
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 41
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 41
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "BoolOp",
-                "op": {
-                  "_type": "Or"
-                },
-                "values": [
+        "kind": "expression_statement",
+        "start": 185,
+        "end": 224,
+        "children": [
+          {
+            "kind": "call",
+            "start": 185,
+            "end": 224,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 185,
+                "end": 190
+              },
+              {
+                "kind": "argument_list",
+                "start": 190,
+                "end": 224,
+                "children": [
                   {
-                    "_type": "Constant",
-                    "value": true,
-                    "kind": null,
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 12,
-                    "end_col_offset": 16
-                  },
-                  {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "boom",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 20,
-                      "end_col_offset": 24
-                    },
-                    "args": [
+                    "kind": "parenthesized_expression",
+                    "start": 191,
+                    "end": 223,
+                    "children": [
                       {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 25,
-                        "end_col_offset": 26
-                      },
-                      {
-                        "_type": "Constant",
-                        "value": 2,
-                        "kind": null,
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 28,
-                        "end_col_offset": 29
+                        "kind": "conditional_expression",
+                        "start": 192,
+                        "end": 222,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 192,
+                            "end": 193
+                          },
+                          {
+                            "kind": "boolean_operator",
+                            "start": 197,
+                            "end": 215,
+                            "children": [
+                              {
+                                "kind": "true",
+                                "start": 197,
+                                "end": 201
+                              },
+                              {
+                                "kind": "call",
+                                "start": 205,
+                                "end": 215,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 205,
+                                    "end": 209
+                                  },
+                                  {
+                                    "kind": "argument_list",
+                                    "start": 209,
+                                    "end": 215,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 210,
+                                        "end": 211
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 213,
+                                        "end": 214
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 221,
+                            "end": 222
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 20,
-                    "end_col_offset": 30
+                    ]
                   }
-                ],
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 12,
-                "end_col_offset": 30
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 36,
-                "end_col_offset": 37
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 37
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 39
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 39
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/slice.py.json
+++ b/tests/json-ast/x/py/slice.py.json
@@ -1,282 +1,234 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 157,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "List",
-                "elts": [
-                  {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 7,
-                    "end_col_offset": 8
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  }
-                ],
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 15
-              },
-              "slice": {
-                "_type": "Slice",
-                "lower": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "upper": {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 18,
-                  "end_col_offset": 19
-                },
-                "step": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 16,
-                "end_col_offset": 19
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 21
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "List",
-                "elts": [
-                  {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 7,
-                    "end_col_offset": 8
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 2,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 10,
-                    "end_col_offset": 11
-                  },
-                  {
-                    "_type": "Constant",
-                    "value": 3,
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  }
-                ],
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 15
-              },
-              "slice": {
-                "_type": "Slice",
-                "lower": {
-                  "_type": "Constant",
-                  "value": 0,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "upper": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 18,
-                  "end_col_offset": 19
-                },
-                "step": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 16,
-                "end_col_offset": 19
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 21
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Constant",
-                "value": "hello",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 13
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 114,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 114,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "slice": {
-                "_type": "Slice",
-                "lower": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "upper": {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "step": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 14,
-                "end_col_offset": 17
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 99,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "list",
+                        "start": 99,
+                        "end": 108,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 100,
+                            "end": 101
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 103,
+                            "end": 104
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 106,
+                            "end": 107
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "slice",
+                        "start": 109,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 109,
+                            "end": 110
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 111,
+                            "end": 112
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 115,
+        "end": 136,
+        "children": [
+          {
+            "kind": "call",
+            "start": 115,
+            "end": 136,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 115,
+                "end": 120
               },
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "argument_list",
+                "start": 120,
+                "end": 136,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 121,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "list",
+                        "start": 121,
+                        "end": 130,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 122,
+                            "end": 123
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 125,
+                            "end": 126
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 128,
+                            "end": 129
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "slice",
+                        "start": 131,
+                        "end": 134,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 131,
+                            "end": 132
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 133,
+                            "end": 134
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 137,
+        "end": 156,
+        "children": [
+          {
+            "kind": "call",
+            "start": 137,
+            "end": 156,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 137,
+                "end": 142
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 18
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 19
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 19
+              {
+                "kind": "argument_list",
+                "start": 142,
+                "end": 156,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 143,
+                    "end": 155,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 143,
+                        "end": 150,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 143,
+                            "end": 144
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 144,
+                            "end": 149
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 149,
+                            "end": 150
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "slice",
+                        "start": 151,
+                        "end": 154,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 151,
+                            "end": 152
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 153,
+                            "end": 154
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/sort_stable.py.json
+++ b/tests/json-ast/x/py/sort_stable.py.json
@@ -1,462 +1,557 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 374,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Item",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "n",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 7,
-              "end_col_offset": 10
-            },
-            "target": {
-              "_type": "Name",
-              "id": "v",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 5
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 10
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Name",
-            "id": "items",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 5
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 9,
-                "end_col_offset": 13
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 17,
-                  "end_col_offset": 20
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 9,
-              "end_col_offset": 21
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 23,
-                "end_col_offset": 27
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 28,
-                  "end_col_offset": 29
-                },
-                {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 31,
-                  "end_col_offset": 34
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 23,
-              "end_col_offset": 35
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Item",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 37,
-                "end_col_offset": 41
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 42,
-                  "end_col_offset": 43
-                },
-                {
-                  "_type": "Constant",
-                  "value": "c",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 45,
-                  "end_col_offset": 48
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 37,
-              "end_col_offset": 49
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 8,
-          "end_col_offset": 50
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 50
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 237,
+        "children": [
           {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 13,
-            "end_lineno": 13,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "i",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            "attr": "v",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 10,
-            "end_col_offset": 13
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
           },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 18,
-                "end_col_offset": 19
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 237,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 214
               },
-              "iter": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "sorted",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 13,
-                  "end_lineno": 13,
-                  "col_offset": 23,
-                  "end_col_offset": 29
-                },
-                "args": [
+              {
+                "kind": "block",
+                "start": 220,
+                "end": 237,
+                "children": [
                   {
-                    "_type": "ListComp",
-                    "elt": {
-                      "_type": "Name",
-                      "id": "i",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 31,
-                      "end_col_offset": 32
-                    },
-                    "generators": [
+                    "kind": "expression_statement",
+                    "start": 220,
+                    "end": 226,
+                    "children": [
                       {
-                        "_type": "comprehension",
-                        "target": {
-                          "_type": "Name",
-                          "id": "i",
-                          "ctx": {
-                            "_type": "Store"
-                          },
-                          "lineno": 13,
-                          "end_lineno": 13,
-                          "col_offset": 37,
-                          "end_col_offset": 38
-                        },
-                        "iter": {
-                          "_type": "Name",
-                          "id": "items",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 13,
-                          "end_lineno": 13,
-                          "col_offset": 42,
-                          "end_col_offset": 47
-                        },
-                        "ifs": [],
-                        "is_async": 0
-                      }
-                    ],
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 30,
-                    "end_col_offset": 48
-                  }
-                ],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "key",
-                    "value": {
-                      "_type": "Lambda",
-                      "args": {
-                        "_type": "arguments",
-                        "posonlyargs": [],
-                        "args": [
+                        "kind": "assignment",
+                        "start": 220,
+                        "end": 226,
+                        "children": [
                           {
-                            "_type": "arg",
-                            "arg": "i",
-                            "annotation": null,
-                            "type_comment": null,
-                            "lineno": 13,
-                            "end_lineno": 13,
-                            "col_offset": 61,
-                            "end_col_offset": 62
-                          }
-                        ],
-                        "vararg": null,
-                        "kwonlyargs": [],
-                        "kw_defaults": [],
-                        "kwarg": null,
-                        "defaults": []
-                      },
-                      "body": {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "i",
-                          "ctx": {
-                            "_type": "Load"
+                            "kind": "identifier",
+                            "start": 220,
+                            "end": 221
                           },
-                          "lineno": 13,
-                          "end_lineno": 13,
-                          "col_offset": 64,
-                          "end_col_offset": 65
-                        },
-                        "attr": "n",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 13,
-                        "end_lineno": 13,
-                        "col_offset": 64,
-                        "end_col_offset": 67
-                      },
-                      "lineno": 13,
-                      "end_lineno": 13,
-                      "col_offset": 54,
-                      "end_col_offset": 67
-                    },
-                    "lineno": 13,
-                    "end_lineno": 13,
-                    "col_offset": 50,
-                    "end_col_offset": 67
+                          {
+                            "kind": "type",
+                            "start": 223,
+                            "end": 226,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 223,
+                                "end": 226
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 231,
+                    "end": 237,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 231,
+                        "end": 237,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 231,
+                            "end": 232
+                          },
+                          {
+                            "kind": "type",
+                            "start": 234,
+                            "end": 237,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 234,
+                                "end": 237
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 13,
-                "end_lineno": 13,
-                "col_offset": 23,
-                "end_col_offset": 68
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 13,
-          "end_lineno": 13,
-          "col_offset": 9,
-          "end_col_offset": 69
-        },
-        "lineno": 13,
-        "end_lineno": 13,
-        "end_col_offset": 69
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "result",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 239,
+        "end": 289,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 239,
+            "end": 289,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 239,
+                "end": 244
               },
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 14,
-          "end_lineno": 14,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 14,
-        "end_lineno": 14,
-        "end_col_offset": 13
+              {
+                "kind": "list",
+                "start": 247,
+                "end": 289,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 248,
+                    "end": 260,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 248,
+                        "end": 252
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 252,
+                        "end": 260,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 253,
+                            "end": 254
+                          },
+                          {
+                            "kind": "string",
+                            "start": 256,
+                            "end": 259,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 256,
+                                "end": 257
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 257,
+                                "end": 258
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 258,
+                                "end": 259
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 262,
+                    "end": 274,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 262,
+                        "end": 266
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 266,
+                        "end": 274,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 267,
+                            "end": 268
+                          },
+                          {
+                            "kind": "string",
+                            "start": 270,
+                            "end": 273,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 270,
+                                "end": 271
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 271,
+                                "end": 272
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 272,
+                                "end": 273
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 276,
+                    "end": 288,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 276,
+                        "end": 280
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 280,
+                        "end": 288,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 281,
+                            "end": 282
+                          },
+                          {
+                            "kind": "string",
+                            "start": 284,
+                            "end": 287,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 284,
+                                "end": 285
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 285,
+                                "end": 286
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 286,
+                                "end": 287
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 290,
+        "end": 359,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 290,
+            "end": 359,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 290,
+                "end": 296
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 299,
+                "end": 359,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 300,
+                    "end": 303,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 300,
+                        "end": 301
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 303
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 304,
+                    "end": 358,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 308,
+                        "end": 309
+                      },
+                      {
+                        "kind": "call",
+                        "start": 313,
+                        "end": 358,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 313,
+                            "end": 319
+                          },
+                          {
+                            "kind": "argument_list",
+                            "start": 319,
+                            "end": 358,
+                            "children": [
+                              {
+                                "kind": "list_comprehension",
+                                "start": 320,
+                                "end": 338,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 321,
+                                    "end": 322
+                                  },
+                                  {
+                                    "kind": "for_in_clause",
+                                    "start": 323,
+                                    "end": 337,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 327,
+                                        "end": 328
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 332,
+                                        "end": 337
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "keyword_argument",
+                                "start": 340,
+                                "end": 357,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 340,
+                                    "end": 343
+                                  },
+                                  {
+                                    "kind": "lambda",
+                                    "start": 344,
+                                    "end": 357,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_parameters",
+                                        "start": 351,
+                                        "end": 352,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 351,
+                                            "end": 352
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "attribute",
+                                        "start": 354,
+                                        "end": 357,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 354,
+                                            "end": 355
+                                          },
+                                          {
+                                            "kind": "identifier",
+                                            "start": 356,
+                                            "end": 357
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 360,
+        "end": 373,
+        "children": [
+          {
+            "kind": "call",
+            "start": 360,
+            "end": 373,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 360,
+                "end": 365
+              },
+              {
+                "kind": "argument_list",
+                "start": 365,
+                "end": 373,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 366,
+                    "end": 372
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/str_builtin.py.json
+++ b/tests/json-ast/x/py/str_builtin.py.json
@@ -1,63 +1,68 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 109,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "str",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 108,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 108,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 123,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 13
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 14
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 15
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 15
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 108,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 107,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 107,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 103,
+                            "end": 106
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_compare.py.json
+++ b/tests/json-ast/x/py/string_compare.py.json
@@ -1,342 +1,422 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 219,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
-                  {
-                    "_type": "Lt"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": "b",
-                    "kind": null,
-                    "lineno": 3,
-                    "end_lineno": 3,
-                    "col_offset": 18,
-                    "end_col_offset": 21
-                  }
-                ],
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 12,
-                "end_col_offset": 21
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 27,
-                "end_col_offset": 28
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 7,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 30
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 30
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "a",
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
-                  {
-                    "_type": "LtE"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": "a",
-                    "kind": null,
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 19,
-                    "end_col_offset": 22
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 22
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 28,
-                "end_col_offset": 29
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 31
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 123,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 123,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
+              },
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 123,
+                "children": [
                   {
-                    "_type": "Gt"
+                    "kind": "parenthesized_expression",
+                    "start": 99,
+                    "end": 122,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 100,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 100,
+                            "end": 101
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 105,
+                            "end": 114,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 105,
+                                "end": 108,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 105,
+                                    "end": 106
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 106,
+                                    "end": 107
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 107,
+                                    "end": 108
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 111,
+                                "end": 114,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 111,
+                                    "end": 112
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 112,
+                                    "end": 113
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 113,
+                                    "end": 114
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 120,
+                            "end": 121
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Constant",
-                    "value": "a",
-                    "kind": null,
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 18,
-                    "end_col_offset": 21
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 21
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 27,
-                "end_col_offset": 28
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 30
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 30
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "b",
-                  "kind": null,
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 12,
-                  "end_col_offset": 15
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 124,
+        "end": 155,
+        "children": [
+          {
+            "kind": "call",
+            "start": 124,
+            "end": 155,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 124,
+                "end": 129
+              },
+              {
+                "kind": "argument_list",
+                "start": 129,
+                "end": 155,
+                "children": [
                   {
-                    "_type": "GtE"
+                    "kind": "parenthesized_expression",
+                    "start": 130,
+                    "end": 154,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 131,
+                        "end": 153,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 131,
+                            "end": 132
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 136,
+                            "end": 146,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 136,
+                                "end": 139,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 136,
+                                    "end": 137
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 137,
+                                    "end": 138
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 138,
+                                    "end": 139
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 143,
+                                "end": 146,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 143,
+                                    "end": 144
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 144,
+                                    "end": 145
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 145,
+                                    "end": 146
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 152,
+                            "end": 153
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 156,
+        "end": 186,
+        "children": [
+          {
+            "kind": "call",
+            "start": 156,
+            "end": 186,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 156,
+                "end": 161
+              },
+              {
+                "kind": "argument_list",
+                "start": 161,
+                "end": 186,
+                "children": [
                   {
-                    "_type": "Constant",
-                    "value": "b",
-                    "kind": null,
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 19,
-                    "end_col_offset": 22
+                    "kind": "parenthesized_expression",
+                    "start": 162,
+                    "end": 185,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 163,
+                        "end": 184,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 163,
+                            "end": 164
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 168,
+                            "end": 177,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 168,
+                                "end": 171,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 168,
+                                    "end": 169
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 169,
+                                    "end": 170
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 170,
+                                    "end": 171
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 174,
+                                "end": 177,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 174,
+                                    "end": 175
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 175,
+                                    "end": 176
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 176,
+                                    "end": 177
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 183,
+                            "end": 184
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 22
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 187,
+        "end": 218,
+        "children": [
+          {
+            "kind": "call",
+            "start": 187,
+            "end": 218,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 192
               },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 28,
-                "end_col_offset": 29
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 31
+              {
+                "kind": "argument_list",
+                "start": 192,
+                "end": 218,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 193,
+                    "end": 217,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 194,
+                        "end": 216,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 194,
+                            "end": 195
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 199,
+                            "end": 209,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 199,
+                                "end": 202,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 199,
+                                    "end": 200
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 200,
+                                    "end": 201
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 201,
+                                    "end": 202
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 206,
+                                "end": 209,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 206,
+                                    "end": 207
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 207,
+                                    "end": 208
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 208,
+                                    "end": 209
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 215,
+                            "end": 216
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_concat.py.json
+++ b/tests/json-ast/x/py/string_concat.py.json
@@ -1,61 +1,95 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 119,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": "hello ",
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 14
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 118,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 118,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": "world",
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 17,
-                "end_col_offset": 24
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 24
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 25
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 25
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 99,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 99,
+                        "end": 107,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 100,
+                            "end": 106
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 106,
+                            "end": 107
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "string",
+                        "start": 110,
+                        "end": 117,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 110,
+                            "end": 111
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 111,
+                            "end": 116
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 116,
+                            "end": 117
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_contains.py.json
+++ b/tests/json-ast/x/py/string_contains.py.json
@@ -1,152 +1,179 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 141,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "string",
+                "start": 97,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 97,
+                    "end": 98
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 98,
+                    "end": 103
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 103,
+                    "end": 104
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "catch",
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 11
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Compare",
-              "left": {
-                "_type": "Constant",
-                "value": "cat",
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 11
+        "kind": "expression_statement",
+        "start": 105,
+        "end": 122,
+        "children": [
+          {
+            "kind": "call",
+            "start": 105,
+            "end": 122,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 110
               },
-              "ops": [
-                {
-                  "_type": "In"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Name",
-                  "id": "s",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 16
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 17
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 17
+              {
+                "kind": "argument_list",
+                "start": 110,
+                "end": 122,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 111,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 111,
+                        "end": 116,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 111,
+                            "end": 112
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 112,
+                            "end": 115
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 115,
+                            "end": 116
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 120,
+                        "end": 121
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Compare",
-              "left": {
-                "_type": "Constant",
-                "value": "dog",
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 6,
-                "end_col_offset": 11
+        "kind": "expression_statement",
+        "start": 123,
+        "end": 140,
+        "children": [
+          {
+            "kind": "call",
+            "start": 123,
+            "end": 140,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 123,
+                "end": 128
               },
-              "ops": [
-                {
-                  "_type": "In"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Name",
-                  "id": "s",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                }
-              ],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 16
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 17
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 17
+              {
+                "kind": "argument_list",
+                "start": 128,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 129,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 129,
+                        "end": 134,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 129,
+                            "end": 130
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 130,
+                            "end": 133
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 133,
+                            "end": 134
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 138,
+                        "end": 139
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_in_operator.py.json
+++ b/tests/json-ast/x/py/string_in_operator.py.json
@@ -1,202 +1,227 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 169,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
           {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 93,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "string",
+                "start": 97,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 97,
+                    "end": 98
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 98,
+                    "end": 103
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 103,
+                    "end": 104
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "catch",
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 11
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "cat",
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 17
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 105,
+        "end": 136,
+        "children": [
+          {
+            "kind": "call",
+            "start": 105,
+            "end": 136,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 110
+              },
+              {
+                "kind": "argument_list",
+                "start": 110,
+                "end": 136,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 111,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 112,
+                        "end": 134,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 112,
+                            "end": 113
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 117,
+                            "end": 127,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 117,
+                                "end": 122,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 117,
+                                    "end": 118
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 118,
+                                    "end": 121
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 121,
+                                    "end": 122
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 126,
+                                "end": 127
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 133,
+                            "end": 134
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 21,
-                    "end_col_offset": 22
-                  }
-                ],
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 12,
-                "end_col_offset": 22
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 28,
-                "end_col_offset": 29
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 31
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Constant",
-                  "value": "dog",
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 17
-                },
-                "ops": [
+        "kind": "expression_statement",
+        "start": 137,
+        "end": 168,
+        "children": [
+          {
+            "kind": "call",
+            "start": 137,
+            "end": 168,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 137,
+                "end": 142
+              },
+              {
+                "kind": "argument_list",
+                "start": 142,
+                "end": 168,
+                "children": [
                   {
-                    "_type": "In"
+                    "kind": "parenthesized_expression",
+                    "start": 143,
+                    "end": 167,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 144,
+                        "end": 166,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 144,
+                            "end": 145
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 149,
+                            "end": 159,
+                            "children": [
+                              {
+                                "kind": "string",
+                                "start": 149,
+                                "end": 154,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 149,
+                                    "end": 150
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 150,
+                                    "end": 153
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 153,
+                                    "end": 154
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 158,
+                                "end": 159
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 165,
+                            "end": 166
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "s",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 21,
-                    "end_col_offset": 22
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 22
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 28,
-                "end_col_offset": 29
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 29
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 31
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 31
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_index.py.json
+++ b/tests/json-ast/x/py/string_index.py.json
@@ -1,87 +1,102 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 117,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "s",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "mochi",
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 11
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 11
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "s",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 104,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 8,
-                "end_col_offset": 9
+              {
+                "kind": "string",
+                "start": 97,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 97,
+                    "end": 98
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 98,
+                    "end": 103
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 103,
+                    "end": 104
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 105,
+        "end": 116,
+        "children": [
+          {
+            "kind": "call",
+            "start": 105,
+            "end": 116,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 110
               },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 11
+              {
+                "kind": "argument_list",
+                "start": 110,
+                "end": 116,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 111,
+                    "end": 115,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 111,
+                        "end": 112
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 113,
+                        "end": 114
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/string_prefix_slice.py.json
+++ b/tests/json-ast/x/py/string_prefix_slice.py.json
@@ -1,372 +1,361 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 235,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "prefix",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "fore",
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 9,
-          "end_col_offset": 15
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 15
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "s1",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "forest",
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 5,
-          "end_col_offset": 13
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 13
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Subscript",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s1",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 12,
-                    "end_col_offset": 14
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 108,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 108,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 99
+              },
+              {
+                "kind": "string",
+                "start": 102,
+                "end": 108,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 102,
+                    "end": 103
                   },
-                  "slice": {
-                    "_type": "Slice",
-                    "lower": {
-                      "_type": "Constant",
-                      "value": 0,
-                      "kind": null,
-                      "lineno": 5,
-                      "end_lineno": 5,
-                      "col_offset": 15,
-                      "end_col_offset": 16
-                    },
-                    "upper": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "len",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 5,
-                        "end_lineno": 5,
-                        "col_offset": 17,
-                        "end_col_offset": 20
-                      },
-                      "args": [
-                        {
-                          "_type": "Name",
-                          "id": "prefix",
-                          "ctx": {
-                            "_type": "Load"
+                  {
+                    "kind": "string_content",
+                    "start": 103,
+                    "end": 107
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 107,
+                    "end": 108
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 109,
+        "end": 122,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 109,
+            "end": 122,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 109,
+                "end": 111
+              },
+              {
+                "kind": "string",
+                "start": 114,
+                "end": 122,
+                "children": [
+                  {
+                    "kind": "string_start",
+                    "start": 114,
+                    "end": 115
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 115,
+                    "end": 121
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 121,
+                    "end": 122
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 123,
+        "end": 171,
+        "children": [
+          {
+            "kind": "call",
+            "start": 123,
+            "end": 171,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 123,
+                "end": 128
+              },
+              {
+                "kind": "argument_list",
+                "start": 128,
+                "end": 171,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 129,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 130,
+                        "end": 169,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 130,
+                            "end": 131
                           },
-                          "lineno": 5,
-                          "end_lineno": 5,
-                          "col_offset": 21,
-                          "end_col_offset": 27
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 5,
-                      "end_lineno": 5,
-                      "col_offset": 17,
-                      "end_col_offset": 28
-                    },
-                    "step": null,
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 15,
-                    "end_col_offset": 28
-                  },
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 12,
-                  "end_col_offset": 29
-                },
-                "ops": [
-                  {
-                    "_type": "Eq"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "prefix",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 5,
-                    "end_lineno": 5,
-                    "col_offset": 33,
-                    "end_col_offset": 39
-                  }
-                ],
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 12,
-                "end_col_offset": 39
-              },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 45,
-                "end_col_offset": 46
-              },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 7,
-              "end_col_offset": 46
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 48
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 48
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "s2",
-            "lineno": 6,
-            "end_lineno": 6,
-            "end_col_offset": 2
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": "desert",
-          "kind": null,
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 5,
-          "end_col_offset": 13
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Subscript",
-                  "value": {
-                    "_type": "Name",
-                    "id": "s2",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 12,
-                    "end_col_offset": 14
-                  },
-                  "slice": {
-                    "_type": "Slice",
-                    "lower": {
-                      "_type": "Constant",
-                      "value": 0,
-                      "kind": null,
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 15,
-                      "end_col_offset": 16
-                    },
-                    "upper": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "len",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 17,
-                        "end_col_offset": 20
-                      },
-                      "args": [
-                        {
-                          "_type": "Name",
-                          "id": "prefix",
-                          "ctx": {
-                            "_type": "Load"
+                          {
+                            "kind": "comparison_operator",
+                            "start": 135,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "subscript",
+                                "start": 135,
+                                "end": 152,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 135,
+                                    "end": 137
+                                  },
+                                  {
+                                    "kind": "slice",
+                                    "start": 138,
+                                    "end": 151,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 138,
+                                        "end": 139
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 140,
+                                        "end": 151,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 140,
+                                            "end": 143
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 143,
+                                            "end": 151,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 144,
+                                                "end": 150
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 156,
+                                "end": 162
+                              }
+                            ]
                           },
-                          "lineno": 7,
-                          "end_lineno": 7,
-                          "col_offset": 21,
-                          "end_col_offset": 27
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 17,
-                      "end_col_offset": 28
-                    },
-                    "step": null,
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 15,
-                    "end_col_offset": 28
-                  },
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 12,
-                  "end_col_offset": 29
-                },
-                "ops": [
-                  {
-                    "_type": "Eq"
+                          {
+                            "kind": "integer",
+                            "start": 168,
+                            "end": 169
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "comparators": [
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 172,
+        "end": 185,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 172,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 172,
+                "end": 174
+              },
+              {
+                "kind": "string",
+                "start": 177,
+                "end": 185,
+                "children": [
                   {
-                    "_type": "Name",
-                    "id": "prefix",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 7,
-                    "end_lineno": 7,
-                    "col_offset": 33,
-                    "end_col_offset": 39
+                    "kind": "string_start",
+                    "start": 177,
+                    "end": 178
+                  },
+                  {
+                    "kind": "string_content",
+                    "start": 178,
+                    "end": 184
+                  },
+                  {
+                    "kind": "string_end",
+                    "start": 184,
+                    "end": 185
                   }
-                ],
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 12,
-                "end_col_offset": 39
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 186,
+        "end": 234,
+        "children": [
+          {
+            "kind": "call",
+            "start": 186,
+            "end": 234,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 186,
+                "end": 191
               },
-              "body": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "orelse": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 45,
-                "end_col_offset": 46
-              },
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 7,
-              "end_col_offset": 46
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 48
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 48
+              {
+                "kind": "argument_list",
+                "start": 191,
+                "end": 234,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 192,
+                    "end": 233,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 193,
+                        "end": 232,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 193,
+                            "end": 194
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 198,
+                            "end": 225,
+                            "children": [
+                              {
+                                "kind": "subscript",
+                                "start": 198,
+                                "end": 215,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 198,
+                                    "end": 200
+                                  },
+                                  {
+                                    "kind": "slice",
+                                    "start": 201,
+                                    "end": 214,
+                                    "children": [
+                                      {
+                                        "kind": "integer",
+                                        "start": 201,
+                                        "end": 202
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 203,
+                                        "end": 214,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 203,
+                                            "end": 206
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 206,
+                                            "end": 214,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 207,
+                                                "end": 213
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 219,
+                                "end": 225
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 231,
+                            "end": 232
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/substring_builtin.py.json
+++ b/tests/json-ast/x/py/substring_builtin.py.json
@@ -1,78 +1,90 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 113,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Constant",
-                "value": "mochi",
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 13
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 112,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 112,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "slice": {
-                "_type": "Slice",
-                "lower": {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 14,
-                  "end_col_offset": 15
-                },
-                "upper": {
-                  "_type": "Constant",
-                  "value": 4,
-                  "kind": null,
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 16,
-                  "end_col_offset": 17
-                },
-                "step": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 14,
-                "end_col_offset": 17
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 18
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 19
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 19
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 99,
+                    "end": 111,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 99,
+                        "end": 106,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 100,
+                            "end": 105
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 105,
+                            "end": 106
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "slice",
+                        "start": 107,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 109,
+                            "end": 110
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/sum_builtin.py.json
+++ b/tests/json-ast/x/py/sum_builtin.py.json
@@ -1,93 +1,85 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 115,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "sum",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 6,
-                "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 114,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 114,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "args": [
-                {
-                  "_type": "List",
-                  "elts": [
-                    {
-                      "_type": "Constant",
-                      "value": 1,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 11,
-                      "end_col_offset": 12
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 14,
-                      "end_col_offset": 15
-                    },
-                    {
-                      "_type": "Constant",
-                      "value": 3,
-                      "kind": null,
-                      "lineno": 3,
-                      "end_lineno": 3,
-                      "col_offset": 17,
-                      "end_col_offset": 18
-                    }
-                  ],
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 3,
-                  "end_lineno": 3,
-                  "col_offset": 10,
-                  "end_col_offset": 19
-                }
-              ],
-              "keywords": [],
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 21
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 99,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 99,
+                        "end": 102
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 102,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "list",
+                            "start": 103,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "integer",
+                                "start": 104,
+                                "end": 105
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 107,
+                                "end": 108
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 110,
+                                "end": 111
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/tail_recursion.py.json
+++ b/tests/json-ast/x/py/tail_recursion.py.json
@@ -1,259 +1,212 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 205,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "sum_rec",
-        "body": [
-          {
-            "_type": "If",
-            "body": [
-              {
-                "_type": "Return",
-                "value": {
-                  "_type": "Name",
-                  "id": "acc",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 15,
-                  "end_col_offset": 18
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 8,
-                "end_col_offset": 18
-              }
-            ],
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Name",
-                "id": "n",
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "ops": [
-                {
-                  "_type": "Eq"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                }
-              ],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 7,
-              "end_col_offset": 13
-            },
-            "lineno": 4,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 18
-          },
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "sum_rec",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 11,
-                "end_col_offset": 18
-              },
-              "args": [
-                {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Name",
-                    "id": "n",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 19,
-                    "end_col_offset": 20
-                  },
-                  "op": {
-                    "_type": "Sub"
-                  },
-                  "right": {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 23,
-                    "end_col_offset": 24
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 19,
-                  "end_col_offset": 24
-                },
-                {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Name",
-                    "id": "acc",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 26,
-                    "end_col_offset": 29
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Name",
-                    "id": "n",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 32,
-                    "end_col_offset": 33
-                  },
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 26,
-                  "end_col_offset": 33
-                }
-              ],
-              "keywords": [],
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 11,
-              "end_col_offset": 34
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 4,
-            "end_col_offset": 34
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "n",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 12,
-              "end_col_offset": 13
-            },
-            {
-              "_type": "arg",
-              "arg": "acc",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 15,
-              "end_col_offset": 18
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 6,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 182,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 97,
+            "end": 104
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "sum_rec",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 7,
-                "end_lineno": 7,
-                "col_offset": 6,
-                "end_col_offset": 13
+          {
+            "kind": "parameters",
+            "start": 104,
+            "end": 112,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 106
               },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 10,
-                  "kind": null,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 14,
-                  "end_col_offset": 16
-                },
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "kind": null,
-                  "lineno": 7,
-                  "end_lineno": 7,
-                  "col_offset": 18,
-                  "end_col_offset": 19
-                }
-              ],
-              "keywords": [],
-              "lineno": 7,
-              "end_lineno": 7,
-              "col_offset": 6,
-              "end_col_offset": 20
-            }
-          ],
-          "keywords": [],
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 0,
-          "end_col_offset": 21
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 21
+              {
+                "kind": "identifier",
+                "start": 108,
+                "end": 111
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 118,
+            "end": 182,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 118,
+                "end": 147,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 121,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 121,
+                        "end": 122
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 126,
+                        "end": 127
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 137,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "return_statement",
+                        "start": 137,
+                        "end": 147,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 144,
+                            "end": 147
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "return_statement",
+                "start": 152,
+                "end": 182,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 159,
+                    "end": 182,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 159,
+                        "end": 166
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 166,
+                        "end": 182,
+                        "children": [
+                          {
+                            "kind": "binary_operator",
+                            "start": 167,
+                            "end": 172,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 167,
+                                "end": 168
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 171,
+                                "end": 172
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "binary_operator",
+                            "start": 174,
+                            "end": 181,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 174,
+                                "end": 177
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 180,
+                                "end": 181
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 183,
+        "end": 204,
+        "children": [
+          {
+            "kind": "call",
+            "start": 183,
+            "end": 204,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 183,
+                "end": 188
+              },
+              {
+                "kind": "argument_list",
+                "start": 188,
+                "end": 204,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 189,
+                    "end": 203,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 189,
+                        "end": 196
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 196,
+                        "end": 203,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 197,
+                            "end": 199
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 201,
+                            "end": 202
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/test_block.py.json
+++ b/tests/json-ast/x/py/test_block.py.json
@@ -1,121 +1,131 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 151,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "comment",
+        "start": 93,
+        "end": 114
+      },
+      {
+        "kind": "expression_statement",
+        "start": 115,
+        "end": 124,
+        "children": [
           {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 1
+            "kind": "assignment",
+            "start": 115,
+            "end": 124,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 115,
+                "end": 116
+              },
+              {
+                "kind": "binary_operator",
+                "start": 119,
+                "end": 124,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 119,
+                    "end": 120
+                  },
+                  {
+                    "kind": "integer",
+                    "start": 123,
+                    "end": 124
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "BinOp",
-          "left": {
-            "_type": "Constant",
-            "value": 1,
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 5
-          },
-          "op": {
-            "_type": "Add"
-          },
-          "right": {
-            "_type": "Constant",
-            "value": 2,
-            "kind": null,
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 8,
-            "end_col_offset": 9
-          },
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 9
+        ]
       },
       {
-        "_type": "Assert",
-        "test": {
-          "_type": "Compare",
-          "left": {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 7,
-            "end_col_offset": 8
-          },
-          "ops": [
-            {
-              "_type": "Eq"
-            }
-          ],
-          "comparators": [
-            {
-              "_type": "Constant",
-              "value": 3,
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 12,
-              "end_col_offset": 13
-            }
-          ],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 7,
-          "end_col_offset": 13
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 13
+        "kind": "assert_statement",
+        "start": 125,
+        "end": 138,
+        "children": [
+          {
+            "kind": "comparison_operator",
+            "start": 132,
+            "end": 138,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 132,
+                "end": 133
+              },
+              {
+                "kind": "integer",
+                "start": 137,
+                "end": 138
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "ok",
-              "kind": null,
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 6,
-          "end_lineno": 6,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 6,
-        "end_lineno": 6,
-        "end_col_offset": 11
+        "kind": "expression_statement",
+        "start": 139,
+        "end": 150,
+        "children": [
+          {
+            "kind": "call",
+            "start": 139,
+            "end": 150,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 139,
+                "end": 144
+              },
+              {
+                "kind": "argument_list",
+                "start": 144,
+                "end": 150,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 145,
+                    "end": 149,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 145,
+                        "end": 146
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 146,
+                        "end": 148
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 148,
+                        "end": 149
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/tree_sum.py.json
+++ b/tests/json-ast/x/py/tree_sum.py.json
@@ -1,621 +1,683 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 489,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Assign",
-        "targets": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "Name",
-            "id": "Leaf",
-            "lineno": 7,
-            "end_lineno": 7,
-            "end_col_offset": 4
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": null,
-          "kind": null,
-          "lineno": 7,
-          "end_lineno": 7,
-          "col_offset": 7,
-          "end_col_offset": 11
-        },
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 11
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Node",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "Tree",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "left",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "value",
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 4,
-            "end_col_offset": 14
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "Tree",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "right",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 15
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 9,
-        "end_lineno": 12,
-        "end_col_offset": 15
+        ]
       },
       {
-        "_type": "FunctionDef",
-        "name": "sum_tree",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "Return",
-            "value": {
-              "_type": "IfExp",
-              "test": {
-                "_type": "Compare",
-                "left": {
-                  "_type": "Name",
-                  "id": "t",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "ops": [
-                  {
-                    "_type": "Eq"
-                  }
-                ],
-                "comparators": [
-                  {
-                    "_type": "Name",
-                    "id": "Leaf",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 22,
-                    "end_col_offset": 26
-                  }
-                ],
-                "lineno": 15,
-                "end_lineno": 15,
-                "col_offset": 17,
-                "end_col_offset": 26
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 193,
+        "end": 204,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 193,
+            "end": 204,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 193,
+                "end": 197
               },
-              "body": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 15,
-                "end_lineno": 15,
-                "col_offset": 12,
-                "end_col_offset": 13
+              {
+                "kind": "none",
+                "start": 200,
+                "end": 204
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 205,
+        "end": 273,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 205,
+            "end": 215,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 206,
+                "end": 215
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 216,
+            "end": 273,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 222,
+                "end": 226
               },
-              "orelse": {
-                "_type": "IfExp",
-                "test": {
-                  "_type": "Compare",
-                  "left": {
-                    "_type": "Name",
-                    "id": "t",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 83,
-                    "end_col_offset": 84
-                  },
-                  "ops": [
-                    {
-                      "_type": "NotEq"
-                    }
-                  ],
-                  "comparators": [
-                    {
-                      "_type": "Constant",
-                      "value": null,
-                      "kind": null,
-                      "lineno": 15,
-                      "end_lineno": 15,
-                      "col_offset": 88,
-                      "end_col_offset": 92
-                    }
-                  ],
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 83,
-                  "end_col_offset": 92
-                },
-                "body": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "BinOp",
-                    "left": {
-                      "_type": "Call",
-                      "func": {
-                        "_type": "Name",
-                        "id": "sum_tree",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 15,
-                        "end_lineno": 15,
-                        "col_offset": 33,
-                        "end_col_offset": 41
-                      },
-                      "args": [
-                        {
-                          "_type": "Attribute",
-                          "value": {
-                            "_type": "Name",
-                            "id": "t",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 15,
-                            "end_lineno": 15,
-                            "col_offset": 42,
-                            "end_col_offset": 43
-                          },
-                          "attr": "left",
-                          "ctx": {
-                            "_type": "Load"
-                          },
-                          "lineno": 15,
-                          "end_lineno": 15,
-                          "col_offset": 42,
-                          "end_col_offset": 48
-                        }
-                      ],
-                      "keywords": [],
-                      "lineno": 15,
-                      "end_lineno": 15,
-                      "col_offset": 33,
-                      "end_col_offset": 49
-                    },
-                    "op": {
-                      "_type": "Add"
-                    },
-                    "right": {
-                      "_type": "Attribute",
-                      "value": {
-                        "_type": "Name",
-                        "id": "t",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 15,
-                        "end_lineno": 15,
-                        "col_offset": 52,
-                        "end_col_offset": 53
-                      },
-                      "attr": "value",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 15,
-                      "end_lineno": 15,
-                      "col_offset": 52,
-                      "end_col_offset": 59
-                    },
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 33,
-                    "end_col_offset": 59
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Call",
-                    "func": {
-                      "_type": "Name",
-                      "id": "sum_tree",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 15,
-                      "end_lineno": 15,
-                      "col_offset": 62,
-                      "end_col_offset": 70
-                    },
-                    "args": [
+              {
+                "kind": "block",
+                "start": 232,
+                "end": 273,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 232,
+                    "end": 242,
+                    "children": [
                       {
-                        "_type": "Attribute",
-                        "value": {
-                          "_type": "Name",
-                          "id": "t",
-                          "ctx": {
-                            "_type": "Load"
+                        "kind": "assignment",
+                        "start": 232,
+                        "end": 242,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 232,
+                            "end": 236
                           },
-                          "lineno": 15,
-                          "end_lineno": 15,
-                          "col_offset": 71,
-                          "end_col_offset": 72
-                        },
-                        "attr": "right",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 15,
-                        "end_lineno": 15,
-                        "col_offset": 71,
-                        "end_col_offset": 78
+                          {
+                            "kind": "type",
+                            "start": 238,
+                            "end": 242,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 238,
+                                "end": 242
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "keywords": [],
-                    "lineno": 15,
-                    "end_lineno": 15,
-                    "col_offset": 62,
-                    "end_col_offset": 79
-                  },
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 33,
-                  "end_col_offset": 79
-                },
-                "orelse": {
-                  "_type": "Constant",
-                  "value": null,
-                  "kind": null,
-                  "lineno": 15,
-                  "end_lineno": 15,
-                  "col_offset": 98,
-                  "end_col_offset": 102
-                },
-                "lineno": 15,
-                "end_lineno": 15,
-                "col_offset": 33,
-                "end_col_offset": 102
-              },
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 12,
-              "end_col_offset": 103
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 104
-          }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "t",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 13,
-              "end_col_offset": 14
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 14,
-        "end_lineno": 15,
-        "end_col_offset": 104
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "t",
-            "lineno": 16,
-            "end_lineno": 16,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "Node",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 8
-          },
-          "args": [],
-          "keywords": [
-            {
-              "_type": "keyword",
-              "arg": "left",
-              "value": {
-                "_type": "Name",
-                "id": "Leaf",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 14,
-                "end_col_offset": 18
-              },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 9,
-              "end_col_offset": 18
-            },
-            {
-              "_type": "keyword",
-              "arg": "value",
-              "value": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 26,
-                "end_col_offset": 27
-              },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 20,
-              "end_col_offset": 27
-            },
-            {
-              "_type": "keyword",
-              "arg": "right",
-              "value": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "Node",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 35,
-                  "end_col_offset": 39
-                },
-                "args": [],
-                "keywords": [
-                  {
-                    "_type": "keyword",
-                    "arg": "left",
-                    "value": {
-                      "_type": "Name",
-                      "id": "Leaf",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 16,
-                      "end_lineno": 16,
-                      "col_offset": 45,
-                      "end_col_offset": 49
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 40,
-                    "end_col_offset": 49
+                    ]
                   },
                   {
-                    "_type": "keyword",
-                    "arg": "value",
-                    "value": {
-                      "_type": "Constant",
-                      "value": 2,
-                      "kind": null,
-                      "lineno": 16,
-                      "end_lineno": 16,
-                      "col_offset": 57,
-                      "end_col_offset": 58
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 51,
-                    "end_col_offset": 58
+                    "kind": "expression_statement",
+                    "start": 247,
+                    "end": 257,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 247,
+                        "end": 257,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 247,
+                            "end": 252
+                          },
+                          {
+                            "kind": "type",
+                            "start": 254,
+                            "end": 257,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 254,
+                                "end": 257
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "_type": "keyword",
-                    "arg": "right",
-                    "value": {
-                      "_type": "Name",
-                      "id": "Leaf",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 16,
-                      "end_lineno": 16,
-                      "col_offset": 66,
-                      "end_col_offset": 70
-                    },
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 60,
-                    "end_col_offset": 70
+                    "kind": "expression_statement",
+                    "start": 262,
+                    "end": 273,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 262,
+                        "end": 273,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 262,
+                            "end": 267
+                          },
+                          {
+                            "kind": "type",
+                            "start": 269,
+                            "end": 273,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 269,
+                                "end": 273
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 35,
-                "end_col_offset": 71
-              },
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 29,
-              "end_col_offset": 71
-            }
-          ],
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 4,
-          "end_col_offset": 72
-        },
-        "lineno": 16,
-        "end_lineno": 16,
-        "end_col_offset": 72
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "function_definition",
+        "start": 275,
+        "end": 396,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 279,
+            "end": 287
           },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "sum_tree",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 6,
-                "end_col_offset": 14
+          {
+            "kind": "parameters",
+            "start": 287,
+            "end": 290,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 288,
+                "end": 289
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 296,
+            "end": 396,
+            "children": [
+              {
+                "kind": "return_statement",
+                "start": 296,
+                "end": 396,
+                "children": [
+                  {
+                    "kind": "parenthesized_expression",
+                    "start": 303,
+                    "end": 396,
+                    "children": [
+                      {
+                        "kind": "conditional_expression",
+                        "start": 304,
+                        "end": 395,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 304,
+                            "end": 305
+                          },
+                          {
+                            "kind": "comparison_operator",
+                            "start": 309,
+                            "end": 318,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 309,
+                                "end": 310
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 314,
+                                "end": 318
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "parenthesized_expression",
+                            "start": 324,
+                            "end": 395,
+                            "children": [
+                              {
+                                "kind": "conditional_expression",
+                                "start": 325,
+                                "end": 394,
+                                "children": [
+                                  {
+                                    "kind": "binary_operator",
+                                    "start": 325,
+                                    "end": 371,
+                                    "children": [
+                                      {
+                                        "kind": "binary_operator",
+                                        "start": 325,
+                                        "end": 351,
+                                        "children": [
+                                          {
+                                            "kind": "call",
+                                            "start": 325,
+                                            "end": 341,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 325,
+                                                "end": 333
+                                              },
+                                              {
+                                                "kind": "argument_list",
+                                                "start": 333,
+                                                "end": 341,
+                                                "children": [
+                                                  {
+                                                    "kind": "attribute",
+                                                    "start": 334,
+                                                    "end": 340,
+                                                    "children": [
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 334,
+                                                        "end": 335
+                                                      },
+                                                      {
+                                                        "kind": "identifier",
+                                                        "start": 336,
+                                                        "end": 340
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "attribute",
+                                            "start": 344,
+                                            "end": 351,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 344,
+                                                "end": 345
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 346,
+                                                "end": 351
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call",
+                                        "start": 354,
+                                        "end": 371,
+                                        "children": [
+                                          {
+                                            "kind": "identifier",
+                                            "start": 354,
+                                            "end": 362
+                                          },
+                                          {
+                                            "kind": "argument_list",
+                                            "start": 362,
+                                            "end": 371,
+                                            "children": [
+                                              {
+                                                "kind": "attribute",
+                                                "start": 363,
+                                                "end": 370,
+                                                "children": [
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 363,
+                                                    "end": 364
+                                                  },
+                                                  {
+                                                    "kind": "identifier",
+                                                    "start": 365,
+                                                    "end": 370
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 375,
+                                    "end": 384,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 375,
+                                        "end": 376
+                                      },
+                                      {
+                                        "kind": "none",
+                                        "start": 380,
+                                        "end": 384
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "none",
+                                    "start": 390,
+                                    "end": 394
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 397,
+        "end": 469,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 397,
+            "end": 469,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 397,
+                "end": 398
               },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "t",
-                  "ctx": {
-                    "_type": "Load"
+              {
+                "kind": "call",
+                "start": 401,
+                "end": 469,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 401,
+                    "end": 405
                   },
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 15,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 6,
-              "end_col_offset": 17
-            }
-          ],
-          "keywords": [],
-          "lineno": 17,
-          "end_lineno": 17,
-          "col_offset": 0,
-          "end_col_offset": 18
-        },
-        "lineno": 17,
-        "end_lineno": 17,
-        "end_col_offset": 18
+                  {
+                    "kind": "argument_list",
+                    "start": 405,
+                    "end": 469,
+                    "children": [
+                      {
+                        "kind": "keyword_argument",
+                        "start": 406,
+                        "end": 415,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 406,
+                            "end": 410
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 411,
+                            "end": 415
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "keyword_argument",
+                        "start": 417,
+                        "end": 424,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 417,
+                            "end": 422
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 423,
+                            "end": 424
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "keyword_argument",
+                        "start": 426,
+                        "end": 468,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 426,
+                            "end": 431
+                          },
+                          {
+                            "kind": "call",
+                            "start": 432,
+                            "end": 468,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 432,
+                                "end": 436
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 436,
+                                "end": 468,
+                                "children": [
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 437,
+                                    "end": 446,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 437,
+                                        "end": 441
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 442,
+                                        "end": 446
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 448,
+                                    "end": 455,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 448,
+                                        "end": 453
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 454,
+                                        "end": 455
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 457,
+                                    "end": 467,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 457,
+                                        "end": 462
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 463,
+                                        "end": 467
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 470,
+        "end": 488,
+        "children": [
+          {
+            "kind": "call",
+            "start": 470,
+            "end": 488,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 470,
+                "end": 475
+              },
+              {
+                "kind": "argument_list",
+                "start": 475,
+                "end": 488,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 476,
+                    "end": 487,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 476,
+                        "end": 484
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 484,
+                        "end": 487,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 485,
+                            "end": 486
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/two-sum.py.json
+++ b/tests/json-ast/x/py/two-sum.py.json
@@ -1,622 +1,490 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 360,
+    "children": [
       {
-        "_type": "FunctionDef",
-        "name": "twoSum",
-        "body": [
+        "kind": "comment",
+        "start": 0,
+        "end": 37
+      },
+      {
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "function_definition",
+        "start": 93,
+        "end": 290,
+        "children": [
           {
-            "_type": "Assign",
-            "targets": [
-              {
-                "_type": "Name",
-                "id": "n",
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 4,
-                "end_col_offset": 5
-              }
-            ],
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "len",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 8,
-                "end_col_offset": 11
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "nums",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 12,
-                  "end_col_offset": 16
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 8,
-              "end_col_offset": 17
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 4,
-            "end_col_offset": 17
+            "kind": "identifier",
+            "start": 97,
+            "end": 103
           },
           {
-            "_type": "For",
-            "body": [
+            "kind": "parameters",
+            "start": 103,
+            "end": 117,
+            "children": [
               {
-                "_type": "For",
-                "body": [
+                "kind": "identifier",
+                "start": 104,
+                "end": 108
+              },
+              {
+                "kind": "identifier",
+                "start": 110,
+                "end": 116
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 123,
+            "end": 290,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 123,
+                "end": 136,
+                "children": [
                   {
-                    "_type": "If",
-                    "body": [
+                    "kind": "assignment",
+                    "start": 123,
+                    "end": 136,
+                    "children": [
                       {
-                        "_type": "Return",
-                        "value": {
-                          "_type": "List",
-                          "elts": [
-                            {
-                              "_type": "Name",
-                              "id": "i",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 8,
-                              "end_lineno": 8,
-                              "col_offset": 24,
-                              "end_col_offset": 25
-                            },
-                            {
-                              "_type": "Name",
-                              "id": "j",
-                              "ctx": {
-                                "_type": "Load"
-                              },
-                              "lineno": 8,
-                              "end_lineno": 8,
-                              "col_offset": 27,
-                              "end_col_offset": 28
-                            }
-                          ],
-                          "ctx": {
-                            "_type": "Load"
+                        "kind": "identifier",
+                        "start": 123,
+                        "end": 124
+                      },
+                      {
+                        "kind": "call",
+                        "start": 127,
+                        "end": 136,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 127,
+                            "end": 130
                           },
-                          "lineno": 8,
-                          "end_lineno": 8,
-                          "col_offset": 23,
-                          "end_col_offset": 29
-                        },
-                        "lineno": 8,
-                        "end_lineno": 8,
-                        "col_offset": 16,
-                        "end_col_offset": 29
+                          {
+                            "kind": "argument_list",
+                            "start": 130,
+                            "end": 136,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 131,
+                                "end": 135
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ],
-                    "test": {
-                      "_type": "Compare",
-                      "left": {
-                        "_type": "BinOp",
-                        "op": {
-                          "_type": "Add"
-                        },
-                        "left": {
-                          "_type": "Subscript",
-                          "value": {
-                            "_type": "Name",
-                            "id": "nums",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 7,
-                            "end_lineno": 7,
-                            "col_offset": 15,
-                            "end_col_offset": 19
-                          },
-                          "slice": {
-                            "_type": "Name",
-                            "id": "i",
-                            "lineno": 7,
-                            "end_lineno": 7,
-                            "col_offset": 20,
-                            "end_col_offset": 21
-                          },
-                          "lineno": 7,
-                          "end_lineno": 7,
-                          "col_offset": 15,
-                          "end_col_offset": 22
-                        },
-                        "right": {
-                          "_type": "Subscript",
-                          "value": {
-                            "_type": "Name",
-                            "id": "nums",
-                            "ctx": {
-                              "_type": "Load"
-                            },
-                            "lineno": 7,
-                            "end_lineno": 7,
-                            "col_offset": 25,
-                            "end_col_offset": 29
-                          },
-                          "slice": {
-                            "_type": "Name",
-                            "id": "j",
-                            "lineno": 7,
-                            "end_lineno": 7,
-                            "col_offset": 30,
-                            "end_col_offset": 31
-                          },
-                          "lineno": 7,
-                          "end_lineno": 7,
-                          "col_offset": 25,
-                          "end_col_offset": 32
-                        },
-                        "lineno": 7,
-                        "end_lineno": 7,
-                        "col_offset": 15,
-                        "end_col_offset": 32
-                      },
-                      "ops": [
-                        {
-                          "_type": "Eq"
-                        }
-                      ],
-                      "comparators": [
-                        {
-                          "_type": "Name",
-                          "id": "target",
-                          "lineno": 7,
-                          "end_lineno": 7,
-                          "col_offset": 36,
-                          "end_col_offset": 42
-                        }
-                      ],
-                      "lineno": 7,
-                      "end_lineno": 7,
-                      "col_offset": 15,
-                      "end_col_offset": 42
-                    },
-                    "lineno": 7,
-                    "end_lineno": 8,
-                    "col_offset": 12,
-                    "end_col_offset": 29
+                    ]
                   }
-                ],
-                "target": {
-                  "_type": "Name",
-                  "id": "j",
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 12,
-                  "end_col_offset": 13
-                },
-                "iter": {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "range",
-                    "lineno": 6,
-                    "end_lineno": 6,
-                    "col_offset": 17,
-                    "end_col_offset": 22
+                ]
+              },
+              {
+                "kind": "for_statement",
+                "start": 141,
+                "end": 270,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 145,
+                    "end": 146
                   },
-                  "args": [
-                    {
-                      "_type": "BinOp",
-                      "left": {
-                        "_type": "Name",
-                        "id": "i",
-                        "ctx": {
-                          "_type": "Load"
-                        },
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 23,
-                        "end_col_offset": 24
+                  {
+                    "kind": "call",
+                    "start": 150,
+                    "end": 161,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 150,
+                        "end": 155
                       },
-                      "op": {
-                        "_type": "Add"
+                      {
+                        "kind": "argument_list",
+                        "start": 155,
+                        "end": 161,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 156,
+                            "end": 157
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 159,
+                            "end": 160
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 171,
+                    "end": 270,
+                    "children": [
+                      {
+                        "kind": "for_statement",
+                        "start": 171,
+                        "end": 270,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 175,
+                            "end": 176
+                          },
+                          {
+                            "kind": "call",
+                            "start": 180,
+                            "end": 195,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 180,
+                                "end": 185
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 185,
+                                "end": 195,
+                                "children": [
+                                  {
+                                    "kind": "binary_operator",
+                                    "start": 186,
+                                    "end": 191,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 186,
+                                        "end": 187
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 190,
+                                        "end": 191
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 193,
+                                    "end": 194
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "block",
+                            "start": 209,
+                            "end": 270,
+                            "children": [
+                              {
+                                "kind": "if_statement",
+                                "start": 209,
+                                "end": 270,
+                                "children": [
+                                  {
+                                    "kind": "comparison_operator",
+                                    "start": 212,
+                                    "end": 239,
+                                    "children": [
+                                      {
+                                        "kind": "binary_operator",
+                                        "start": 212,
+                                        "end": 229,
+                                        "children": [
+                                          {
+                                            "kind": "subscript",
+                                            "start": 212,
+                                            "end": 219,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 212,
+                                                "end": 216
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 217,
+                                                "end": 218
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "subscript",
+                                            "start": 222,
+                                            "end": 229,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 222,
+                                                "end": 226
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 227,
+                                                "end": 228
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 233,
+                                        "end": 239
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "block",
+                                    "start": 257,
+                                    "end": 270,
+                                    "children": [
+                                      {
+                                        "kind": "return_statement",
+                                        "start": 257,
+                                        "end": 270,
+                                        "children": [
+                                          {
+                                            "kind": "list",
+                                            "start": 264,
+                                            "end": 270,
+                                            "children": [
+                                              {
+                                                "kind": "identifier",
+                                                "start": 265,
+                                                "end": 266
+                                              },
+                                              {
+                                                "kind": "identifier",
+                                                "start": 268,
+                                                "end": 269
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "return_statement",
+                "start": 275,
+                "end": 290,
+                "children": [
+                  {
+                    "kind": "list",
+                    "start": 282,
+                    "end": 290,
+                    "children": [
+                      {
+                        "kind": "unary_operator",
+                        "start": 283,
+                        "end": 285,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 284,
+                            "end": 285
+                          }
+                        ]
                       },
-                      "right": {
-                        "_type": "Constant",
-                        "value": 1,
-                        "kind": null,
-                        "lineno": 6,
-                        "end_lineno": 6,
-                        "col_offset": 27,
-                        "end_col_offset": 28
-                      },
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 23,
-                      "end_col_offset": 28
-                    },
-                    {
-                      "_type": "Name",
-                      "id": "n",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 6,
-                      "end_lineno": 6,
-                      "col_offset": 30,
-                      "end_col_offset": 31
-                    }
-                  ],
-                  "lineno": 6,
-                  "end_lineno": 6,
-                  "col_offset": 17,
-                  "end_col_offset": 32
-                },
-                "lineno": 6,
-                "end_lineno": 8,
-                "col_offset": 8,
-                "end_col_offset": 29
+                      {
+                        "kind": "unary_operator",
+                        "start": 287,
+                        "end": 289,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 288,
+                            "end": 289
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
-            ],
-            "target": {
-              "_type": "Name",
-              "id": "i",
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 8,
-              "end_col_offset": 9
-            },
-            "iter": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "range",
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 13,
-                "end_col_offset": 18
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 0,
-                  "kind": null,
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 19,
-                  "end_col_offset": 20
-                },
-                {
-                  "_type": "Name",
-                  "id": "n",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                }
-              ],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 13,
-              "end_col_offset": 24
-            },
-            "lineno": 5,
-            "end_lineno": 8,
-            "col_offset": 4,
-            "end_col_offset": 29
-          },
-          {
-            "_type": "Return",
-            "value": {
-              "_type": "List",
-              "elts": [
-                {
-                  "_type": "UnaryOp",
-                  "op": {
-                    "_type": "USub"
-                  },
-                  "operand": {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 9,
-                    "end_lineno": 9,
-                    "col_offset": 13,
-                    "end_col_offset": 14
-                  },
-                  "lineno": 9,
-                  "end_lineno": 9,
-                  "col_offset": 12,
-                  "end_col_offset": 14
-                },
-                {
-                  "_type": "UnaryOp",
-                  "op": {
-                    "_type": "USub"
-                  },
-                  "operand": {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 9,
-                    "end_lineno": 9,
-                    "col_offset": 17,
-                    "end_col_offset": 18
-                  },
-                  "lineno": 9,
-                  "end_lineno": 9,
-                  "col_offset": 16,
-                  "end_col_offset": 18
-                }
-              ],
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 11,
-              "end_col_offset": 19
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 19
+            ]
           }
-        ],
-        "args": {
-          "_type": "arguments",
-          "posonlyargs": [],
-          "args": [
-            {
-              "_type": "arg",
-              "arg": "nums",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 11,
-              "end_col_offset": 15
-            },
-            {
-              "_type": "arg",
-              "arg": "target",
-              "annotation": null,
-              "type_comment": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 17,
-              "end_col_offset": 23
-            }
-          ],
-          "vararg": null,
-          "kwonlyargs": [],
-          "kw_defaults": [],
-          "kwarg": null,
-          "defaults": []
-        },
-        "lineno": 3,
-        "end_lineno": 9,
-        "end_col_offset": 19
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "expression_statement",
+        "start": 291,
+        "end": 325,
+        "children": [
           {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 10,
-            "end_lineno": 10,
-            "end_col_offset": 6
+            "kind": "assignment",
+            "start": 291,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 291,
+                "end": 297
+              },
+              {
+                "kind": "call",
+                "start": 300,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 300,
+                    "end": 306
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 306,
+                    "end": 325,
+                    "children": [
+                      {
+                        "kind": "list",
+                        "start": 307,
+                        "end": 321,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 308,
+                            "end": 309
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 314,
+                            "end": 316
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 318,
+                            "end": 320
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 323,
+                        "end": 324
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "twoSum",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 9,
-            "end_col_offset": 15
-          },
-          "args": [
-            {
-              "_type": "List",
-              "elts": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 10,
-                  "end_lineno": 10,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                {
-                  "_type": "Constant",
-                  "value": 7,
-                  "kind": null,
-                  "lineno": 10,
-                  "end_lineno": 10,
-                  "col_offset": 20,
-                  "end_col_offset": 21
-                },
-                {
-                  "_type": "Constant",
-                  "value": 11,
-                  "kind": null,
-                  "lineno": 10,
-                  "end_lineno": 10,
-                  "col_offset": 23,
-                  "end_col_offset": 25
-                },
-                {
-                  "_type": "Constant",
-                  "value": 15,
-                  "kind": null,
-                  "lineno": 10,
-                  "end_lineno": 10,
-                  "col_offset": 27,
-                  "end_col_offset": 29
-                }
-              ],
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 16,
-              "end_col_offset": 30
-            },
-            {
-              "_type": "Constant",
-              "value": 9,
-              "kind": null,
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 32,
-              "end_col_offset": 33
-            }
-          ],
-          "keywords": [],
-          "lineno": 10,
-          "end_lineno": 10,
-          "col_offset": 9,
-          "end_col_offset": 34
-        },
-        "lineno": 10,
-        "end_lineno": 10,
-        "end_col_offset": 34
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 11,
-            "end_lineno": 11,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "result",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 6,
-                "end_col_offset": 12
+        "kind": "expression_statement",
+        "start": 326,
+        "end": 342,
+        "children": [
+          {
+            "kind": "call",
+            "start": 326,
+            "end": 342,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 326,
+                "end": 331
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 0,
-                "kind": null,
-                "lineno": 11,
-                "end_lineno": 11,
-                "col_offset": 13,
-                "end_col_offset": 14
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 11,
-              "end_lineno": 11,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 11,
-          "end_lineno": 11,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 11,
-        "end_lineno": 11,
-        "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 331,
+                "end": 342,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 332,
+                    "end": 341,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 332,
+                        "end": 338
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 339,
+                        "end": 340
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Subscript",
-              "value": {
-                "_type": "Name",
-                "id": "result",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 6,
-                "end_col_offset": 12
+        "kind": "expression_statement",
+        "start": 343,
+        "end": 359,
+        "children": [
+          {
+            "kind": "call",
+            "start": 343,
+            "end": 359,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
               },
-              "slice": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 14
-              },
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 6,
-              "end_col_offset": 15
-            }
-          ],
-          "keywords": [],
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 0,
-          "end_col_offset": 16
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 16
+              {
+                "kind": "argument_list",
+                "start": 348,
+                "end": 359,
+                "children": [
+                  {
+                    "kind": "subscript",
+                    "start": 349,
+                    "end": 358,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 349,
+                        "end": 355
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 356,
+                        "end": 357
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/typed_let.py.json
+++ b/tests/json-ast/x/py/typed_let.py.json
@@ -1,68 +1,73 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 108,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "y",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 0,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "y",
-              "ctx": {
-                "_type": "Load"
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 7
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 8
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 8
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 107,
+        "children": [
+          {
+            "kind": "call",
+            "start": 99,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 104
+              },
+              {
+                "kind": "argument_list",
+                "start": 104,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 105,
+                    "end": 106
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/typed_var.py.json
+++ b/tests/json-ast/x/py/typed_var.py.json
@@ -1,68 +1,73 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 108,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 0,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 7
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 8
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 8
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 107,
+        "children": [
+          {
+            "kind": "call",
+            "start": 99,
+            "end": 107,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 104
+              },
+              {
+                "kind": "argument_list",
+                "start": 104,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 105,
+                    "end": 106
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/unary_neg.py.json
+++ b/tests/json-ast/x/py/unary_neg.py.json
@@ -1,117 +1,106 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 117,
+    "children": [
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 3,
-            "end_lineno": 3,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "UnaryOp",
-              "op": {
-                "_type": "USub"
-              },
-              "operand": {
-                "_type": "Constant",
-                "value": 3,
-                "kind": null,
-                "lineno": 3,
-                "end_lineno": 3,
-                "col_offset": 7,
-                "end_col_offset": 8
-              },
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 6,
-              "end_col_offset": 8
-            }
-          ],
-          "keywords": [],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 0,
-          "end_col_offset": 9
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 9
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Constant",
-                "value": 5,
-                "kind": null,
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 7
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 102,
+        "children": [
+          {
+            "kind": "call",
+            "start": 93,
+            "end": 102,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 98
               },
-              "op": {
-                "_type": "Add"
+              {
+                "kind": "argument_list",
+                "start": 98,
+                "end": 102,
+                "children": [
+                  {
+                    "kind": "unary_operator",
+                    "start": 99,
+                    "end": 101,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 100,
+                        "end": 101
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 103,
+        "end": 116,
+        "children": [
+          {
+            "kind": "call",
+            "start": 103,
+            "end": 116,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 103,
+                "end": 108
               },
-              "right": {
-                "_type": "UnaryOp",
-                "op": {
-                  "_type": "USub"
-                },
-                "operand": {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 11,
-                  "end_col_offset": 12
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 10,
-                "end_col_offset": 12
-              },
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 12
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 13
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 13
+              {
+                "kind": "argument_list",
+                "start": 108,
+                "end": 116,
+                "children": [
+                  {
+                    "kind": "binary_operator",
+                    "start": 109,
+                    "end": 115,
+                    "children": [
+                      {
+                        "kind": "integer",
+                        "start": 109,
+                        "end": 110
+                      },
+                      {
+                        "kind": "unary_operator",
+                        "start": 113,
+                        "end": 115,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 114,
+                            "end": 115
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/update_stmt.py.json
+++ b/tests/json-ast/x/py/update_stmt.py.json
@@ -1,1095 +1,1488 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 887,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "Import",
-        "lineno": 7,
-        "end_lineno": 7,
-        "end_col_offset": 10
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Attribute",
-            "value": {
-              "_type": "Name",
-              "id": "sys",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 0,
-              "end_col_offset": 3
-            },
-            "attr": "set_int_max_str_digits",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 8,
-            "end_lineno": 8,
-            "col_offset": 0,
-            "end_col_offset": 26
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": 0,
-              "kind": null,
-              "lineno": 8,
-              "end_lineno": 8,
-              "col_offset": 27,
-              "end_col_offset": 28
-            }
-          ],
-          "keywords": [],
-          "lineno": 8,
-          "end_lineno": 8,
-          "col_offset": 0,
-          "end_col_offset": 29
-        },
-        "lineno": 8,
-        "end_lineno": 8,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Person",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 4,
-            "end_col_offset": 13
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 13,
-              "end_lineno": 13,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 12,
-              "end_col_offset": 15
-            },
-            "target": {
-              "_type": "Name",
-              "id": "status",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 4,
-            "end_col_offset": 15
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 11,
-        "end_lineno": 14,
-        "end_col_offset": 15
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 16,
-            "end_lineno": 16,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Person",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 10,
-                "end_col_offset": 16
-              },
-              "args": [],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "name",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "Alice",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 22,
-                    "end_col_offset": 29
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 17,
-                  "end_col_offset": 29
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "age",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 17,
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 35,
-                    "end_col_offset": 37
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 31,
-                  "end_col_offset": 37
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "status",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "minor",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 46,
-                    "end_col_offset": 53
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 39,
-                  "end_col_offset": 53
-                }
-              ],
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 10,
-              "end_col_offset": 54
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Person",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 56,
-                "end_col_offset": 62
-              },
-              "args": [],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "name",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "Bob",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 68,
-                    "end_col_offset": 73
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 63,
-                  "end_col_offset": 73
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "age",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 25,
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 79,
-                    "end_col_offset": 81
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 75,
-                  "end_col_offset": 81
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "status",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "unknown",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 90,
-                    "end_col_offset": 99
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 83,
-                  "end_col_offset": 99
-                }
-              ],
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 56,
-              "end_col_offset": 100
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Person",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 102,
-                "end_col_offset": 108
-              },
-              "args": [],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "name",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "Charlie",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 114,
-                    "end_col_offset": 123
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 109,
-                  "end_col_offset": 123
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "age",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 18,
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 129,
-                    "end_col_offset": 131
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 125,
-                  "end_col_offset": 131
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "status",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "unknown",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 140,
-                    "end_col_offset": 149
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 133,
-                  "end_col_offset": 149
-                }
-              ],
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 102,
-              "end_col_offset": 150
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Person",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 16,
-                "end_lineno": 16,
-                "col_offset": 152,
-                "end_col_offset": 158
-              },
-              "args": [],
-              "keywords": [
-                {
-                  "_type": "keyword",
-                  "arg": "name",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "Diana",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 164,
-                    "end_col_offset": 171
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 159,
-                  "end_col_offset": 171
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "age",
-                  "value": {
-                    "_type": "Constant",
-                    "value": 16,
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 177,
-                    "end_col_offset": 179
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 173,
-                  "end_col_offset": 179
-                },
-                {
-                  "_type": "keyword",
-                  "arg": "status",
-                  "value": {
-                    "_type": "Constant",
-                    "value": "minor",
-                    "kind": null,
-                    "lineno": 16,
-                    "end_lineno": 16,
-                    "col_offset": 188,
-                    "end_col_offset": 195
-                  },
-                  "lineno": 16,
-                  "end_lineno": 16,
-                  "col_offset": 181,
-                  "end_col_offset": 195
-                }
-              ],
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 152,
-              "end_col_offset": 196
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 16,
-          "end_lineno": 16,
-          "col_offset": 9,
-          "end_col_offset": 197
-        },
-        "lineno": 16,
-        "end_lineno": 16,
-        "end_col_offset": 197
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "If",
-            "body": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "item",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 19,
-                      "end_lineno": 19,
-                      "col_offset": 8,
-                      "end_col_offset": 12
-                    },
-                    "attr": "status",
-                    "lineno": 19,
-                    "end_lineno": 19,
-                    "col_offset": 8,
-                    "end_col_offset": 19
-                  }
-                ],
-                "value": {
-                  "_type": "Constant",
-                  "value": "adult",
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 22,
-                  "end_col_offset": 29
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 8,
-                "end_col_offset": 29
-              },
-              {
-                "_type": "Assign",
-                "targets": [
-                  {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "item",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 20,
-                      "end_lineno": 20,
-                      "col_offset": 8,
-                      "end_col_offset": 12
-                    },
-                    "attr": "age",
-                    "lineno": 20,
-                    "end_lineno": 20,
-                    "col_offset": 8,
-                    "end_col_offset": 16
-                  }
-                ],
-                "value": {
-                  "_type": "BinOp",
-                  "left": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "item",
-                      "ctx": {
-                        "_type": "Load"
-                      },
-                      "lineno": 20,
-                      "end_lineno": 20,
-                      "col_offset": 19,
-                      "end_col_offset": 23
-                    },
-                    "attr": "age",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 20,
-                    "end_lineno": 20,
-                    "col_offset": 19,
-                    "end_col_offset": 27
-                  },
-                  "op": {
-                    "_type": "Add"
-                  },
-                  "right": {
-                    "_type": "Constant",
-                    "value": 1,
-                    "kind": null,
-                    "lineno": 20,
-                    "end_lineno": 20,
-                    "col_offset": 30,
-                    "end_col_offset": 31
-                  },
-                  "lineno": 20,
-                  "end_lineno": 20,
-                  "col_offset": 19,
-                  "end_col_offset": 31
-                },
-                "lineno": 20,
-                "end_lineno": 20,
-                "col_offset": 8,
-                "end_col_offset": 31
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "test": {
-              "_type": "Compare",
-              "left": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "item",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 7,
-                  "end_col_offset": 11
-                },
-                "attr": "age",
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 7,
-                "end_col_offset": 15
-              },
-              "ops": [
-                {
-                  "_type": "GtE"
-                }
-              ],
-              "comparators": [
-                {
-                  "_type": "Constant",
-                  "value": 18,
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 19,
-                  "end_col_offset": 21
-                }
-              ],
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 7,
-              "end_col_offset": 21
-            },
-            "lineno": 18,
-            "end_lineno": 20,
-            "col_offset": 4,
-            "end_col_offset": 31
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "Assign",
-            "targets": [
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
               {
-                "_type": "Subscript",
-                "value": {
-                  "_type": "Name",
-                  "id": "people",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 4,
-                  "end_col_offset": 10
-                },
-                "slice": {
-                  "_type": "Name",
-                  "id": "idx",
-                  "lineno": 21,
-                  "end_lineno": 21,
-                  "col_offset": 11,
-                  "end_col_offset": 14
-                },
-                "lineno": 21,
-                "end_lineno": 21,
-                "col_offset": 4,
-                "end_col_offset": 15
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
               }
-            ],
-            "value": {
-              "_type": "Name",
-              "id": "item",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 21,
-              "end_lineno": 21,
-              "col_offset": 18,
-              "end_col_offset": 22
-            },
-            "lineno": 21,
-            "end_lineno": 21,
-            "col_offset": 4,
-            "end_col_offset": 22
+            ]
           }
-        ],
-        "target": {
-          "_type": "Tuple",
-          "elts": [
-            {
-              "_type": "Name",
-              "id": "idx",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            {
-              "_type": "Name",
-              "id": "item",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 9,
-              "end_col_offset": 13
-            }
-          ],
-          "lineno": 17,
-          "end_lineno": 17,
-          "col_offset": 4,
-          "end_col_offset": 13
-        },
-        "iter": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "enumerate",
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 17,
-            "end_col_offset": 26
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "people",
-              "ctx": {
-                "_type": "Load"
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_statement",
+        "start": 193,
+        "end": 203,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 200,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 200,
+                "end": 203
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 204,
+        "end": 233,
+        "children": [
+          {
+            "kind": "call",
+            "start": 204,
+            "end": 233,
+            "children": [
+              {
+                "kind": "attribute",
+                "start": 204,
+                "end": 230,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 204,
+                    "end": 207
+                  },
+                  {
+                    "kind": "identifier",
+                    "start": 208,
+                    "end": 230
+                  }
+                ]
               },
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 27,
-              "end_col_offset": 33
-            }
-          ],
-          "lineno": 17,
-          "end_lineno": 17,
-          "col_offset": 17,
-          "end_col_offset": 34
-        },
-        "lineno": 17,
-        "end_lineno": 21,
-        "end_col_offset": 22
+              {
+                "kind": "argument_list",
+                "start": 230,
+                "end": 233,
+                "children": [
+                  {
+                    "kind": "integer",
+                    "start": 231,
+                    "end": 232
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Assert",
-        "test": {
-          "_type": "Compare",
-          "left": {
-            "_type": "Name",
-            "id": "people",
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 7,
-            "end_col_offset": 13
+        "kind": "decorated_definition",
+        "start": 235,
+        "end": 302,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 235,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 236,
+                "end": 245
+              }
+            ]
           },
-          "ops": [
-            {
-              "_type": "Eq"
-            }
-          ],
-          "comparators": [
-            {
-              "_type": "List",
-              "elts": [
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Person",
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 18,
-                    "end_col_offset": 24
+          {
+            "kind": "class_definition",
+            "start": 246,
+            "end": 302,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 252,
+                "end": 258
+              },
+              {
+                "kind": "block",
+                "start": 264,
+                "end": 302,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 264,
+                    "end": 273,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 264,
+                        "end": 273,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 264,
+                            "end": 268
+                          },
+                          {
+                            "kind": "type",
+                            "start": 270,
+                            "end": 273,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 270,
+                                "end": 273
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "args": [],
-                  "keywords": [
-                    {
-                      "_type": "keyword",
-                      "arg": "name",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "Alice",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 30,
-                        "end_col_offset": 37
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 25,
-                      "end_col_offset": 37
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "age",
-                      "value": {
-                        "_type": "Constant",
-                        "value": 17,
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 43,
-                        "end_col_offset": 45
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 39,
-                      "end_col_offset": 45
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "status",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "minor",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 54,
-                        "end_col_offset": 61
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 47,
-                      "end_col_offset": 61
-                    }
-                  ],
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 18,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Person",
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 64,
-                    "end_col_offset": 70
+                  {
+                    "kind": "expression_statement",
+                    "start": 278,
+                    "end": 286,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 278,
+                        "end": 286,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 278,
+                            "end": 281
+                          },
+                          {
+                            "kind": "type",
+                            "start": 283,
+                            "end": 286,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 283,
+                                "end": 286
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "args": [],
-                  "keywords": [
-                    {
-                      "_type": "keyword",
-                      "arg": "name",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "Bob",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 76,
-                        "end_col_offset": 81
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 71,
-                      "end_col_offset": 81
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "age",
-                      "value": {
-                        "_type": "Constant",
-                        "value": 26,
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 87,
-                        "end_col_offset": 89
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 83,
-                      "end_col_offset": 89
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "status",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "adult",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 98,
-                        "end_col_offset": 105
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 91,
-                      "end_col_offset": 105
-                    }
-                  ],
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 64,
-                  "end_col_offset": 106
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Person",
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 108,
-                    "end_col_offset": 114
-                  },
-                  "args": [],
-                  "keywords": [
-                    {
-                      "_type": "keyword",
-                      "arg": "name",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "Charlie",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 120,
-                        "end_col_offset": 129
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 115,
-                      "end_col_offset": 129
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "age",
-                      "value": {
-                        "_type": "Constant",
-                        "value": 19,
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 135,
-                        "end_col_offset": 137
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 131,
-                      "end_col_offset": 137
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "status",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "adult",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 146,
-                        "end_col_offset": 153
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 139,
-                      "end_col_offset": 153
-                    }
-                  ],
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 108,
-                  "end_col_offset": 154
-                },
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Name",
-                    "id": "Person",
-                    "lineno": 23,
-                    "end_lineno": 23,
-                    "col_offset": 156,
-                    "end_col_offset": 162
-                  },
-                  "args": [],
-                  "keywords": [
-                    {
-                      "_type": "keyword",
-                      "arg": "name",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "Diana",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 168,
-                        "end_col_offset": 175
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 163,
-                      "end_col_offset": 175
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "age",
-                      "value": {
-                        "_type": "Constant",
-                        "value": 16,
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 181,
-                        "end_col_offset": 183
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 177,
-                      "end_col_offset": 183
-                    },
-                    {
-                      "_type": "keyword",
-                      "arg": "status",
-                      "value": {
-                        "_type": "Constant",
-                        "value": "minor",
-                        "kind": null,
-                        "lineno": 23,
-                        "end_lineno": 23,
-                        "col_offset": 192,
-                        "end_col_offset": 199
-                      },
-                      "lineno": 23,
-                      "end_lineno": 23,
-                      "col_offset": 185,
-                      "end_col_offset": 199
-                    }
-                  ],
-                  "lineno": 23,
-                  "end_lineno": 23,
-                  "col_offset": 156,
-                  "end_col_offset": 200
-                }
-              ],
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 17,
-              "end_col_offset": 201
-            }
-          ],
-          "lineno": 23,
-          "end_lineno": 23,
-          "col_offset": 7,
-          "end_col_offset": 201
-        },
-        "lineno": 23,
-        "end_lineno": 23,
-        "end_col_offset": 201
+                  {
+                    "kind": "expression_statement",
+                    "start": 291,
+                    "end": 302,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 291,
+                        "end": 302,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 291,
+                            "end": 297
+                          },
+                          {
+                            "kind": "type",
+                            "start": 299,
+                            "end": 302,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 299,
+                                "end": 302
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "expression_statement",
+        "start": 304,
+        "end": 501,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 304,
+            "end": 501,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 304,
+                "end": 310
+              },
+              {
+                "kind": "list",
+                "start": 313,
+                "end": 501,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 314,
+                    "end": 358,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 314,
+                        "end": 320
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 320,
+                        "end": 358,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 321,
+                            "end": 333,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 321,
+                                "end": 325
+                              },
+                              {
+                                "kind": "string",
+                                "start": 326,
+                                "end": 333,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 326,
+                                    "end": 327
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 327,
+                                    "end": 332
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 332,
+                                    "end": 333
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 335,
+                            "end": 341,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 335,
+                                "end": 338
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 339,
+                                "end": 341
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 343,
+                            "end": 357,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 343,
+                                "end": 349
+                              },
+                              {
+                                "kind": "string",
+                                "start": 350,
+                                "end": 357,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 350,
+                                    "end": 351
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 351,
+                                    "end": 356
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 356,
+                                    "end": 357
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 360,
+                    "end": 404,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 360,
+                        "end": 366
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 366,
+                        "end": 404,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 367,
+                            "end": 377,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 367,
+                                "end": 371
+                              },
+                              {
+                                "kind": "string",
+                                "start": 372,
+                                "end": 377,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 372,
+                                    "end": 373
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 373,
+                                    "end": 376
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 376,
+                                    "end": 377
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 379,
+                            "end": 385,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 379,
+                                "end": 382
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 383,
+                                "end": 385
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 387,
+                            "end": 403,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 387,
+                                "end": 393
+                              },
+                              {
+                                "kind": "string",
+                                "start": 394,
+                                "end": 403,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 394,
+                                    "end": 395
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 395,
+                                    "end": 402
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 402,
+                                    "end": 403
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 406,
+                    "end": 454,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 406,
+                        "end": 412
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 412,
+                        "end": 454,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 413,
+                            "end": 427,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 413,
+                                "end": 417
+                              },
+                              {
+                                "kind": "string",
+                                "start": 418,
+                                "end": 427,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 418,
+                                    "end": 419
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 419,
+                                    "end": 426
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 426,
+                                    "end": 427
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 429,
+                            "end": 435,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 429,
+                                "end": 432
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 433,
+                                "end": 435
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 437,
+                            "end": 453,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 437,
+                                "end": 443
+                              },
+                              {
+                                "kind": "string",
+                                "start": 444,
+                                "end": 453,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 444,
+                                    "end": 445
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 445,
+                                    "end": 452
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 452,
+                                    "end": 453
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 456,
+                    "end": 500,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 456,
+                        "end": 462
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 462,
+                        "end": 500,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 463,
+                            "end": 475,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 463,
+                                "end": 467
+                              },
+                              {
+                                "kind": "string",
+                                "start": 468,
+                                "end": 475,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 468,
+                                    "end": 469
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 469,
+                                    "end": 474
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 474,
+                                    "end": 475
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 477,
+                            "end": 483,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 477,
+                                "end": 480
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 481,
+                                "end": 483
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 485,
+                            "end": 499,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 485,
+                                "end": 491
+                              },
+                              {
+                                "kind": "string",
+                                "start": 492,
+                                "end": 499,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 492,
+                                    "end": 493
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 493,
+                                    "end": 498
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 498,
+                                    "end": 499
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 502,
+        "end": 645,
+        "children": [
+          {
+            "kind": "pattern_list",
+            "start": 506,
+            "end": 515,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 506,
+                "end": 509
+              },
+              {
+                "kind": "identifier",
+                "start": 511,
+                "end": 515
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "ok",
-              "kind": null,
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 6,
-              "end_col_offset": 10
-            }
-          ],
-          "keywords": [],
-          "lineno": 24,
-          "end_lineno": 24,
-          "col_offset": 0,
-          "end_col_offset": 11
-        },
-        "lineno": 24,
-        "end_lineno": 24,
-        "end_col_offset": 11
+          {
+            "kind": "call",
+            "start": 519,
+            "end": 536,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 519,
+                "end": 528
+              },
+              {
+                "kind": "argument_list",
+                "start": 528,
+                "end": 536,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 529,
+                    "end": 535
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "block",
+            "start": 542,
+            "end": 645,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 542,
+                "end": 622,
+                "children": [
+                  {
+                    "kind": "comparison_operator",
+                    "start": 545,
+                    "end": 559,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 545,
+                        "end": 553,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 545,
+                            "end": 549
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 550,
+                            "end": 553
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 557,
+                        "end": 559
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "block",
+                    "start": 569,
+                    "end": 622,
+                    "children": [
+                      {
+                        "kind": "expression_statement",
+                        "start": 569,
+                        "end": 590,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 569,
+                            "end": 590,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 569,
+                                "end": 580,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 569,
+                                    "end": 573
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 574,
+                                    "end": 580
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "string",
+                                "start": 583,
+                                "end": 590,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 583,
+                                    "end": 584
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 584,
+                                    "end": 589
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 589,
+                                    "end": 590
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "expression_statement",
+                        "start": 599,
+                        "end": 622,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 599,
+                            "end": 622,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 599,
+                                "end": 607,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 599,
+                                    "end": 603
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 604,
+                                    "end": 607
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "binary_operator",
+                                "start": 610,
+                                "end": 622,
+                                "children": [
+                                  {
+                                    "kind": "attribute",
+                                    "start": 610,
+                                    "end": 618,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 610,
+                                        "end": 614
+                                      },
+                                      {
+                                        "kind": "identifier",
+                                        "start": 615,
+                                        "end": 618
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer",
+                                    "start": 621,
+                                    "end": 622
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 627,
+                "end": 645,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 627,
+                    "end": 645,
+                    "children": [
+                      {
+                        "kind": "subscript",
+                        "start": 627,
+                        "end": 638,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 627,
+                            "end": 633
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 634,
+                            "end": 637
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 641,
+                        "end": 645
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "comment",
+        "start": 646,
+        "end": 672
+      },
+      {
+        "kind": "assert_statement",
+        "start": 673,
+        "end": 874,
+        "children": [
+          {
+            "kind": "comparison_operator",
+            "start": 680,
+            "end": 874,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 680,
+                "end": 686
+              },
+              {
+                "kind": "list",
+                "start": 690,
+                "end": 874,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 691,
+                    "end": 735,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 691,
+                        "end": 697
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 697,
+                        "end": 735,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 698,
+                            "end": 710,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 698,
+                                "end": 702
+                              },
+                              {
+                                "kind": "string",
+                                "start": 703,
+                                "end": 710,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 703,
+                                    "end": 704
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 704,
+                                    "end": 709
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 709,
+                                    "end": 710
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 712,
+                            "end": 718,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 712,
+                                "end": 715
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 716,
+                                "end": 718
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 720,
+                            "end": 734,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 720,
+                                "end": 726
+                              },
+                              {
+                                "kind": "string",
+                                "start": 727,
+                                "end": 734,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 727,
+                                    "end": 728
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 728,
+                                    "end": 733
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 733,
+                                    "end": 734
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 737,
+                    "end": 779,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 737,
+                        "end": 743
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 743,
+                        "end": 779,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 744,
+                            "end": 754,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 744,
+                                "end": 748
+                              },
+                              {
+                                "kind": "string",
+                                "start": 749,
+                                "end": 754,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 749,
+                                    "end": 750
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 750,
+                                    "end": 753
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 753,
+                                    "end": 754
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 756,
+                            "end": 762,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 756,
+                                "end": 759
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 760,
+                                "end": 762
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 764,
+                            "end": 778,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 764,
+                                "end": 770
+                              },
+                              {
+                                "kind": "string",
+                                "start": 771,
+                                "end": 778,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 771,
+                                    "end": 772
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 772,
+                                    "end": 777
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 777,
+                                    "end": 778
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 781,
+                    "end": 827,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 781,
+                        "end": 787
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 787,
+                        "end": 827,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 788,
+                            "end": 802,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 788,
+                                "end": 792
+                              },
+                              {
+                                "kind": "string",
+                                "start": 793,
+                                "end": 802,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 793,
+                                    "end": 794
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 794,
+                                    "end": 801
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 801,
+                                    "end": 802
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 804,
+                            "end": 810,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 804,
+                                "end": 807
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 808,
+                                "end": 810
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 812,
+                            "end": 826,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 812,
+                                "end": 818
+                              },
+                              {
+                                "kind": "string",
+                                "start": 819,
+                                "end": 826,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 819,
+                                    "end": 820
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 820,
+                                    "end": 825
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 825,
+                                    "end": 826
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 829,
+                    "end": 873,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 829,
+                        "end": 835
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 835,
+                        "end": 873,
+                        "children": [
+                          {
+                            "kind": "keyword_argument",
+                            "start": 836,
+                            "end": 848,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 836,
+                                "end": 840
+                              },
+                              {
+                                "kind": "string",
+                                "start": 841,
+                                "end": 848,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 841,
+                                    "end": 842
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 842,
+                                    "end": 847
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 847,
+                                    "end": 848
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 850,
+                            "end": 856,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 850,
+                                "end": 853
+                              },
+                              {
+                                "kind": "integer",
+                                "start": 854,
+                                "end": 856
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "keyword_argument",
+                            "start": 858,
+                            "end": 872,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 858,
+                                "end": 864
+                              },
+                              {
+                                "kind": "string",
+                                "start": 865,
+                                "end": 872,
+                                "children": [
+                                  {
+                                    "kind": "string_start",
+                                    "start": 865,
+                                    "end": 866
+                                  },
+                                  {
+                                    "kind": "string_content",
+                                    "start": 866,
+                                    "end": 871
+                                  },
+                                  {
+                                    "kind": "string_end",
+                                    "start": 871,
+                                    "end": 872
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 875,
+        "end": 886,
+        "children": [
+          {
+            "kind": "call",
+            "start": 875,
+            "end": 886,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 875,
+                "end": 880
+              },
+              {
+                "kind": "argument_list",
+                "start": 880,
+                "end": 886,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 881,
+                    "end": 885,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 881,
+                        "end": 882
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 882,
+                        "end": 884
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 884,
+                        "end": 885
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/user_type_literal.py.json
+++ b/tests/json-ast/x/py/user_type_literal.py.json
@@ -1,334 +1,520 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 387,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Person",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 13
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 9,
-              "end_col_offset": 12
-            },
-            "target": {
-              "_type": "Name",
-              "id": "age",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 7
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 12
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
           }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 12
+        ]
       },
       {
-        "_type": "ClassDef",
-        "name": "Book",
-        "body": [
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "title",
-              "lineno": 14,
-              "end_lineno": 14,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 14,
-            "end_lineno": 14,
-            "col_offset": 4,
-            "end_col_offset": 14
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
           },
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "Person",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 12,
-              "end_col_offset": 18
-            },
-            "target": {
-              "_type": "Name",
-              "id": "author",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 10
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 18
-          }
-        ],
-        "decorator_list": [
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
           {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 12,
-            "end_lineno": 12,
-            "col_offset": 1,
-            "end_col_offset": 10
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
           }
-        ],
-        "lineno": 13,
-        "end_lineno": 15,
-        "end_col_offset": 18
+        ]
       },
       {
-        "_type": "Assign",
-        "targets": [
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 244,
+        "children": [
           {
-            "_type": "Name",
-            "id": "book",
-            "lineno": 17,
-            "end_lineno": 17,
-            "end_col_offset": 4
-          }
-        ],
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "Book",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 7,
-            "end_col_offset": 11
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
           },
-          "args": [],
-          "keywords": [
-            {
-              "_type": "keyword",
-              "arg": "title",
-              "value": {
-                "_type": "Constant",
-                "value": "Go",
-                "kind": null,
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 18,
-                "end_col_offset": 22
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 244,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 216
               },
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 12,
-              "end_col_offset": 22
-            },
-            {
-              "_type": "keyword",
-              "arg": "author",
-              "value": {
-                "_type": "Call",
-                "func": {
-                  "_type": "Name",
-                  "id": "Person",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 17,
-                  "end_lineno": 17,
-                  "col_offset": 31,
-                  "end_col_offset": 37
-                },
-                "args": [],
-                "keywords": [
+              {
+                "kind": "block",
+                "start": 222,
+                "end": 244,
+                "children": [
                   {
-                    "_type": "keyword",
-                    "arg": "name",
-                    "value": {
-                      "_type": "Constant",
-                      "value": "Bob",
-                      "kind": null,
-                      "lineno": 17,
-                      "end_lineno": 17,
-                      "col_offset": 43,
-                      "end_col_offset": 48
-                    },
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 38,
-                    "end_col_offset": 48
+                    "kind": "expression_statement",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 222,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 222,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "_type": "keyword",
-                    "arg": "age",
-                    "value": {
-                      "_type": "Constant",
-                      "value": 42,
-                      "kind": null,
-                      "lineno": 17,
-                      "end_lineno": 17,
-                      "col_offset": 54,
-                      "end_col_offset": 56
-                    },
-                    "lineno": 17,
-                    "end_lineno": 17,
-                    "col_offset": 50,
-                    "end_col_offset": 56
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 239
+                          },
+                          {
+                            "kind": "type",
+                            "start": 241,
+                            "end": 244,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 241,
+                                "end": 244
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
-                ],
-                "lineno": 17,
-                "end_lineno": 17,
-                "col_offset": 31,
-                "end_col_offset": 57
-              },
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 24,
-              "end_col_offset": 57
-            }
-          ],
-          "lineno": 17,
-          "end_lineno": 17,
-          "col_offset": 7,
-          "end_col_offset": 58
-        },
-        "lineno": 17,
-        "end_lineno": 17,
-        "end_col_offset": 58
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 18,
-            "end_lineno": 18,
-            "col_offset": 0,
-            "end_col_offset": 5
+        "kind": "decorated_definition",
+        "start": 246,
+        "end": 302,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 246,
+            "end": 256,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              }
+            ]
           },
-          "args": [
-            {
-              "_type": "Attribute",
-              "value": {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "book",
-                  "ctx": {
-                    "_type": "Load"
+          {
+            "kind": "class_definition",
+            "start": 257,
+            "end": 302,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 263,
+                "end": 267
+              },
+              {
+                "kind": "block",
+                "start": 273,
+                "end": 302,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 273,
+                    "end": 283,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 273,
+                        "end": 283,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 273,
+                            "end": 278
+                          },
+                          {
+                            "kind": "type",
+                            "start": 280,
+                            "end": 283,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 280,
+                                "end": 283
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
-                  "lineno": 18,
-                  "end_lineno": 18,
-                  "col_offset": 6,
-                  "end_col_offset": 10
-                },
-                "attr": "author",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 18,
-                "end_lineno": 18,
-                "col_offset": 6,
-                "end_col_offset": 17
+                  {
+                    "kind": "expression_statement",
+                    "start": 288,
+                    "end": 302,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 288,
+                        "end": 302,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 288,
+                            "end": 294
+                          },
+                          {
+                            "kind": "type",
+                            "start": 296,
+                            "end": 302,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 296,
+                                "end": 302
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 304,
+        "end": 362,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 304,
+            "end": 362,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 304,
+                "end": 308
               },
-              "attr": "name",
-              "ctx": {
-                "_type": "Load"
+              {
+                "kind": "call",
+                "start": 311,
+                "end": 362,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 311,
+                    "end": 315
+                  },
+                  {
+                    "kind": "argument_list",
+                    "start": 315,
+                    "end": 362,
+                    "children": [
+                      {
+                        "kind": "keyword_argument",
+                        "start": 316,
+                        "end": 326,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 316,
+                            "end": 321
+                          },
+                          {
+                            "kind": "string",
+                            "start": 322,
+                            "end": 326,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 322,
+                                "end": 323
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 323,
+                                "end": 325
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 325,
+                                "end": 326
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "keyword_argument",
+                        "start": 328,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 328,
+                            "end": 334
+                          },
+                          {
+                            "kind": "call",
+                            "start": 335,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 335,
+                                "end": 341
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 341,
+                                "end": 361,
+                                "children": [
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 342,
+                                    "end": 352,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 342,
+                                        "end": 346
+                                      },
+                                      {
+                                        "kind": "string",
+                                        "start": 347,
+                                        "end": 352,
+                                        "children": [
+                                          {
+                                            "kind": "string_start",
+                                            "start": 347,
+                                            "end": 348
+                                          },
+                                          {
+                                            "kind": "string_content",
+                                            "start": 348,
+                                            "end": 351
+                                          },
+                                          {
+                                            "kind": "string_end",
+                                            "start": 351,
+                                            "end": 352
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "keyword_argument",
+                                    "start": 354,
+                                    "end": 360,
+                                    "children": [
+                                      {
+                                        "kind": "identifier",
+                                        "start": 354,
+                                        "end": 357
+                                      },
+                                      {
+                                        "kind": "integer",
+                                        "start": 358,
+                                        "end": 360
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 363,
+        "end": 386,
+        "children": [
+          {
+            "kind": "call",
+            "start": 363,
+            "end": 386,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 363,
+                "end": 368
               },
-              "lineno": 18,
-              "end_lineno": 18,
-              "col_offset": 6,
-              "end_col_offset": 22
-            }
-          ],
-          "keywords": [],
-          "lineno": 18,
-          "end_lineno": 18,
-          "col_offset": 0,
-          "end_col_offset": 23
-        },
-        "lineno": 18,
-        "end_lineno": 18,
-        "end_col_offset": 23
+              {
+                "kind": "argument_list",
+                "start": 368,
+                "end": 386,
+                "children": [
+                  {
+                    "kind": "attribute",
+                    "start": 369,
+                    "end": 385,
+                    "children": [
+                      {
+                        "kind": "attribute",
+                        "start": 369,
+                        "end": 380,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 369,
+                            "end": 373
+                          },
+                          {
+                            "kind": "identifier",
+                            "start": 374,
+                            "end": 380
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 381,
+                        "end": 385
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/values_builtin.py.json
+++ b/tests/json-ast/x/py/values_builtin.py.json
@@ -1,165 +1,220 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 146,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "m",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Dict",
-          "keys": [
-            {
-              "_type": "Constant",
-              "value": "a",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 5,
-              "end_col_offset": 8
-            },
-            {
-              "_type": "Constant",
-              "value": "b",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            {
-              "_type": "Constant",
-              "value": "c",
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 21,
-              "end_col_offset": 24
-            }
-          ],
-          "values": [
-            {
-              "_type": "Constant",
-              "value": 1,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 10,
-              "end_col_offset": 11
-            },
-            {
-              "_type": "Constant",
-              "value": 2,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 18,
-              "end_col_offset": 19
-            },
-            {
-              "_type": "Constant",
-              "value": 3,
-              "kind": null,
-              "lineno": 3,
-              "end_lineno": 3,
-              "col_offset": 26,
-              "end_col_offset": 27
-            }
-          ],
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 28
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 28
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "list",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 4,
-                "end_lineno": 4,
-                "col_offset": 6,
-                "end_col_offset": 10
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 121,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 121,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "args": [
-                {
-                  "_type": "Call",
-                  "func": {
-                    "_type": "Attribute",
-                    "value": {
-                      "_type": "Name",
-                      "id": "m",
-                      "ctx": {
-                        "_type": "Load"
+              {
+                "kind": "dictionary",
+                "start": 97,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "pair",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 98,
+                        "end": 101,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 98,
+                            "end": 99
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 99,
+                            "end": 100
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 100,
+                            "end": 101
+                          }
+                        ]
                       },
-                      "lineno": 4,
-                      "end_lineno": 4,
-                      "col_offset": 11,
-                      "end_col_offset": 12
-                    },
-                    "attr": "values",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 4,
-                    "end_lineno": 4,
-                    "col_offset": 11,
-                    "end_col_offset": 19
+                      {
+                        "kind": "integer",
+                        "start": 103,
+                        "end": 104
+                      }
+                    ]
                   },
-                  "args": [],
-                  "keywords": [],
-                  "lineno": 4,
-                  "end_lineno": 4,
-                  "col_offset": 11,
-                  "end_col_offset": 21
-                }
-              ],
-              "keywords": [],
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 6,
-              "end_col_offset": 22
-            }
-          ],
-          "keywords": [],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 0,
-          "end_col_offset": 23
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 23
+                  {
+                    "kind": "pair",
+                    "start": 106,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 106,
+                        "end": 109,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 107,
+                            "end": 108
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 108,
+                            "end": 109
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 111,
+                        "end": 112
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "pair",
+                    "start": 114,
+                    "end": 120,
+                    "children": [
+                      {
+                        "kind": "string",
+                        "start": 114,
+                        "end": 117,
+                        "children": [
+                          {
+                            "kind": "string_start",
+                            "start": 114,
+                            "end": 115
+                          },
+                          {
+                            "kind": "string_content",
+                            "start": 115,
+                            "end": 116
+                          },
+                          {
+                            "kind": "string_end",
+                            "start": 116,
+                            "end": 117
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "integer",
+                        "start": 119,
+                        "end": 120
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 122,
+        "end": 145,
+        "children": [
+          {
+            "kind": "call",
+            "start": 122,
+            "end": 145,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 122,
+                "end": 127
+              },
+              {
+                "kind": "argument_list",
+                "start": 127,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 128,
+                    "end": 144,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 128,
+                        "end": 132
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 132,
+                        "end": 144,
+                        "children": [
+                          {
+                            "kind": "call",
+                            "start": 133,
+                            "end": 143,
+                            "children": [
+                              {
+                                "kind": "attribute",
+                                "start": 133,
+                                "end": 141,
+                                "children": [
+                                  {
+                                    "kind": "identifier",
+                                    "start": 133,
+                                    "end": 134
+                                  },
+                                  {
+                                    "kind": "identifier",
+                                    "start": 135,
+                                    "end": 141
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "argument_list",
+                                "start": 141,
+                                "end": 143
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/var_assignment.py.json
+++ b/tests/json-ast/x/py/var_assignment.py.json
@@ -1,92 +1,97 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 114,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 1,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "x",
-            "lineno": 4,
-            "end_lineno": 4,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 2,
-          "kind": null,
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Name",
-              "id": "x",
-              "ctx": {
-                "_type": "Load"
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
               },
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 6,
-              "end_col_offset": 7
-            }
-          ],
-          "keywords": [],
-          "lineno": 5,
-          "end_lineno": 5,
-          "col_offset": 0,
-          "end_col_offset": 8
-        },
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 8
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 99,
+        "end": 104,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 99,
+            "end": 104,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 99,
+                "end": 100
+              },
+              {
+                "kind": "integer",
+                "start": 103,
+                "end": 104
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 105,
+        "end": 113,
+        "children": [
+          {
+            "kind": "call",
+            "start": 105,
+            "end": 113,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 110
+              },
+              {
+                "kind": "argument_list",
+                "start": 110,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "identifier",
+                    "start": 111,
+                    "end": 112
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tests/json-ast/x/py/while_loop.py.json
+++ b/tests/json-ast/x/py/while_loop.py.json
@@ -1,154 +1,140 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 139,
+    "children": [
       {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "i",
-            "lineno": 3,
-            "end_lineno": 3,
-            "end_col_offset": 1
-          }
-        ],
-        "value": {
-          "_type": "Constant",
-          "value": 0,
-          "kind": null,
-          "lineno": 3,
-          "end_lineno": 3,
-          "col_offset": 4,
-          "end_col_offset": 5
-        },
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 5
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "While",
-        "body": [
+        "kind": "comment",
+        "start": 38,
+        "end": 92
+      },
+      {
+        "kind": "expression_statement",
+        "start": 93,
+        "end": 98,
+        "children": [
           {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 5,
-                "end_lineno": 5,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Name",
-                  "id": "i",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 5,
-                  "end_lineno": 5,
-                  "col_offset": 10,
-                  "end_col_offset": 11
-                }
-              ],
-              "keywords": [],
-              "lineno": 5,
-              "end_lineno": 5,
-              "col_offset": 4,
-              "end_col_offset": 12
-            },
-            "lineno": 5,
-            "end_lineno": 5,
-            "col_offset": 4,
-            "end_col_offset": 12
-          },
-          {
-            "_type": "Assign",
-            "targets": [
+            "kind": "assignment",
+            "start": 93,
+            "end": 98,
+            "children": [
               {
-                "_type": "Name",
-                "id": "i",
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 4,
-                "end_col_offset": 5
+                "kind": "identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "integer",
+                "start": 97,
+                "end": 98
               }
-            ],
-            "value": {
-              "_type": "BinOp",
-              "left": {
-                "_type": "Name",
-                "id": "i",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 8,
-                "end_col_offset": 9
-              },
-              "op": {
-                "_type": "Add"
-              },
-              "right": {
-                "_type": "Constant",
-                "value": 1,
-                "kind": null,
-                "lineno": 6,
-                "end_lineno": 6,
-                "col_offset": 12,
-                "end_col_offset": 13
-              },
-              "lineno": 6,
-              "end_lineno": 6,
-              "col_offset": 8,
-              "end_col_offset": 13
-            },
-            "lineno": 6,
-            "end_lineno": 6,
-            "col_offset": 4,
-            "end_col_offset": 13
+            ]
           }
-        ],
-        "test": {
-          "_type": "Compare",
-          "left": {
-            "_type": "Name",
-            "id": "i",
-            "lineno": 4,
-            "end_lineno": 4,
-            "col_offset": 6,
-            "end_col_offset": 7
+        ]
+      },
+      {
+        "kind": "while_statement",
+        "start": 99,
+        "end": 138,
+        "children": [
+          {
+            "kind": "comparison_operator",
+            "start": 105,
+            "end": 110,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 105,
+                "end": 106
+              },
+              {
+                "kind": "integer",
+                "start": 109,
+                "end": 110
+              }
+            ]
           },
-          "ops": [
-            {
-              "_type": "Lt"
-            }
-          ],
-          "comparators": [
-            {
-              "_type": "Constant",
-              "value": 3,
-              "lineno": 4,
-              "end_lineno": 4,
-              "col_offset": 10,
-              "end_col_offset": 11
-            }
-          ],
-          "lineno": 4,
-          "end_lineno": 4,
-          "col_offset": 6,
-          "end_col_offset": 11
-        },
-        "lineno": 4,
-        "end_lineno": 6,
-        "end_col_offset": 13
+          {
+            "kind": "block",
+            "start": 116,
+            "end": 138,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 116,
+                "end": 124,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 116,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 116,
+                        "end": 121
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 121,
+                        "end": 124,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 122,
+                            "end": 123
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "expression_statement",
+                "start": 129,
+                "end": 138,
+                "children": [
+                  {
+                    "kind": "assignment",
+                    "start": 129,
+                    "end": 138,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 129,
+                        "end": 130
+                      },
+                      {
+                        "kind": "binary_operator",
+                        "start": 133,
+                        "end": 138,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 133,
+                            "end": 134
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 137,
+                            "end": 138
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tools/json-ast/x/py/inspect.go
+++ b/tools/json-ast/x/py/inspect.go
@@ -1,105 +1,48 @@
 package py
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"os/exec"
-	"strings"
-	"time"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	python "github.com/smacker/go-tree-sitter/python"
 )
 
-// ASTNode mirrors Python's ast.AST structure as produced by the helper script.
-type ASTNode struct {
-	Type          string          `json:"_type"`
-	Name          string          `json:"name,omitempty"`
-	ID            string          `json:"id,omitempty"`
-	Arg           string          `json:"arg,omitempty"`
-	Body          []*ASTNode      `json:"body,omitempty"`
-	Targets       []*ASTNode      `json:"targets,omitempty"`
-	Value         json.RawMessage `json:"value,omitempty"`
-	Func          *ASTNode        `json:"func,omitempty"`
-	Args          json.RawMessage `json:"args,omitempty"`
-	Keywords      []*ASTNode      `json:"keywords,omitempty"`
-	Annotation    *ASTNode        `json:"annotation,omitempty"`
-	Returns       *ASTNode        `json:"returns,omitempty"`
-	Test          *ASTNode        `json:"test,omitempty"`
-	Target        *ASTNode        `json:"target,omitempty"`
-	Iter          *ASTNode        `json:"iter,omitempty"`
-	Operand       *ASTNode        `json:"operand,omitempty"`
-	Orelse        []*ASTNode      `json:"orelse,omitempty"`
-	Op            *ASTNode        `json:"op,omitempty"`
-	Left          *ASTNode        `json:"left,omitempty"`
-	Right         *ASTNode        `json:"right,omitempty"`
-	Attr          string          `json:"attr,omitempty"`
-	Elts          []*ASTNode      `json:"elts,omitempty"`
-	Keys          []*ASTNode      `json:"keys,omitempty"`
-	Values        []*ASTNode      `json:"values,omitempty"`
-	Slice         *ASTNode        `json:"slice,omitempty"`
-	Lower         *ASTNode        `json:"lower,omitempty"`
-	Upper         *ASTNode        `json:"upper,omitempty"`
-	Step          *ASTNode        `json:"step,omitempty"`
-	Ops           []*ASTNode      `json:"ops,omitempty"`
-	Comparators   []*ASTNode      `json:"comparators,omitempty"`
-	DecoratorList []*ASTNode      `json:"decorator_list,omitempty"`
-	Bases         []*ASTNode      `json:"bases,omitempty"`
-	Generators    []*ASTNode      `json:"generators,omitempty"`
-	Ifs           []*ASTNode      `json:"ifs,omitempty"`
-	Elt           *ASTNode        `json:"elt,omitempty"`
-	Line          int             `json:"lineno,omitempty"`
-	EndLine       int             `json:"end_lineno,omitempty"`
-	Col           int             `json:"col_offset,omitempty"`
-	EndCol        int             `json:"end_col_offset,omitempty"`
+// Node represents a tree-sitter node in a generic form.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
 }
 
 // Program represents a parsed Python source file.
 type Program struct {
-	Module *ASTNode `json:"module"`
+	File *Node `json:"file"`
 }
 
-const astScript = `import ast, json, sys
-
-def node_to_dict(node):
-    if isinstance(node, ast.AST):
-        fields = {}
-        for k, v in ast.iter_fields(node):
-            fields[k] = node_to_dict(v)
-        for attr in ("lineno", "end_lineno", "col_offset", "end_col_offset"):
-            if hasattr(node, attr):
-                fields[attr] = getattr(node, attr)
-        return {'_type': node.__class__.__name__, **fields}
-    elif isinstance(node, list):
-        return [node_to_dict(x) for x in node]
-    else:
-        return node
-
-tree = ast.parse(sys.stdin.read())
-json.dump(node_to_dict(tree), sys.stdout)
-`
-
-var pythonCmd = "python3"
-
-// Inspect parses the given Python source code and returns a Program describing
-// its AST.
+// Inspect parses the given Python source code using tree-sitter and returns
+// a Program describing its syntax tree.
 func Inspect(src string) (*Program, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, pythonCmd, "-c", astScript)
-	cmd.Stdin = strings.NewReader(src)
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(errBuf.String())
-		if msg != "" {
-			return nil, fmt.Errorf("%v: %s", err, msg)
-		}
-		return nil, err
+	p := sitter.NewParser()
+	p.SetLanguage(python.GetLanguage())
+	tree := p.Parse(nil, []byte(src))
+	return &Program{File: toNode(tree.RootNode())}, nil
+}
+
+func toNode(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
 	}
-	var root ASTNode
-	if err := json.Unmarshal(out.Bytes(), &root); err != nil {
-		return nil, err
+	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, toNode(child))
 	}
-	return &Program{Module: &root}, nil
+	return out
+}
+
+// MarshalJSON implements json.Marshaler for Program to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }


### PR DESCRIPTION
## Summary
- rewrite Python AST inspection to use go-tree-sitter
- regenerate `.py.json` fixtures with the new structure

## Testing
- `go test ./tools/json-ast/x/py -tags slow -update`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889a985d8248320bc7d96f03dfcc651