### PR TITLE
Refactor Rust AST inspection tests

### DIFF
--- a/tools/json-ast/x/rs/inspect_test.go
+++ b/tools/json-ast/x/rs/inspect_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -42,14 +41,7 @@ func shouldUpdate() bool {
 	return f != nil && f.Value.String() == "true"
 }
 
-func ensureTreeSitter(t *testing.T) {
-	if _, err := exec.LookPath("tree-sitter"); err != nil {
-		t.Skip("tree-sitter not installed")
-	}
-}
-
 func TestInspect_Golden(t *testing.T) {
-	ensureTreeSitter(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "rs")
 	outDir := filepath.Join(root, "tests", "json-ast", "x", "rs")


### PR DESCRIPTION
## Summary
- rewrite `tools/json-ast/x/rs` tests to not depend on the `tree-sitter` CLI
- keep Rust AST inspection using go-tree-sitter

## Testing
- `go vet ./tools/json-ast/x/rs`
- `go test ./tools/json-ast/x/rs -tags slow -run TestInspect_Golden`


------
https://chatgpt.com/codex/tasks/task_e_6889aa3cb6988320b6b14d754c73f30a