### PR TITLE
Rewrite Swift JSON AST parser using tree-sitter

### DIFF
--- a/tests/json-ast/x/swift/append_builtin.swift.json
+++ b/tests/json-ast/x/swift/append_builtin.swift.json
@@ -1,51 +1,344 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 187,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 103
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 103
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "a"
-        }
+        "end": 104,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 95,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 95
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 98,
+            "end": 104,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 99,
+                "end": 100
+              },
+              {
+                "kind": "integer_literal",
+                "start": 102,
+                "end": 103
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 105,
-          "end": 185
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 105,
-        "end": 185
+        "end": 186,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 105,
+            "end": 110
+          },
+          {
+            "kind": "call_suffix",
+            "start": 110,
+            "end": 186,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 110,
+                "end": 186,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 111,
+                    "end": 185,
+                    "children": [
+                      {
+                        "kind": "additive_expression",
+                        "start": 111,
+                        "end": 185,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 111,
+                            "end": 179,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 111,
+                                "end": 163,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 111,
+                                    "end": 156,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 111,
+                                        "end": 130,
+                                        "children": [
+                                          {
+                                            "kind": "additive_expression",
+                                            "start": 111,
+                                            "end": 126,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 111,
+                                                "end": 114,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 112,
+                                                    "end": 113
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 117,
+                                                "end": 126,
+                                                "children": [
+                                                  {
+                                                    "kind": "additive_expression",
+                                                    "start": 118,
+                                                    "end": 125,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 118,
+                                                        "end": 119
+                                                      },
+                                                      {
+                                                        "kind": "array_literal",
+                                                        "start": 122,
+                                                        "end": 125,
+                                                        "children": [
+                                                          {
+                                                            "kind": "integer_literal",
+                                                            "start": 123,
+                                                            "end": 124
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 126,
+                                            "end": 130,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 127,
+                                                "end": 130
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 130,
+                                        "end": 156,
+                                        "children": [
+                                          {
+                                            "kind": "lambda_literal",
+                                            "start": 130,
+                                            "end": 156,
+                                            "children": [
+                                              {
+                                                "kind": "statements",
+                                                "start": 132,
+                                                "end": 154,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 132,
+                                                    "end": 154,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 132,
+                                                        "end": 138
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 138,
+                                                        "end": 154,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 138,
+                                                            "end": 154,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 139,
+                                                                "end": 153,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument_label",
+                                                                    "start": 139,
+                                                                    "end": 149,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 139,
+                                                                        "end": 149
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 151,
+                                                                    "end": 153
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 156,
+                                    "end": 163,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 157,
+                                        "end": 163
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 163,
+                                "end": 179,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 163,
+                                    "end": 179,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 164,
+                                        "end": 178,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument_label",
+                                            "start": 164,
+                                            "end": 173,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 164,
+                                                "end": 173
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 175,
+                                            "end": 178,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 176,
+                                                "end": 177
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 182,
+                            "end": 185,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 183,
+                                "end": 184
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/avg_builtin.swift.json
+++ b/tests/json-ast/x/swift/avg_builtin.swift.json
@@ -1,17 +1,292 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 151
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 153,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 151
+        "end": 152,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 152,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 152,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 151,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 77,
+                        "end": 151,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 78,
+                            "end": 150,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 78,
+                                "end": 139,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 79,
+                                    "end": 138,
+                                    "children": [
+                                      {
+                                        "kind": "multiplicative_expression",
+                                        "start": 79,
+                                        "end": 119,
+                                        "children": [
+                                          {
+                                            "kind": "call_expression",
+                                            "start": 79,
+                                            "end": 110,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 79,
+                                                "end": 85
+                                              },
+                                              {
+                                                "kind": "call_suffix",
+                                                "start": 85,
+                                                "end": 110,
+                                                "children": [
+                                                  {
+                                                    "kind": "value_arguments",
+                                                    "start": 85,
+                                                    "end": 110,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_argument",
+                                                        "start": 86,
+                                                        "end": 109,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 86,
+                                                            "end": 109,
+                                                            "children": [
+                                                              {
+                                                                "kind": "navigation_expression",
+                                                                "start": 86,
+                                                                "end": 104,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "tuple_expression",
+                                                                    "start": 86,
+                                                                    "end": 97,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "array_literal",
+                                                                        "start": 87,
+                                                                        "end": 96,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "integer_literal",
+                                                                            "start": 88,
+                                                                            "end": 89
+                                                                          },
+                                                                          {
+                                                                            "kind": "integer_literal",
+                                                                            "start": 91,
+                                                                            "end": 92
+                                                                          },
+                                                                          {
+                                                                            "kind": "integer_literal",
+                                                                            "start": 94,
+                                                                            "end": 95
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "navigation_suffix",
+                                                                    "start": 97,
+                                                                    "end": 104,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 98,
+                                                                        "end": 104
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 104,
+                                                                "end": 109,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 104,
+                                                                    "end": 109,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 105,
+                                                                        "end": 106,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "integer_literal",
+                                                                            "start": 105,
+                                                                            "end": 106
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 107,
+                                                                        "end": 108
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 113,
+                                            "end": 119
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 119,
+                                        "end": 138,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 119,
+                                            "end": 138,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 120,
+                                                "end": 137,
+                                                "children": [
+                                                  {
+                                                    "kind": "navigation_expression",
+                                                    "start": 120,
+                                                    "end": 137,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 120,
+                                                        "end": 131,
+                                                        "children": [
+                                                          {
+                                                            "kind": "array_literal",
+                                                            "start": 121,
+                                                            "end": 130,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 122,
+                                                                "end": 123
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 125,
+                                                                "end": 126
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 128,
+                                                                "end": 129
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "navigation_suffix",
+                                                        "start": 131,
+                                                        "end": 137,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 132,
+                                                            "end": 137
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 140,
+                                "end": 143
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 144,
+                                "end": 150,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 144,
+                                    "end": 150
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/basic_compare.swift.json
+++ b/tests/json-ast/x/swift/basic_compare.swift.json
@@ -1,97 +1,310 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 86
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 164,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 86
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "a"
-        }
+        "end": 87,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 79,
+            "end": 87,
+            "children": [
+              {
+                "kind": "additive_expression",
+                "start": 80,
+                "end": 86,
+                "children": [
+                  {
+                    "kind": "integer_literal",
+                    "start": 80,
+                    "end": 82
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 85,
+                    "end": 86
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 88,
-          "end": 102
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 88,
-        "end": 102
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "b"
-        }
+        "end": 103,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 88,
+            "end": 91
+          },
+          {
+            "kind": "pattern",
+            "start": 92,
+            "end": 93,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 92,
+                "end": 93
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 96,
+            "end": 103,
+            "children": [
+              {
+                "kind": "additive_expression",
+                "start": 97,
+                "end": 102,
+                "children": [
+                  {
+                    "kind": "integer_literal",
+                    "start": 97,
+                    "end": 98
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 101,
+                    "end": 102
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 92,
-        "end": 92
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 104,
-          "end": 111
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 104,
-        "end": 111
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 113,
-          "end": 137
-        }
+        "end": 112,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 104,
+            "end": 109
+          },
+          {
+            "kind": "call_suffix",
+            "start": 109,
+            "end": 112,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 109,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 110,
+                    "end": 111,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 110,
+                        "end": 111
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 113,
-        "end": 137
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 139,
-          "end": 162
-        }
+        "end": 138,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 113,
+            "end": 118
+          },
+          {
+            "kind": "call_suffix",
+            "start": 118,
+            "end": 138,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 118,
+                "end": 138,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 119,
+                    "end": 137,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 119,
+                        "end": 137,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 120,
+                            "end": 136,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 120,
+                                "end": 128,
+                                "children": [
+                                  {
+                                    "kind": "equality_expression",
+                                    "start": 121,
+                                    "end": 127,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 121,
+                                        "end": 122
+                                      },
+                                      {
+                                        "kind": "integer_literal",
+                                        "start": 126,
+                                        "end": 127
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 131,
+                                "end": 132
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 135,
+                                "end": 136
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 139,
-        "end": 162
+        "end": 163,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 139,
+            "end": 144
+          },
+          {
+            "kind": "call_suffix",
+            "start": 144,
+            "end": 163,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 144,
+                "end": 163,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 145,
+                    "end": 162,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 145,
+                        "end": 162,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 146,
+                            "end": 161,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 146,
+                                "end": 153,
+                                "children": [
+                                  {
+                                    "kind": "comparison_expression",
+                                    "start": 147,
+                                    "end": 152,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 147,
+                                        "end": 148
+                                      },
+                                      {
+                                        "kind": "integer_literal",
+                                        "start": 151,
+                                        "end": 152
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 156,
+                                "end": 157
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 160,
+                                "end": 161
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/bench_block.swift.json
+++ b/tests/json-ast/x/swift/bench_block.swift.json
@@ -1,102 +1,1233 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 890,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 105
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 105
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "_nowSeed"
-        }
+        "end": 106,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 102,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 102
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 105,
+            "end": 106
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 107,
-          "end": 124
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 107,
-        "end": 124
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "_nowSeeded"
-        }
+        "end": 129,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 107,
+            "end": 110
+          },
+          {
+            "kind": "pattern",
+            "start": 111,
+            "end": 121,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 111,
+                "end": 121
+              }
+            ]
+          },
+          {
+            "kind": "boolean_literal",
+            "start": 124,
+            "end": 129
+          }
+        ]
       },
-      "range": {
-        "start": 111,
-        "end": 111
-      },
-      "interface_type": "$sSbD",
-      "access": "internal"
-    },
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "_now"
-        }
-      },
-      "params": {
-        "params": null
-      },
-      "body": {
-        "range": {
-          "start": 149,
-          "end": 511
-        }
-      },
-      "range": {
+      {
+        "kind": "function_declaration",
         "start": 130,
-        "end": 511
+        "end": 512,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 135,
+            "end": 139
+          },
+          {
+            "kind": "user_type",
+            "start": 145,
+            "end": 148,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 145,
+                "end": 148
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 149,
+            "end": 512,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 155,
+                "end": 511,
+                "children": [
+                  {
+                    "kind": "if_statement",
+                    "start": 155,
+                    "end": 333,
+                    "children": [
+                      {
+                        "kind": "prefix_expression",
+                        "start": 158,
+                        "end": 169,
+                        "children": [
+                          {
+                            "kind": "bang",
+                            "start": 158,
+                            "end": 159
+                          },
+                          {
+                            "kind": "simple_identifier",
+                            "start": 159,
+                            "end": 169
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "statements",
+                        "start": 180,
+                        "end": 332,
+                        "children": [
+                          {
+                            "kind": "if_statement",
+                            "start": 180,
+                            "end": 327,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 183,
+                                "end": 186
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 187,
+                                "end": 188
+                              },
+                              {
+                                "kind": "call_expression",
+                                "start": 191,
+                                "end": 244,
+                                "children": [
+                                  {
+                                    "kind": "navigation_expression",
+                                    "start": 191,
+                                    "end": 226,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 191,
+                                        "end": 214,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 191,
+                                            "end": 202
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 202,
+                                            "end": 214,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 203,
+                                                "end": 214
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "navigation_suffix",
+                                        "start": 214,
+                                        "end": 226,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 215,
+                                            "end": 226
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 226,
+                                    "end": 244,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 226,
+                                        "end": 244,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 227,
+                                            "end": 243,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 227,
+                                                "end": 243,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 228,
+                                                    "end": 242
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 246,
+                                "end": 249
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 250,
+                                "end": 251
+                              },
+                              {
+                                "kind": "call_expression",
+                                "start": 254,
+                                "end": 260,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 254,
+                                    "end": 257
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 257,
+                                    "end": 260,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 257,
+                                        "end": 260,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 258,
+                                            "end": 259,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 258,
+                                                "end": 259
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 275,
+                                "end": 326,
+                                "children": [
+                                  {
+                                    "kind": "assignment",
+                                    "start": 275,
+                                    "end": 287,
+                                    "children": [
+                                      {
+                                        "kind": "directly_assignable_expression",
+                                        "start": 275,
+                                        "end": 283,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 275,
+                                            "end": 283
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 286,
+                                        "end": 287
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "assignment",
+                                    "start": 300,
+                                    "end": 317,
+                                    "children": [
+                                      {
+                                        "kind": "directly_assignable_expression",
+                                        "start": 300,
+                                        "end": 310,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 300,
+                                            "end": 310
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "boolean_literal",
+                                        "start": 313,
+                                        "end": 317
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "if_statement",
+                    "start": 338,
+                    "end": 449,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 341,
+                        "end": 351
+                      },
+                      {
+                        "kind": "statements",
+                        "start": 362,
+                        "end": 448,
+                        "children": [
+                          {
+                            "kind": "assignment",
+                            "start": 362,
+                            "end": 419,
+                            "children": [
+                              {
+                                "kind": "directly_assignable_expression",
+                                "start": 362,
+                                "end": 370,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 362,
+                                    "end": 370
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "multiplicative_expression",
+                                "start": 373,
+                                "end": 419,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 373,
+                                    "end": 406,
+                                    "children": [
+                                      {
+                                        "kind": "additive_expression",
+                                        "start": 374,
+                                        "end": 405,
+                                        "children": [
+                                          {
+                                            "kind": "multiplicative_expression",
+                                            "start": 374,
+                                            "end": 392,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 374,
+                                                "end": 382
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 385,
+                                                "end": 392
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 395,
+                                            "end": 405
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 409,
+                                    "end": 419
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 428,
+                            "end": 443,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 435,
+                                "end": 443
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 454,
+                    "end": 510,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 461,
+                        "end": 510,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 461,
+                            "end": 464
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 464,
+                            "end": 510,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 464,
+                                "end": 510,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 465,
+                                    "end": 509,
+                                    "children": [
+                                      {
+                                        "kind": "multiplicative_expression",
+                                        "start": 465,
+                                        "end": 509,
+                                        "children": [
+                                          {
+                                            "kind": "navigation_expression",
+                                            "start": 465,
+                                            "end": 493,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 465,
+                                                "end": 471,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 465,
+                                                    "end": 469
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 469,
+                                                    "end": 471,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 469,
+                                                        "end": 471
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "navigation_suffix",
+                                                "start": 471,
+                                                "end": 493,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 472,
+                                                    "end": 493
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 496,
+                                            "end": 509
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "result": "$sSiD",
-      "interface_type": "$sSiycD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 513,
-          "end": 888
-        }
-      },
-      "range": {
+      {
+        "kind": "do_statement",
         "start": 513,
-        "end": 888
+        "end": 889,
+        "children": [
+          {
+            "kind": "statements",
+            "start": 522,
+            "end": 888,
+            "children": [
+              {
+                "kind": "property_declaration",
+                "start": 522,
+                "end": 544,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 522,
+                    "end": 525
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 526,
+                    "end": 540,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 526,
+                        "end": 540
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 543,
+                    "end": 544
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 549,
+                "end": 573,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 549,
+                    "end": 552
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 553,
+                    "end": 564,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 553,
+                        "end": 564
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call_expression",
+                    "start": 567,
+                    "end": 573,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 567,
+                        "end": 571
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 571,
+                        "end": 573,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 571,
+                            "end": 573
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 578,
+                "end": 590,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 578,
+                    "end": 581
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 582,
+                    "end": 583,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 582,
+                        "end": 583
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 586,
+                    "end": 590
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 595,
+                "end": 604,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 595,
+                    "end": 598
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 599,
+                    "end": 600,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 599,
+                        "end": 600
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 603,
+                    "end": 604
+                  }
+                ]
+              },
+              {
+                "kind": "for_statement",
+                "start": 609,
+                "end": 681,
+                "children": [
+                  {
+                    "kind": "pattern",
+                    "start": 613,
+                    "end": 614,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 613,
+                        "end": 614
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "range_expression",
+                    "start": 618,
+                    "end": 628,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 618,
+                        "end": 619
+                      },
+                      {
+                        "kind": "call_expression",
+                        "start": 622,
+                        "end": 628,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 622,
+                            "end": 625
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 625,
+                            "end": 628,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 625,
+                                "end": 628,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 626,
+                                    "end": 627,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 626,
+                                        "end": 627
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "statements",
+                    "start": 639,
+                    "end": 680,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 639,
+                        "end": 675,
+                        "children": [
+                          {
+                            "kind": "directly_assignable_expression",
+                            "start": 639,
+                            "end": 640,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 639,
+                                "end": 640
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 643,
+                            "end": 675,
+                            "children": [
+                              {
+                                "kind": "as_expression",
+                                "start": 644,
+                                "end": 674,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 644,
+                                    "end": 666,
+                                    "children": [
+                                      {
+                                        "kind": "additive_expression",
+                                        "start": 645,
+                                        "end": 665,
+                                        "children": [
+                                          {
+                                            "kind": "call_expression",
+                                            "start": 645,
+                                            "end": 651,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 645,
+                                                "end": 648
+                                              },
+                                              {
+                                                "kind": "call_suffix",
+                                                "start": 648,
+                                                "end": 651,
+                                                "children": [
+                                                  {
+                                                    "kind": "value_arguments",
+                                                    "start": 648,
+                                                    "end": 651,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_argument",
+                                                        "start": 649,
+                                                        "end": 650,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 649,
+                                                            "end": 650
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 654,
+                                            "end": 665,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 655,
+                                                "end": 664,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 655,
+                                                    "end": 656
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 657,
+                                                    "end": 660
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 661,
+                                                    "end": 664,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 661,
+                                                        "end": 664
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "as_operator",
+                                    "start": 667,
+                                    "end": 670
+                                  },
+                                  {
+                                    "kind": "user_type",
+                                    "start": 671,
+                                    "end": 674,
+                                    "children": [
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 671,
+                                        "end": 674
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 686,
+                "end": 708,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 686,
+                    "end": 689
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 690,
+                    "end": 699,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 690,
+                        "end": 699
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call_expression",
+                    "start": 702,
+                    "end": 708,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 702,
+                        "end": 706
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 706,
+                        "end": 708,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 706,
+                            "end": 708
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 713,
+                "end": 733,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 713,
+                    "end": 716
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 717,
+                    "end": 729,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 717,
+                        "end": 729
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 732,
+                    "end": 733
+                  }
+                ]
+              },
+              {
+                "kind": "call_expression",
+                "start": 738,
+                "end": 887,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 738,
+                    "end": 743
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 743,
+                    "end": 887,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 743,
+                        "end": 887,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 744,
+                            "end": 886,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 744,
+                                "end": 886,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 745,
+                                    "end": 746
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 746,
+                                    "end": 748
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 748,
+                                    "end": 750
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 750,
+                                    "end": 752
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 752,
+                                    "end": 763
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 763,
+                                    "end": 765
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 765,
+                                    "end": 767
+                                  },
+                                  {
+                                    "kind": "interpolated_expression",
+                                    "start": 769,
+                                    "end": 801,
+                                    "children": [
+                                      {
+                                        "kind": "multiplicative_expression",
+                                        "start": 769,
+                                        "end": 801,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 769,
+                                            "end": 794,
+                                            "children": [
+                                              {
+                                                "kind": "additive_expression",
+                                                "start": 770,
+                                                "end": 793,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 770,
+                                                    "end": 779
+                                                  },
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 782,
+                                                    "end": 793
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 797,
+                                            "end": 801
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 802,
+                                    "end": 803
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 803,
+                                    "end": 805
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 805,
+                                    "end": 807
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 807,
+                                    "end": 809
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 809,
+                                    "end": 821
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 821,
+                                    "end": 823
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 823,
+                                    "end": 825
+                                  },
+                                  {
+                                    "kind": "interpolated_expression",
+                                    "start": 827,
+                                    "end": 856,
+                                    "children": [
+                                      {
+                                        "kind": "additive_expression",
+                                        "start": 827,
+                                        "end": 856,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 827,
+                                            "end": 839
+                                          },
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 842,
+                                            "end": 856
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 857,
+                                    "end": 858
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 858,
+                                    "end": 860
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 860,
+                                    "end": 862
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 862,
+                                    "end": 864
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 864,
+                                    "end": 868
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 868,
+                                    "end": 870
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 870,
+                                    "end": 872
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 872,
+                                    "end": 874
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 874,
+                                    "end": 880
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 880,
+                                    "end": 882
+                                  },
+                                  {
+                                    "kind": "str_escaped_char",
+                                    "start": 882,
+                                    "end": 884
+                                  },
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 884,
+                                    "end": 885
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/binary_precedence.swift.json
+++ b/tests/json-ast/x/swift/binary_precedence.swift.json
@@ -1,56 +1,166 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 78
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 107,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 80,
-          "end": 87
-        }
+        "end": 79,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 79,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 79,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 78,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 78
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 80,
-        "end": 87
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 89,
-          "end": 96
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 80,
+            "end": 85
+          },
+          {
+            "kind": "call_suffix",
+            "start": 85,
+            "end": 88,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 85,
+                "end": 88,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 86,
+                    "end": 87,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 86,
+                        "end": 87
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 89,
-        "end": 96
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 98,
-          "end": 105
-        }
+        "end": 97,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 89,
+            "end": 94
+          },
+          {
+            "kind": "call_suffix",
+            "start": 94,
+            "end": 97,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 94,
+                "end": 97,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 95,
+                    "end": 96,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 95,
+                        "end": 96
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 98,
-        "end": 105
+        "end": 106,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 98,
+            "end": 103
+          },
+          {
+            "kind": "call_suffix",
+            "start": 103,
+            "end": 106,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 103,
+                "end": 106,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 104,
+                    "end": 105,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 104,
+                        "end": 105
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/bool_chain.swift.json
+++ b/tests/json-ast/x/swift/bool_chain.swift.json
@@ -1,67 +1,928 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "boom"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 403,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": null
-      },
-      "body": {
-        "range": {
-          "start": 91,
-          "end": 127
-        }
-      },
-      "range": {
+      {
+        "kind": "function_declaration",
         "start": 71,
-        "end": 127
+        "end": 128,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 80
+          },
+          {
+            "kind": "user_type",
+            "start": 86,
+            "end": 90,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 86,
+                "end": 90
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 91,
+            "end": 128,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 97,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 97,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 97,
+                        "end": 102
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 102,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 102,
+                            "end": 110,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 103,
+                                "end": 109,
+                                "children": [
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 103,
+                                    "end": 109,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 104,
+                                        "end": 108
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 115,
+                    "end": 126,
+                    "children": [
+                      {
+                        "kind": "boolean_literal",
+                        "start": 122,
+                        "end": 126
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "result": "$sSbD",
-      "interface_type": "$sSbycD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 129,
-          "end": 211
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 129,
-        "end": 211
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 213,
-          "end": 294
-        }
+        "end": 212,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 129,
+            "end": 134
+          },
+          {
+            "kind": "call_suffix",
+            "start": 134,
+            "end": 212,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 134,
+                "end": 212,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 135,
+                    "end": 211,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 135,
+                        "end": 211,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 136,
+                            "end": 210,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 136,
+                                "end": 202,
+                                "children": [
+                                  {
+                                    "kind": "conjunction_expression",
+                                    "start": 137,
+                                    "end": 201,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 137,
+                                        "end": 179,
+                                        "children": [
+                                          {
+                                            "kind": "conjunction_expression",
+                                            "start": 138,
+                                            "end": 178,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 138,
+                                                "end": 156,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 139,
+                                                    "end": 155,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 139,
+                                                        "end": 146,
+                                                        "children": [
+                                                          {
+                                                            "kind": "comparison_expression",
+                                                            "start": 140,
+                                                            "end": 145,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 140,
+                                                                "end": 141
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 144,
+                                                                "end": 145
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 147,
+                                                        "end": 150
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 151,
+                                                        "end": 155,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 151,
+                                                            "end": 155
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 160,
+                                                "end": 178,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 161,
+                                                    "end": 177,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 161,
+                                                        "end": 168,
+                                                        "children": [
+                                                          {
+                                                            "kind": "comparison_expression",
+                                                            "start": 162,
+                                                            "end": 167,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 162,
+                                                                "end": 163
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 166,
+                                                                "end": 167
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 169,
+                                                        "end": 172
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 173,
+                                                        "end": 177,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 173,
+                                                            "end": 177
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 183,
+                                        "end": 201,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 184,
+                                            "end": 200,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 184,
+                                                "end": 191,
+                                                "children": [
+                                                  {
+                                                    "kind": "comparison_expression",
+                                                    "start": 185,
+                                                    "end": 190,
+                                                    "children": [
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 185,
+                                                        "end": 186
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 189,
+                                                        "end": 190
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 192,
+                                                "end": 195
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 196,
+                                                "end": 200,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 196,
+                                                    "end": 200
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 205,
+                                "end": 206
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 209,
+                                "end": 210
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 213,
-        "end": 294
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 296,
-          "end": 401
-        }
+        "end": 295,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 213,
+            "end": 218
+          },
+          {
+            "kind": "call_suffix",
+            "start": 218,
+            "end": 295,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 218,
+                "end": 295,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 219,
+                    "end": 294,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 219,
+                        "end": 294,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 220,
+                            "end": 293,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 220,
+                                "end": 285,
+                                "children": [
+                                  {
+                                    "kind": "conjunction_expression",
+                                    "start": 221,
+                                    "end": 284,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 221,
+                                        "end": 263,
+                                        "children": [
+                                          {
+                                            "kind": "conjunction_expression",
+                                            "start": 222,
+                                            "end": 262,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 222,
+                                                "end": 240,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 223,
+                                                    "end": 239,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 223,
+                                                        "end": 230,
+                                                        "children": [
+                                                          {
+                                                            "kind": "comparison_expression",
+                                                            "start": 224,
+                                                            "end": 229,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 224,
+                                                                "end": 225
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 228,
+                                                                "end": 229
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 231,
+                                                        "end": 234
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 235,
+                                                        "end": 239,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 235,
+                                                            "end": 239
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 244,
+                                                "end": 262,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 245,
+                                                    "end": 261,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 245,
+                                                        "end": 252,
+                                                        "children": [
+                                                          {
+                                                            "kind": "comparison_expression",
+                                                            "start": 246,
+                                                            "end": 251,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 246,
+                                                                "end": 247
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 250,
+                                                                "end": 251
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 253,
+                                                        "end": 256
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 257,
+                                                        "end": 261,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 257,
+                                                            "end": 261
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 267,
+                                        "end": 284,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 268,
+                                            "end": 283,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 268,
+                                                "end": 274,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 268,
+                                                    "end": 272
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 272,
+                                                    "end": 274,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 272,
+                                                        "end": 274
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 275,
+                                                "end": 278
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 279,
+                                                "end": 283,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 279,
+                                                    "end": 283
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 288,
+                                "end": 289
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 292,
+                                "end": 293
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 296,
-        "end": 401
+        "end": 402,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 296,
+            "end": 301
+          },
+          {
+            "kind": "call_suffix",
+            "start": 301,
+            "end": 402,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 301,
+                "end": 402,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 302,
+                    "end": 401,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 302,
+                        "end": 401,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 303,
+                            "end": 400,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 303,
+                                "end": 392,
+                                "children": [
+                                  {
+                                    "kind": "conjunction_expression",
+                                    "start": 304,
+                                    "end": 391,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 304,
+                                        "end": 370,
+                                        "children": [
+                                          {
+                                            "kind": "conjunction_expression",
+                                            "start": 305,
+                                            "end": 369,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 305,
+                                                "end": 347,
+                                                "children": [
+                                                  {
+                                                    "kind": "conjunction_expression",
+                                                    "start": 306,
+                                                    "end": 346,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 306,
+                                                        "end": 324,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 307,
+                                                            "end": 323,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 307,
+                                                                "end": 314,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "comparison_expression",
+                                                                    "start": 308,
+                                                                    "end": 313,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "integer_literal",
+                                                                        "start": 308,
+                                                                        "end": 309
+                                                                      },
+                                                                      {
+                                                                        "kind": "integer_literal",
+                                                                        "start": 312,
+                                                                        "end": 313
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 315,
+                                                                "end": 318
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 319,
+                                                                "end": 323,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 319,
+                                                                    "end": 323
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 328,
+                                                        "end": 346,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 329,
+                                                            "end": 345,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 329,
+                                                                "end": 336,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "comparison_expression",
+                                                                    "start": 330,
+                                                                    "end": 335,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "integer_literal",
+                                                                        "start": 330,
+                                                                        "end": 331
+                                                                      },
+                                                                      {
+                                                                        "kind": "integer_literal",
+                                                                        "start": 334,
+                                                                        "end": 335
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 337,
+                                                                "end": 340
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 341,
+                                                                "end": 345,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 341,
+                                                                    "end": 345
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 351,
+                                                "end": 369,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 352,
+                                                    "end": 368,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 352,
+                                                        "end": 359,
+                                                        "children": [
+                                                          {
+                                                            "kind": "comparison_expression",
+                                                            "start": 353,
+                                                            "end": 358,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 353,
+                                                                "end": 354
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 357,
+                                                                "end": 358
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 360,
+                                                        "end": 363
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 364,
+                                                        "end": 368,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 364,
+                                                            "end": 368
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 374,
+                                        "end": 391,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 375,
+                                            "end": 390,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 375,
+                                                "end": 381,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 375,
+                                                    "end": 379
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 379,
+                                                    "end": 381,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 379,
+                                                        "end": 381
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 382,
+                                                "end": 385
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 386,
+                                                "end": 390,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 386,
+                                                    "end": 390
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 395,
+                                "end": 396
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 399,
+                                "end": 400
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/break_continue.swift.json
+++ b/tests/json-ast/x/swift/break_continue.swift.json
@@ -1,44 +1,314 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 111
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 256,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 111
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "numbers"
-        }
+        "end": 112,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 82,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 82
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 85,
+            "end": 112,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              },
+              {
+                "kind": "integer_literal",
+                "start": 89,
+                "end": 90
+              },
+              {
+                "kind": "integer_literal",
+                "start": 92,
+                "end": 93
+              },
+              {
+                "kind": "integer_literal",
+                "start": 95,
+                "end": 96
+              },
+              {
+                "kind": "integer_literal",
+                "start": 98,
+                "end": 99
+              },
+              {
+                "kind": "integer_literal",
+                "start": 101,
+                "end": 102
+              },
+              {
+                "kind": "integer_literal",
+                "start": 104,
+                "end": 105
+              },
+              {
+                "kind": "integer_literal",
+                "start": 107,
+                "end": 108
+              },
+              {
+                "kind": "integer_literal",
+                "start": 110,
+                "end": 111
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 113,
-          "end": 254
-        }
-      },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 113,
-        "end": 254
+        "end": 255,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 117,
+            "end": 118,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 117,
+                "end": 118
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 122,
+            "end": 129
+          },
+          {
+            "kind": "statements",
+            "start": 136,
+            "end": 254,
+            "children": [
+              {
+                "kind": "if_statement",
+                "start": 136,
+                "end": 178,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 139,
+                    "end": 153,
+                    "children": [
+                      {
+                        "kind": "equality_expression",
+                        "start": 140,
+                        "end": 152,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 140,
+                            "end": 147,
+                            "children": [
+                              {
+                                "kind": "multiplicative_expression",
+                                "start": 141,
+                                "end": 146,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 141,
+                                    "end": 142
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 145,
+                                    "end": 146
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer_literal",
+                            "start": 151,
+                            "end": 152
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "statements",
+                    "start": 164,
+                    "end": 177,
+                    "children": [
+                      {
+                        "kind": "control_transfer_statement",
+                        "start": 164,
+                        "end": 172
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "if_statement",
+                "start": 183,
+                "end": 225,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 186,
+                    "end": 203,
+                    "children": [
+                      {
+                        "kind": "comparison_expression",
+                        "start": 187,
+                        "end": 202,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 187,
+                            "end": 198,
+                            "children": [
+                              {
+                                "kind": "as_expression",
+                                "start": 188,
+                                "end": 197,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 188,
+                                    "end": 189
+                                  },
+                                  {
+                                    "kind": "as_operator",
+                                    "start": 190,
+                                    "end": 193
+                                  },
+                                  {
+                                    "kind": "user_type",
+                                    "start": 194,
+                                    "end": 197,
+                                    "children": [
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 194,
+                                        "end": 197
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer_literal",
+                            "start": 201,
+                            "end": 202
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "statements",
+                    "start": 214,
+                    "end": 224,
+                    "children": [
+                      {
+                        "kind": "control_transfer_statement",
+                        "start": 214,
+                        "end": 219
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_expression",
+                "start": 230,
+                "end": 253,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 230,
+                    "end": 235
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 235,
+                    "end": 253,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 235,
+                        "end": 253,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 236,
+                            "end": 249,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 236,
+                                "end": 249,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 237,
+                                    "end": 248
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 251,
+                            "end": 252,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 251,
+                                "end": 252
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/cast_string_to_int.swift.json
+++ b/tests/json-ast/x/swift/cast_string_to_int.swift.json
@@ -1,17 +1,52 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 81
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 83,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 81
+        "end": 82,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 82,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 82,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 81,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 81
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/cast_struct.swift.json
+++ b/tests/json-ast/x/swift/cast_struct.swift.json
@@ -1,114 +1,233 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 175,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "struct_decl",
-      "name": {
-        "base_name": {
-          "name": "Todo"
-        }
-      },
-      "range": {
-        "start": 90,
-        "end": 126
-      },
-      "interface_type": "$s4main4TodoVmD",
-      "access": "internal",
-      "members": [
-        {
-          "_kind": "pattern_binding_decl",
-          "range": {
-            "start": 108,
-            "end": 119
-          }
-        },
-        {
-          "_kind": "var_decl",
-          "name": {
-            "base_name": {
-              "name": "title"
-            }
-          },
-          "range": {
-            "start": 112,
-            "end": 112
-          },
-          "interface_type": "$sSSD",
-          "access": "internal"
-        },
-        {
-          "_kind": "constructor_decl",
-          "name": {
-            "base_name": {
-              "name": ""
-            }
-          },
-          "params": {
-            "params": [
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
               {
-                "name": {
-                  "base_name": {
-                    "name": "title"
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 90,
+        "end": 127,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 97,
+            "end": 101
+          },
+          {
+            "kind": "class_body",
+            "start": 102,
+            "end": 127,
+            "children": [
+              {
+                "kind": "property_declaration",
+                "start": 108,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 108,
+                    "end": 111
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 112,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 112,
+                        "end": 117
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "type_annotation",
+                    "start": 117,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "user_type",
+                        "start": 119,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 119,
+                            "end": 125
+                          }
+                        ]
+                      }
+                    ]
                   }
-                },
-                "interface_type": "$sSSD"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 128,
+        "end": 156,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 128,
+            "end": 131
+          },
+          {
+            "kind": "pattern",
+            "start": 132,
+            "end": 136,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 132,
+                "end": 136
               }
             ]
           },
-          "range": {
-            "start": 97,
-            "end": 97
-          },
-          "interface_type": "$sy4main4TodoVSS_tcACmcD",
-          "access": "internal"
-        }
-      ]
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 128,
-          "end": 155
-        }
+          {
+            "kind": "call_expression",
+            "start": 139,
+            "end": 156,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 139,
+                "end": 143
+              },
+              {
+                "kind": "call_suffix",
+                "start": 143,
+                "end": 156,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 143,
+                    "end": 156,
+                    "children": [
+                      {
+                        "kind": "value_argument",
+                        "start": 144,
+                        "end": 155,
+                        "children": [
+                          {
+                            "kind": "value_argument_label",
+                            "start": 144,
+                            "end": 149,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 144,
+                                "end": 149
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 151,
+                            "end": 155,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 152,
+                                "end": 154
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 128,
-        "end": 155
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "todo"
-        }
-      },
-      "range": {
-        "start": 132,
-        "end": 132
-      },
-      "interface_type": "$s4main4TodoVD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 157,
-          "end": 173
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 157,
-        "end": 173
+        "end": 174,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 157,
+            "end": 162
+          },
+          {
+            "kind": "call_suffix",
+            "start": 162,
+            "end": 174,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 162,
+                "end": 174,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 163,
+                    "end": 173,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 163,
+                        "end": 173,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 163,
+                            "end": 167
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 167,
+                            "end": 173,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 168,
+                                "end": 173
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/count_builtin.swift.json
+++ b/tests/json-ast/x/swift/count_builtin.swift.json
@@ -1,17 +1,133 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 106
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 108,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 106
+        "end": 107,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 107,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 106,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 77,
+                        "end": 106,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 78,
+                            "end": 105,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 78,
+                                "end": 97,
+                                "children": [
+                                  {
+                                    "kind": "navigation_expression",
+                                    "start": 79,
+                                    "end": 96,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 79,
+                                        "end": 90,
+                                        "children": [
+                                          {
+                                            "kind": "array_literal",
+                                            "start": 80,
+                                            "end": 89,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 81,
+                                                "end": 82
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 84,
+                                                "end": 85
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 87,
+                                                "end": 88
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "navigation_suffix",
+                                        "start": 90,
+                                        "end": 96,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 91,
+                                            "end": 96
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 98,
+                                "end": 101
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 102,
+                                "end": 105,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 102,
+                                    "end": 105
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/cross_join.swift.json
+++ b/tests/json-ast/x/swift/cross_join.swift.json
@@ -1,1106 +1,1068 @@
 {
   "file": {
     "kind": "source_file",
+    "start": 0,
+    "end": 846,
     "children": [
       {
-        "kind": "compiler_version"
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
       {
-        "kind": "top_level_code_decl",
-        "range": {
-          "start": 71,
-          "end": 170
-        },
+        "kind": "property_declaration",
+        "start": 71,
+        "end": 171,
         "children": [
           {
-            "kind": "brace_stmt",
-            "range": {
-              "start": 71,
-              "end": 170
-            },
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
             "children": [
               {
-                "kind": "pattern_binding_decl",
-                "range": {
-                  "start": 71,
-                  "end": 170
-                },
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 171,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
                 "children": [
                   {
-                    "kind": "pattern_entry",
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
                     "children": [
                       {
-                        "kind": "pattern_named",
-                        "name": "customers",
-                        "type": "$sSSypXSDXSaD"
-                      },
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
                       {
-                        "kind": "array_expr",
-                        "type": "$sSSypXSDXSaD",
-                        "range": {
-                          "start": 87,
-                          "end": 170
-                        },
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 142,
+                "end": 170,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 143,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 144,
+                        "end": 146
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 149,
+                    "end": 150
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 152,
+                    "end": 158,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 153,
+                        "end": 157
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 160,
+                    "end": 169,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 161,
+                        "end": 168
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 172,
+        "end": 317,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 172,
+            "end": 175
+          },
+          {
+            "kind": "pattern",
+            "start": 176,
+            "end": 182,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 176,
+                "end": 182
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 185,
+            "end": 317,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 186,
+                "end": 228,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 187,
+                    "end": 191,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 188,
+                        "end": 190
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 193,
+                    "end": 196
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 209
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 212,
+                    "end": 213
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 215,
+                    "end": 222,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 216,
+                        "end": 221
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 224,
+                    "end": 227
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 230,
+                "end": 272,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 231,
+                    "end": 235,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 232,
+                        "end": 234
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 237,
+                    "end": 240
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 242,
+                    "end": 254,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 243,
+                        "end": 253
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 256,
+                    "end": 257
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 259,
+                    "end": 266,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 260,
+                        "end": 265
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 268,
+                    "end": 271
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 274,
+                "end": 316,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 275,
+                    "end": 279,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 276,
+                        "end": 278
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 281,
+                    "end": 284
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 286,
+                    "end": 298,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 287,
+                        "end": 297
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 300,
+                    "end": 301
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 303,
+                    "end": 310,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 304,
+                        "end": 309
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 312,
+                    "end": 315
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 318,
+        "end": 603,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 318,
+            "end": 321
+          },
+          {
+            "kind": "pattern",
+            "start": 322,
+            "end": 328,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 322,
+                "end": 328
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 331,
+            "end": 603,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 331,
+                "end": 601,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 332,
+                    "end": 600,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 334,
+                        "end": 598,
                         "children": [
                           {
-                            "kind": "decl_ref",
+                            "kind": "property_declaration",
+                            "start": 334,
+                            "end": 364,
                             "children": [
                               {
-                                "kind": "substitution_map",
+                                "kind": "value_binding_pattern",
+                                "start": 334,
+                                "end": 337
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 338,
+                                "end": 342,
                                 "children": [
                                   {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
+                                    "kind": "simple_identifier",
+                                    "start": 338,
+                                    "end": 342
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 342,
+                                "end": 359,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 344,
+                                    "end": 359,
                                     "children": [
                                       {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSypXSDD"
+                                        "kind": "dictionary_type",
+                                        "start": 345,
+                                        "end": 358,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 346,
+                                            "end": 352,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 346,
+                                                "end": 352
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 354,
+                                            "end": 357,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 354,
+                                                "end": 357
+                                              }
+                                            ]
+                                          }
+                                        ]
                                       }
                                     ]
-                                  },
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 362,
+                                "end": 364
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 365,
+                            "end": 586,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 369,
+                                "end": 370,
+                                "children": [
                                   {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
+                                    "kind": "simple_identifier",
+                                    "start": 369,
+                                    "end": 370
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 374,
+                                "end": 380
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 387,
+                                "end": 585,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 387,
+                                    "end": 584,
                                     "children": [
                                       {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSypXSDD"
+                                        "kind": "pattern",
+                                        "start": 391,
+                                        "end": 392,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 391,
+                                            "end": 392
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 396,
+                                        "end": 405
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 416,
+                                        "end": 583,
+                                        "children": [
+                                          {
+                                            "kind": "call_expression",
+                                            "start": 416,
+                                            "end": 578,
+                                            "children": [
+                                              {
+                                                "kind": "navigation_expression",
+                                                "start": 416,
+                                                "end": 427,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 416,
+                                                    "end": 420
+                                                  },
+                                                  {
+                                                    "kind": "navigation_suffix",
+                                                    "start": 420,
+                                                    "end": 427,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 421,
+                                                        "end": 427
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_suffix",
+                                                "start": 427,
+                                                "end": 578,
+                                                "children": [
+                                                  {
+                                                    "kind": "value_arguments",
+                                                    "start": 427,
+                                                    "end": 578,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_argument",
+                                                        "start": 428,
+                                                        "end": 577,
+                                                        "children": [
+                                                          {
+                                                            "kind": "dictionary_literal",
+                                                            "start": 428,
+                                                            "end": 577,
+                                                            "children": [
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 429,
+                                                                "end": 438,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 430,
+                                                                    "end": 437
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 440,
+                                                                "end": 458,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 441,
+                                                                    "end": 457,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 441,
+                                                                        "end": 449,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 441,
+                                                                            "end": 448,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 441,
+                                                                                "end": 442
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 442,
+                                                                                "end": 448,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 442,
+                                                                                    "end": 448,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 443,
+                                                                                        "end": 447,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 443,
+                                                                                            "end": 447,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 444,
+                                                                                                "end": 446
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 448,
+                                                                            "end": 449
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 450,
+                                                                        "end": 453
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 454,
+                                                                        "end": 457,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 454,
+                                                                            "end": 457
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 460,
+                                                                "end": 477,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 461,
+                                                                    "end": 476
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 479,
+                                                                "end": 505,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 480,
+                                                                    "end": 504,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 480,
+                                                                        "end": 496,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 480,
+                                                                            "end": 495,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 480,
+                                                                                "end": 481
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 481,
+                                                                                "end": 495,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 481,
+                                                                                    "end": 495,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 482,
+                                                                                        "end": 494,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 482,
+                                                                                            "end": 494,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 483,
+                                                                                                "end": 493
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 495,
+                                                                            "end": 496
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 497,
+                                                                        "end": 500
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 501,
+                                                                        "end": 504,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 501,
+                                                                            "end": 504
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 507,
+                                                                "end": 527,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 508,
+                                                                    "end": 526
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 529,
+                                                                "end": 539,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 529,
+                                                                    "end": 538,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 529,
+                                                                        "end": 530
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 530,
+                                                                        "end": 538,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 530,
+                                                                            "end": 538,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 531,
+                                                                                "end": 537,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 531,
+                                                                                    "end": 537,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 532,
+                                                                                        "end": 536
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 538,
+                                                                    "end": 539
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 541,
+                                                                "end": 553,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 542,
+                                                                    "end": 552
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 555,
+                                                                "end": 576,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 556,
+                                                                    "end": 575,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 556,
+                                                                        "end": 567,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 556,
+                                                                            "end": 566,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 556,
+                                                                                "end": 557
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 557,
+                                                                                "end": 566,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 557,
+                                                                                    "end": 566,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 558,
+                                                                                        "end": 565,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 558,
+                                                                                            "end": 565,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 559,
+                                                                                                "end": 564
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 566,
+                                                                            "end": 567
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 568,
+                                                                        "end": 571
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 572,
+                                                                        "end": 575,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 572,
+                                                                            "end": 575
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": "substitution"
                                   }
                                 ]
                               }
                             ]
                           },
                           {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 88,
-                              "end": 113
-                            },
+                            "kind": "control_transfer_statement",
+                            "start": 587,
+                            "end": 598,
                             "children": [
                               {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 89,
-                                  "end": 95
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 89,
-                                      "end": 89
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 95,
-                                      "end": 95
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 95,
-                                          "end": 95
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 98,
-                                  "end": 106
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 98,
-                                      "end": 98
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 106,
-                                      "end": 106
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 106,
-                                          "end": 106
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 116,
-                              "end": 139
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 117,
-                                  "end": 123
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 117,
-                                      "end": 117
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 123,
-                                      "end": 123
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 123,
-                                          "end": 123
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 126,
-                                  "end": 134
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 126,
-                                      "end": 126
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 134,
-                                      "end": 134
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 134,
-                                          "end": 134
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 142,
-                              "end": 169
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 143,
-                                  "end": 149
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 143,
-                                      "end": 143
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 149,
-                                      "end": 149
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 149,
-                                          "end": 149
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 152,
-                                  "end": 160
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 152,
-                                      "end": 152
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 160,
-                                      "end": 160
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 160,
-                                          "end": 160
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
+                                "kind": "simple_identifier",
+                                "start": 594,
+                                "end": 598
                               }
                             ]
                           }
                         ]
-                      },
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 601,
+                "end": 603,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 601,
+                    "end": 603
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 604,
+        "end": 657,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 604,
+            "end": 609
+          },
+          {
+            "kind": "call_suffix",
+            "start": 609,
+            "end": 657,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 609,
+                "end": 657,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 610,
+                    "end": 656,
+                    "children": [
                       {
-                        "kind": "array_expr",
-                        "type": "$sSSypXSDXSaD",
-                        "range": {
-                          "start": 87,
-                          "end": 170
-                        },
+                        "kind": "line_string_literal",
+                        "start": 610,
+                        "end": 656,
                         "children": [
                           {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 88,
-                              "end": 113
-                            },
-                            "children": [
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 89,
-                                  "end": 95
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 89,
-                                      "end": 89
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 95,
-                                      "end": 95
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 95,
-                                          "end": 95
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 98,
-                                  "end": 106
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 98,
-                                      "end": 98
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 106,
-                                      "end": 106
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 106,
-                                          "end": 106
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 116,
-                              "end": 139
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 117,
-                                  "end": 123
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 117,
-                                      "end": 117
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 123,
-                                      "end": 123
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 123,
-                                          "end": 123
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 126,
-                                  "end": 134
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 126,
-                                      "end": 126
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 134,
-                                      "end": 134
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 134,
-                                          "end": 134
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSypXSDD",
-                            "range": {
-                              "start": 142,
-                              "end": 169
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "self_conformance",
-                                            "type": "$sypD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 143,
-                                  "end": 149
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 143,
-                                      "end": 143
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 149,
-                                      "end": 149
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSiD"
-                                      },
-                                      {
-                                        "kind": "integer_literal_expr",
-                                        "type": "$sSiD",
-                                        "range": {
-                                          "start": 149,
-                                          "end": 149
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_yptD",
-                                "range": {
-                                  "start": 152,
-                                  "end": 160
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 152,
-                                      "end": 152
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 160,
-                                      "end": 160
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 160,
-                                          "end": 160
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "decl_ref",
-                            "children": [
-                              {
-                                "kind": "substitution_map",
-                                "children": [
-                                  {
-                                    "kind": "substitution"
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSypXSDD"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSypXSDD"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
+                            "kind": "line_str_text",
+                            "start": 611,
+                            "end": 655
                           }
                         ]
                       }
@@ -1113,4520 +1075,117 @@
         ]
       },
       {
-        "kind": "var_decl",
-        "name": "customers",
-        "range": {
-          "start": 75,
-          "end": 75
-        }
-      },
-      {
-        "kind": "top_level_code_decl",
-        "range": {
-          "start": 172,
-          "end": 316
-        },
+        "kind": "for_statement",
+        "start": 658,
+        "end": 845,
         "children": [
           {
-            "kind": "brace_stmt",
-            "range": {
-              "start": 172,
-              "end": 316
-            },
+            "kind": "pattern",
+            "start": 662,
+            "end": 667,
             "children": [
               {
-                "kind": "pattern_binding_decl",
-                "range": {
-                  "start": 172,
-                  "end": 316
-                },
-                "children": [
-                  {
-                    "kind": "pattern_entry",
-                    "children": [
-                      {
-                        "kind": "array_expr",
-                        "type": "$sSSSiXSDXSaD",
-                        "range": {
-                          "start": 185,
-                          "end": 316
-                        },
-                        "children": [
-                          {
-                            "kind": "decl_ref",
-                            "children": [
-                              {
-                                "kind": "substitution_map",
-                                "children": [
-                                  {
-                                    "kind": "substitution"
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSSiXSDD"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSSiXSDD"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 186,
-                              "end": 227
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 187,
-                                  "end": 193
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 187,
-                                      "end": 187
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 193,
-                                      "end": 193
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 198,
-                                  "end": 212
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 198,
-                                      "end": 198
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 212,
-                                      "end": 212
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 215,
-                                  "end": 224
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 215,
-                                      "end": 215
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 224,
-                                      "end": 224
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 230,
-                              "end": 271
-                            },
-                            "children": [
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 231,
-                                  "end": 237
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 231,
-                                      "end": 231
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 237,
-                                      "end": 237
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 242,
-                                  "end": 256
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 242,
-                                      "end": 242
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 256,
-                                      "end": 256
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 259,
-                                  "end": 268
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 259,
-                                      "end": 259
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 268,
-                                      "end": 268
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 274,
-                              "end": 315
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 275,
-                                  "end": 281
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 275,
-                                      "end": 275
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 281,
-                                      "end": 281
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 286,
-                                  "end": 300
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 286,
-                                      "end": 286
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 300,
-                                      "end": 300
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 303,
-                                  "end": 312
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 303,
-                                      "end": 303
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 312,
-                                      "end": 312
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "array_expr",
-                        "type": "$sSSSiXSDXSaD",
-                        "range": {
-                          "start": 185,
-                          "end": 316
-                        },
-                        "children": [
-                          {
-                            "kind": "decl_ref",
-                            "children": [
-                              {
-                                "kind": "substitution_map",
-                                "children": [
-                                  {
-                                    "kind": "substitution"
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSSiXSDD"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "conformance",
-                                    "type": "$sxD",
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSSiXSDD"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 186,
-                              "end": 227
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 187,
-                                  "end": 193
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 187,
-                                      "end": 187
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 193,
-                                      "end": 193
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 198,
-                                  "end": 212
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 198,
-                                      "end": 198
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 212,
-                                      "end": 212
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 215,
-                                  "end": 224
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 215,
-                                      "end": 215
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 224,
-                                      "end": 224
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 230,
-                              "end": 271
-                            },
-                            "children": [
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 231,
-                                  "end": 237
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 231,
-                                      "end": 231
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 237,
-                                      "end": 237
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 242,
-                                  "end": 256
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 242,
-                                      "end": 242
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 256,
-                                      "end": 256
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 259,
-                                  "end": 268
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 259,
-                                      "end": 259
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 268,
-                                      "end": 268
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "dictionary_expr",
-                            "type": "$sSSSiXSDD",
-                            "range": {
-                              "start": 274,
-                              "end": 315
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref",
-                                "children": [
-                                  {
-                                    "kind": "substitution_map",
-                                    "children": [
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "substitution"
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
-                                        "children": [
-                                          {
-                                            "kind": "normal_conformance",
-                                            "type": "$sSSD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "conformance",
-                                        "type": "$sq_D",
-                                        "children": [
-                                          {
-                                            "kind": "builtin_conformance",
-                                            "type": "$sSiD"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 275,
-                                  "end": 281
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 275,
-                                      "end": 275
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 281,
-                                      "end": 281
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 286,
-                                  "end": 300
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 286,
-                                      "end": 286
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 300,
-                                      "end": 300
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "tuple_expr",
-                                "type": "$sSS_SitD",
-                                "range": {
-                                  "start": 303,
-                                  "end": 312
-                                },
-                                "children": [
-                                  {
-                                    "kind": "string_literal_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 303,
-                                      "end": 303
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "integer_literal_expr",
-                                    "type": "$sSiD",
-                                    "range": {
-                                      "start": 312,
-                                      "end": 312
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "pattern_named",
-                        "name": "orders",
-                        "type": "$sSSSiXSDXSaD"
-                      }
-                    ]
-                  }
-                ]
+                "kind": "simple_identifier",
+                "start": 662,
+                "end": 667
               }
             ]
-          }
-        ]
-      },
-      {
-        "kind": "var_decl",
-        "name": "orders",
-        "range": {
-          "start": 176,
-          "end": 176
-        }
-      },
-      {
-        "kind": "top_level_code_decl",
-        "range": {
-          "start": 318,
-          "end": 602
-        },
-        "children": [
+          },
           {
-            "kind": "brace_stmt",
-            "range": {
-              "start": 318,
-              "end": 602
-            },
+            "kind": "simple_identifier",
+            "start": 671,
+            "end": 677
+          },
+          {
+            "kind": "statements",
+            "start": 684,
+            "end": 844,
             "children": [
               {
-                "kind": "pattern_binding_decl",
-                "range": {
-                  "start": 318,
-                  "end": 602
-                },
+                "kind": "call_expression",
+                "start": 684,
+                "end": 843,
                 "children": [
                   {
-                    "kind": "pattern_entry",
-                    "children": [
-                      {
-                        "kind": "call_expr",
-                        "type": "$sSSypXSDXSaD",
-                        "range": {
-                          "start": 331,
-                          "end": 602
-                        },
-                        "children": [
-                          {
-                            "kind": "paren_expr",
-                            "type": "$sSSypXSDXSayXED",
-                            "range": {
-                              "start": 331,
-                              "end": 600
-                            },
-                            "children": [
-                              {
-                                "kind": "closure_expr",
-                                "type": "$sSSypXSDXSayXED",
-                                "range": {
-                                  "start": 332,
-                                  "end": 599
-                                },
-                                "children": [
-                                  {
-                                    "kind": "captured_value",
-                                    "children": [
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "orders",
-                                        "range": {
-                                          "start": 176,
-                                          "end": 176
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "captured_value",
-                                    "children": [
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "customers",
-                                        "range": {
-                                          "start": 75,
-                                          "end": 75
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "parameter_list",
-                                    "range": {
-                                      "start": 332,
-                                      "end": 332
-                                    }
-                                  },
-                                  {
-                                    "kind": "brace_stmt",
-                                    "range": {
-                                      "start": 332,
-                                      "end": 599
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "pattern_binding_decl",
-                                        "range": {
-                                          "start": 334,
-                                          "end": 363
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "pattern_entry",
-                                            "children": [
-                                              {
-                                                "kind": "pattern_typed",
-                                                "type": "$sSSypXSDXSaD",
-                                                "children": [
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "_res",
-                                                    "type": "$sSSypXSDXSaD"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "array_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 362,
-                                                  "end": 363
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "array_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 362,
-                                                  "end": 363
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "_res",
-                                        "range": {
-                                          "start": 338,
-                                          "end": 338
-                                        }
-                                      },
-                                      {
-                                        "kind": "for_each_stmt",
-                                        "range": {
-                                          "start": 365,
-                                          "end": 585
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "call_expr",
-                                            "type": "$sSSSiXSDXSqD",
-                                            "range": {
-                                              "start": 365,
-                                              "end": 365
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "dot_syntax_call_expr",
-                                                "type": "$sSSSiXSDXSqycD",
-                                                "range": {
-                                                  "start": 365,
-                                                  "end": 365
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sySSSiXSDXSqycs16IndexingIteratorVySSSiXSDXSaGzcD",
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution_map",
-                                                            "children": [
-                                                              {
-                                                                "kind": "substitution"
-                                                              },
-                                                              {
-                                                                "kind": "conformance",
-                                                                "type": "$sxD",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "specialized_conformance",
-                                                                    "type": "$sSSSiXSDXSaD"
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "inout_expr",
-                                                            "type": "$ss16IndexingIteratorVySSSiXSDXSaGzD",
-                                                            "range": {
-                                                              "start": 365,
-                                                              "end": 365
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "declref_expr",
-                                                                "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                                "range": {
-                                                                  "start": 365,
-                                                                  "end": 365
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "decl_ref"
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "argument_list"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "brace_stmt",
-                                            "range": {
-                                              "start": 381,
-                                              "end": 585
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "for_each_stmt",
-                                                "range": {
-                                                  "start": 387,
-                                                  "end": 583
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "c",
-                                                    "type": "$sSSypXSDD"
-                                                  },
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "pattern_binding_decl",
-                                                    "children": [
-                                                      {
-                                                        "kind": "pattern_entry",
-                                                        "children": [
-                                                          {
-                                                            "kind": "pattern_named",
-                                                            "name": "$c$generator",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
-                                                          },
-                                                          {
-                                                            "kind": "call_expr",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                            "range": {
-                                                              "start": 396,
-                                                              "end": 396
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "dot_syntax_call_expr",
-                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                                                "range": {
-                                                                  "start": 396,
-                                                                  "end": 396
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "specialized_conformance",
-                                                                                    "type": "$sSSypXSDXSaD"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "argument_list",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "argument",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 396,
-                                                                              "end": 396
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "argument_list"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "call_expr",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                            "range": {
-                                                              "start": 396,
-                                                              "end": 396
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "dot_syntax_call_expr",
-                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                                                "range": {
-                                                                  "start": 396,
-                                                                  "end": 396
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "specialized_conformance",
-                                                                                    "type": "$sSSypXSDXSaD"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "argument_list",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "argument",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 396,
-                                                                              "end": 396
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "argument_list"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$sSSypXSDXSqD",
-                                                    "range": {
-                                                      "start": 387,
-                                                      "end": 387
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument_list"
-                                                      },
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$sSSypXSDXSqycD",
-                                                        "range": {
-                                                          "start": 387,
-                                                          "end": 387
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      },
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSypXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "inout_expr",
-                                                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
-                                                                    "range": {
-                                                                      "start": 387,
-                                                                      "end": 387
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "declref_expr",
-                                                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                                        "range": {
-                                                                          "start": 387,
-                                                                          "end": 387
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "decl_ref"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "brace_stmt",
-                                                    "range": {
-                                                      "start": 406,
-                                                      "end": 583
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "call_expr",
-                                                        "type": "$sytD",
-                                                        "range": {
-                                                          "start": 416,
-                                                          "end": 577
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "dot_syntax_call_expr",
-                                                            "type": "$syySSypXSDncD",
-                                                            "range": {
-                                                              "start": 416,
-                                                              "end": 421
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "declref_expr",
-                                                                "type": "$syySSypXSDncSaySSypXSDGzcD",
-                                                                "range": {
-                                                                  "start": 421,
-                                                                  "end": 421
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "decl_ref",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution_map",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution"
-                                                                          },
-                                                                          {
-                                                                            "kind": "conformance",
-                                                                            "type": "$sxD",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSSypXSDD"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "conformance",
-                                                                            "type": "$sxD",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSSypXSDD"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "argument_list",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "argument",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "inout_expr",
-                                                                        "type": "$sSaySSypXSDGzD",
-                                                                        "range": {
-                                                                          "start": 416,
-                                                                          "end": 416
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 416,
-                                                                              "end": 416
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "dictionary_expr",
-                                                                    "type": "$sSSypXSDD",
-                                                                    "range": {
-                                                                      "start": 428,
-                                                                      "end": 576
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "normal_conformance",
-                                                                                    "type": "$sSSD"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sq_D",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "self_conformance",
-                                                                                    "type": "$sypD"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sq_D",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "self_conformance",
-                                                                                    "type": "$sypD"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 429,
-                                                                          "end": 457
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 429,
-                                                                              "end": 429
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 440,
-                                                                              "end": 457
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 440,
-                                                                                  "end": 457
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 441,
-                                                                                      "end": 454
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 441,
-                                                                                          "end": 448
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 441,
-                                                                                              "end": 447
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 441,
-                                                                                                  "end": 441
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 443,
-                                                                                                          "end": 443
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 460,
-                                                                          "end": 504
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 460,
-                                                                              "end": 460
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 479,
-                                                                              "end": 504
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 479,
-                                                                                  "end": 504
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 480,
-                                                                                      "end": 501
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 480,
-                                                                                          "end": 495
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 480,
-                                                                                              "end": 494
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 480,
-                                                                                                  "end": 480
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 482,
-                                                                                                          "end": 482
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 507,
-                                                                          "end": 538
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 507,
-                                                                              "end": 507
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "force_value_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 529,
-                                                                              "end": 538
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "subscript_expr",
-                                                                                "type": "$sypXSqD",
-                                                                                "range": {
-                                                                                  "start": 529,
-                                                                                  "end": 537
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "decl_ref",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "substitution_map",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "substitution"
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "substitution"
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sxD",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "normal_conformance",
-                                                                                                "type": "$sSSD"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sq_D",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "self_conformance",
-                                                                                                "type": "$sypD"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sq_D",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "self_conformance",
-                                                                                                "type": "$sypD"
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "declref_expr",
-                                                                                    "type": "$sSSypXSDD",
-                                                                                    "range": {
-                                                                                      "start": 529,
-                                                                                      "end": 529
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "decl_ref"
-                                                                                      }
-                                                                                    ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "argument_list",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "argument",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "string_literal_expr",
-                                                                                            "type": "$sSSD",
-                                                                                            "range": {
-                                                                                              "start": 531,
-                                                                                              "end": 531
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref"
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 541,
-                                                                          "end": 575
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 541,
-                                                                              "end": 541
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 555,
-                                                                              "end": 575
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 555,
-                                                                                  "end": 575
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 556,
-                                                                                      "end": 572
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 556,
-                                                                                          "end": 566
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 556,
-                                                                                              "end": 565
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 556,
-                                                                                                  "end": 556
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 558,
-                                                                                                          "end": 558
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "pattern_named",
-                                            "name": "o",
-                                            "type": "$sSSSiXSDD"
-                                          },
-                                          {
-                                            "kind": "declref_expr",
-                                            "children": [
-                                              {
-                                                "kind": "decl_ref"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "pattern_binding_decl",
-                                            "children": [
-                                              {
-                                                "kind": "pattern_entry",
-                                                "children": [
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "$o$generator",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD"
-                                                  },
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                    "range": {
-                                                      "start": 374,
-                                                      "end": 374
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
-                                                        "range": {
-                                                          "start": 374,
-                                                          "end": 374
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      },
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSSiXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sSSSiXSDXSaD",
-                                                                    "range": {
-                                                                      "start": 374,
-                                                                      "end": 374
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref"
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "kind": "argument_list"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                    "range": {
-                                                      "start": 374,
-                                                      "end": 374
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
-                                                        "range": {
-                                                          "start": 374,
-                                                          "end": 374
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      },
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSSiXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sSSSiXSDXSaD",
-                                                                    "range": {
-                                                                      "start": 374,
-                                                                      "end": 374
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref"
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "kind": "argument_list"
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "return_stmt",
-                                        "range": {
-                                          "start": 587,
-                                          "end": 594
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "load_expr",
-                                            "type": "$sSSypXSDXSaD",
-                                            "range": {
-                                              "start": 594,
-                                              "end": 594
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "declref_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 594,
-                                                  "end": 594
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "kind": "argument_list"
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "pattern_named",
-                        "name": "result",
-                        "type": "$sSSypXSDXSaD"
-                      },
-                      {
-                        "kind": "call_expr",
-                        "type": "$sSSypXSDXSaD",
-                        "range": {
-                          "start": 331,
-                          "end": 602
-                        },
-                        "children": [
-                          {
-                            "kind": "argument_list"
-                          },
-                          {
-                            "kind": "paren_expr",
-                            "type": "$sSSypXSDXSayXED",
-                            "range": {
-                              "start": 331,
-                              "end": 600
-                            },
-                            "children": [
-                              {
-                                "kind": "closure_expr",
-                                "type": "$sSSypXSDXSayXED",
-                                "range": {
-                                  "start": 332,
-                                  "end": 599
-                                },
-                                "children": [
-                                  {
-                                    "kind": "captured_value",
-                                    "children": [
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "orders",
-                                        "range": {
-                                          "start": 176,
-                                          "end": 176
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "captured_value",
-                                    "children": [
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "customers",
-                                        "range": {
-                                          "start": 75,
-                                          "end": 75
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "kind": "parameter_list",
-                                    "range": {
-                                      "start": 332,
-                                      "end": 332
-                                    }
-                                  },
-                                  {
-                                    "kind": "brace_stmt",
-                                    "range": {
-                                      "start": 332,
-                                      "end": 599
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "pattern_binding_decl",
-                                        "range": {
-                                          "start": 334,
-                                          "end": 363
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "pattern_entry",
-                                            "children": [
-                                              {
-                                                "kind": "pattern_typed",
-                                                "type": "$sSSypXSDXSaD",
-                                                "children": [
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "_res",
-                                                    "type": "$sSSypXSDXSaD"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "array_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 362,
-                                                  "end": 363
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "array_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 362,
-                                                  "end": 363
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "builtin_conformance",
-                                                                "type": "$sSSypXSDD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "var_decl",
-                                        "name": "_res",
-                                        "range": {
-                                          "start": 338,
-                                          "end": 338
-                                        }
-                                      },
-                                      {
-                                        "kind": "for_each_stmt",
-                                        "range": {
-                                          "start": 365,
-                                          "end": 585
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "call_expr",
-                                            "type": "$sSSSiXSDXSqD",
-                                            "range": {
-                                              "start": 365,
-                                              "end": 365
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "dot_syntax_call_expr",
-                                                "type": "$sSSSiXSDXSqycD",
-                                                "range": {
-                                                  "start": 365,
-                                                  "end": 365
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sySSSiXSDXSqycs16IndexingIteratorVySSSiXSDXSaGzcD",
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution_map",
-                                                            "children": [
-                                                              {
-                                                                "kind": "substitution"
-                                                              },
-                                                              {
-                                                                "kind": "conformance",
-                                                                "type": "$sxD",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "specialized_conformance",
-                                                                    "type": "$sSSSiXSDXSaD"
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "inout_expr",
-                                                            "type": "$ss16IndexingIteratorVySSSiXSDXSaGzD",
-                                                            "range": {
-                                                              "start": 365,
-                                                              "end": 365
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "declref_expr",
-                                                                "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                                "range": {
-                                                                  "start": 365,
-                                                                  "end": 365
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "decl_ref"
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "kind": "argument_list"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "brace_stmt",
-                                            "range": {
-                                              "start": 381,
-                                              "end": 585
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "for_each_stmt",
-                                                "range": {
-                                                  "start": 387,
-                                                  "end": 583
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "brace_stmt",
-                                                    "range": {
-                                                      "start": 406,
-                                                      "end": 583
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "call_expr",
-                                                        "type": "$sytD",
-                                                        "range": {
-                                                          "start": 416,
-                                                          "end": 577
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "dot_syntax_call_expr",
-                                                            "type": "$syySSypXSDncD",
-                                                            "range": {
-                                                              "start": 416,
-                                                              "end": 421
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "declref_expr",
-                                                                "type": "$syySSypXSDncSaySSypXSDGzcD",
-                                                                "range": {
-                                                                  "start": 421,
-                                                                  "end": 421
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "decl_ref",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution_map",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution"
-                                                                          },
-                                                                          {
-                                                                            "kind": "conformance",
-                                                                            "type": "$sxD",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSSypXSDD"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "conformance",
-                                                                            "type": "$sxD",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSSypXSDD"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "argument_list",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "argument",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "inout_expr",
-                                                                        "type": "$sSaySSypXSDGzD",
-                                                                        "range": {
-                                                                          "start": 416,
-                                                                          "end": 416
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 416,
-                                                                              "end": 416
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "dictionary_expr",
-                                                                    "type": "$sSSypXSDD",
-                                                                    "range": {
-                                                                      "start": 428,
-                                                                      "end": 576
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "normal_conformance",
-                                                                                    "type": "$sSSD"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sq_D",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "self_conformance",
-                                                                                    "type": "$sypD"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sq_D",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "self_conformance",
-                                                                                    "type": "$sypD"
-                                                                                  }
-                                                                                ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 429,
-                                                                          "end": 457
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 429,
-                                                                              "end": 429
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 440,
-                                                                              "end": 457
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 440,
-                                                                                  "end": 457
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 441,
-                                                                                      "end": 454
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 441,
-                                                                                          "end": 448
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 441,
-                                                                                              "end": 447
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 441,
-                                                                                                  "end": 441
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 443,
-                                                                                                          "end": 443
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 460,
-                                                                          "end": 504
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 460,
-                                                                              "end": 460
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 479,
-                                                                              "end": 504
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 479,
-                                                                                  "end": 504
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 480,
-                                                                                      "end": 501
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 480,
-                                                                                          "end": 495
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 480,
-                                                                                              "end": 494
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 480,
-                                                                                                  "end": 480
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 482,
-                                                                                                          "end": 482
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 507,
-                                                                          "end": 538
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 507,
-                                                                              "end": 507
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "force_value_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 529,
-                                                                              "end": 538
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "subscript_expr",
-                                                                                "type": "$sypXSqD",
-                                                                                "range": {
-                                                                                  "start": 529,
-                                                                                  "end": 537
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "declref_expr",
-                                                                                    "type": "$sSSypXSDD",
-                                                                                    "range": {
-                                                                                      "start": 529,
-                                                                                      "end": 529
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "decl_ref"
-                                                                                      }
-                                                                                    ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "argument_list",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "argument",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "string_literal_expr",
-                                                                                            "type": "$sSSD",
-                                                                                            "range": {
-                                                                                              "start": 531,
-                                                                                              "end": 531
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref"
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "decl_ref",
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "substitution_map",
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "substitution"
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "substitution"
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sxD",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "normal_conformance",
-                                                                                                "type": "$sSSD"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sq_D",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "self_conformance",
-                                                                                                "type": "$sypD"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "conformance",
-                                                                                            "type": "$sq_D",
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "self_conformance",
-                                                                                                "type": "$sypD"
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "tuple_expr",
-                                                                        "type": "$sSS_yptD",
-                                                                        "range": {
-                                                                          "start": 541,
-                                                                          "end": 575
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "string_literal_expr",
-                                                                            "type": "$sSSD",
-                                                                            "range": {
-                                                                              "start": 541,
-                                                                              "end": 541
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "kind": "erasure_expr",
-                                                                            "type": "$sypD",
-                                                                            "range": {
-                                                                              "start": 555,
-                                                                              "end": 575
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "builtin_conformance",
-                                                                                "type": "$sSiD"
-                                                                              },
-                                                                              {
-                                                                                "kind": "paren_expr",
-                                                                                "type": "$sSiD",
-                                                                                "range": {
-                                                                                  "start": 555,
-                                                                                  "end": 575
-                                                                                },
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "forced_checked_cast_expr",
-                                                                                    "type": "$sSiD",
-                                                                                    "range": {
-                                                                                      "start": 556,
-                                                                                      "end": 572
-                                                                                    },
-                                                                                    "children": [
-                                                                                      {
-                                                                                        "kind": "force_value_expr",
-                                                                                        "type": "$sSiD",
-                                                                                        "range": {
-                                                                                          "start": 556,
-                                                                                          "end": 566
-                                                                                        },
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "kind": "subscript_expr",
-                                                                                            "type": "$sSiXSqD",
-                                                                                            "range": {
-                                                                                              "start": 556,
-                                                                                              "end": 565
-                                                                                            },
-                                                                                            "children": [
-                                                                                              {
-                                                                                                "kind": "decl_ref",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "substitution_map",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sxD",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "normal_conformance",
-                                                                                                            "type": "$sSSD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "conformance",
-                                                                                                        "type": "$sq_D",
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "builtin_conformance",
-                                                                                                            "type": "$sSiD"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "substitution"
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "declref_expr",
-                                                                                                "type": "$sSSSiXSDD",
-                                                                                                "range": {
-                                                                                                  "start": 556,
-                                                                                                  "end": 556
-                                                                                                },
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "decl_ref"
-                                                                                                  }
-                                                                                                ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "argument_list",
-                                                                                                "children": [
-                                                                                                  {
-                                                                                                    "kind": "argument",
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "kind": "string_literal_expr",
-                                                                                                        "type": "$sSSD",
-                                                                                                        "range": {
-                                                                                                          "start": 558,
-                                                                                                          "end": 558
-                                                                                                        },
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "kind": "decl_ref"
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                  }
-                                                                                                ]
-                                                                                              }
-                                                                                            ]
-                                                                                          }
-                                                                                        ]
-                                                                                      }
-                                                                                    ]
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "c",
-                                                    "type": "$sSSypXSDD"
-                                                  },
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "pattern_binding_decl",
-                                                    "children": [
-                                                      {
-                                                        "kind": "pattern_entry",
-                                                        "children": [
-                                                          {
-                                                            "kind": "pattern_named",
-                                                            "name": "$c$generator",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
-                                                          },
-                                                          {
-                                                            "kind": "call_expr",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                            "range": {
-                                                              "start": 396,
-                                                              "end": 396
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "dot_syntax_call_expr",
-                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                                                "range": {
-                                                                  "start": 396,
-                                                                  "end": 396
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "specialized_conformance",
-                                                                                    "type": "$sSSypXSDXSaD"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "argument_list",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "argument",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 396,
-                                                                              "end": 396
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              },
-                                                              {
-                                                                "kind": "argument_list"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "call_expr",
-                                                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                            "range": {
-                                                              "start": 396,
-                                                              "end": 396
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument_list"
-                                                              },
-                                                              {
-                                                                "kind": "dot_syntax_call_expr",
-                                                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                                                "range": {
-                                                                  "start": 396,
-                                                                  "end": 396
-                                                                },
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "substitution_map",
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "substitution"
-                                                                              },
-                                                                              {
-                                                                                "kind": "conformance",
-                                                                                "type": "$sxD",
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "specialized_conformance",
-                                                                                    "type": "$sSSypXSDXSaD"
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "argument_list",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "argument",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "declref_expr",
-                                                                            "type": "$sSSypXSDXSaD",
-                                                                            "range": {
-                                                                              "start": 396,
-                                                                              "end": 396
-                                                                            },
-                                                                            "children": [
-                                                                              {
-                                                                                "kind": "decl_ref"
-                                                                              }
-                                                                            ]
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$sSSypXSDXSqD",
-                                                    "range": {
-                                                      "start": 387,
-                                                      "end": 387
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$sSSypXSDXSqycD",
-                                                        "range": {
-                                                          "start": 387,
-                                                          "end": 387
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "inout_expr",
-                                                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
-                                                                    "range": {
-                                                                      "start": 387,
-                                                                      "end": 387
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "declref_expr",
-                                                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                                                        "range": {
-                                                                          "start": 387,
-                                                                          "end": 387
-                                                                        },
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "decl_ref"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      },
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSypXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "kind": "argument_list"
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "pattern_named",
-                                            "name": "o",
-                                            "type": "$sSSSiXSDD"
-                                          },
-                                          {
-                                            "kind": "declref_expr",
-                                            "children": [
-                                              {
-                                                "kind": "decl_ref"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "pattern_binding_decl",
-                                            "children": [
-                                              {
-                                                "kind": "pattern_entry",
-                                                "children": [
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                    "range": {
-                                                      "start": 374,
-                                                      "end": 374
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
-                                                        "range": {
-                                                          "start": 374,
-                                                          "end": 374
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      },
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSSiXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sSSSiXSDXSaD",
-                                                                    "range": {
-                                                                      "start": 374,
-                                                                      "end": 374
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref"
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "kind": "argument_list"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "call_expr",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD",
-                                                    "range": {
-                                                      "start": 374,
-                                                      "end": 374
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "dot_syntax_call_expr",
-                                                        "type": "$ss16IndexingIteratorVySSSiXSDXSaGycD",
-                                                        "range": {
-                                                          "start": 374,
-                                                          "end": 374
-                                                        },
-                                                        "children": [
-                                                          {
-                                                            "kind": "argument_list",
-                                                            "children": [
-                                                              {
-                                                                "kind": "argument",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "declref_expr",
-                                                                    "type": "$sSSSiXSDXSaD",
-                                                                    "range": {
-                                                                      "start": 374,
-                                                                      "end": 374
-                                                                    },
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "decl_ref"
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "declref_expr",
-                                                            "type": "$sys16IndexingIteratorVySSSiXSDXSaGycSSSiXSDXSancD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref",
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "substitution_map",
-                                                                    "children": [
-                                                                      {
-                                                                        "kind": "conformance",
-                                                                        "type": "$sxD",
-                                                                        "children": [
-                                                                          {
-                                                                            "kind": "specialized_conformance",
-                                                                            "type": "$sSSSiXSDXSaD"
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "substitution"
-                                                                      }
-                                                                    ]
-                                                                  }
-                                                                ]
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      },
-                                                      {
-                                                        "kind": "argument_list"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "pattern_named",
-                                                    "name": "$o$generator",
-                                                    "type": "$ss16IndexingIteratorVySSSiXSDXSaGD"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "kind": "return_stmt",
-                                        "range": {
-                                          "start": 587,
-                                          "end": 594
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "load_expr",
-                                            "type": "$sSSypXSDXSaD",
-                                            "range": {
-                                              "start": 594,
-                                              "end": 594
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "declref_expr",
-                                                "type": "$sSSypXSDXSaD",
-                                                "range": {
-                                                  "start": 594,
-                                                  "end": 594
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "kind": "var_decl",
-        "name": "result",
-        "range": {
-          "start": 322,
-          "end": 322
-        }
-      },
-      {
-        "kind": "top_level_code_decl",
-        "range": {
-          "start": 604,
-          "end": 656
-        },
-        "children": [
-          {
-            "kind": "brace_stmt",
-            "range": {
-              "start": 604,
-              "end": 656
-            },
-            "children": [
-              {
-                "kind": "call_expr",
-                "type": "$sytD",
-                "range": {
-                  "start": 604,
-                  "end": 656
-                },
-                "children": [
-                  {
-                    "kind": "declref_expr",
-                    "type": "$s_9separator10terminatoryypd_S2StcD",
-                    "range": {
-                      "start": 604,
-                      "end": 604
-                    },
-                    "children": [
-                      {
-                        "kind": "decl_ref"
-                      }
-                    ]
+                    "kind": "simple_identifier",
+                    "start": 684,
+                    "end": 689
                   },
                   {
-                    "kind": "argument_list",
+                    "kind": "call_suffix",
+                    "start": 689,
+                    "end": 843,
                     "children": [
                       {
-                        "kind": "argument",
+                        "kind": "value_arguments",
+                        "start": 689,
+                        "end": 843,
                         "children": [
                           {
-                            "kind": "vararg_expansion_expr",
-                            "type": "$sypXSaD",
-                            "range": {
-                              "start": 610,
-                              "end": 610
-                            },
+                            "kind": "value_argument",
+                            "start": 690,
+                            "end": 697,
                             "children": [
                               {
-                                "kind": "array_expr",
-                                "type": "$sypXSaD",
-                                "range": {
-                                  "start": 610,
-                                  "end": 610
-                                },
+                                "kind": "line_string_literal",
+                                "start": 690,
+                                "end": 697,
                                 "children": [
                                   {
-                                    "kind": "erasure_expr",
-                                    "type": "$sypD",
-                                    "range": {
-                                      "start": 610,
-                                      "end": 610
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "builtin_conformance",
-                                        "type": "$sSSD"
-                                      },
-                                      {
-                                        "kind": "string_literal_expr",
-                                        "type": "$sSSD",
-                                        "range": {
-                                          "start": 610,
-                                          "end": 610
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "line_str_text",
+                                    "start": 691,
+                                    "end": 696
                                   }
                                 ]
                               }
                             ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "argument",
-                        "children": [
-                          {
-                            "kind": "default_argument_expr",
-                            "type": "$sSSD",
-                            "range": {
-                              "start": 609,
-                              "end": 609
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref"
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "argument",
-                        "children": [
-                          {
-                            "kind": "default_argument_expr",
-                            "type": "$sSSD",
-                            "range": {
-                              "start": 609,
-                              "end": 609
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref"
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "kind": "top_level_code_decl",
-        "range": {
-          "start": 658,
-          "end": 844
-        },
-        "children": [
-          {
-            "kind": "brace_stmt",
-            "range": {
-              "start": 658,
-              "end": 844
-            },
-            "children": [
-              {
-                "kind": "for_each_stmt",
-                "range": {
-                  "start": 658,
-                  "end": 844
-                },
-                "children": [
-                  {
-                    "kind": "pattern_named",
-                    "name": "entry",
-                    "type": "$sSSypXSDD"
-                  },
-                  {
-                    "kind": "declref_expr",
-                    "children": [
-                      {
-                        "kind": "decl_ref"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "pattern_binding_decl",
-                    "children": [
-                      {
-                        "kind": "pattern_entry",
-                        "children": [
-                          {
-                            "kind": "pattern_named",
-                            "name": "$entry$generator",
-                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD"
                           },
                           {
-                            "kind": "call_expr",
-                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                            "range": {
-                              "start": 671,
-                              "end": 671
-                            },
+                            "kind": "value_argument",
+                            "start": 699,
+                            "end": 716,
                             "children": [
                               {
-                                "kind": "dot_syntax_call_expr",
-                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                "range": {
-                                  "start": 671,
-                                  "end": 671
-                                },
+                                "kind": "postfix_expression",
+                                "start": 699,
+                                "end": 716,
                                 "children": [
                                   {
-                                    "kind": "declref_expr",
-                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                    "kind": "call_expression",
+                                    "start": 699,
+                                    "end": 715,
                                     "children": [
                                       {
-                                        "kind": "decl_ref",
+                                        "kind": "simple_identifier",
+                                        "start": 699,
+                                        "end": 704
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 704,
+                                        "end": 715,
                                         "children": [
                                           {
-                                            "kind": "substitution_map",
+                                            "kind": "value_arguments",
+                                            "start": 704,
+                                            "end": 715,
                                             "children": [
                                               {
-                                                "kind": "substitution"
-                                              },
-                                              {
-                                                "kind": "conformance",
-                                                "type": "$sxD",
+                                                "kind": "value_argument",
+                                                "start": 705,
+                                                "end": 714,
                                                 "children": [
                                                   {
-                                                    "kind": "specialized_conformance",
-                                                    "type": "$sSSypXSDXSaD"
+                                                    "kind": "line_string_literal",
+                                                    "start": 705,
+                                                    "end": 714,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 706,
+                                                        "end": 713
+                                                      }
+                                                    ]
                                                   }
                                                 ]
                                               }
@@ -5637,71 +1196,79 @@
                                     ]
                                   },
                                   {
-                                    "kind": "argument_list",
-                                    "children": [
-                                      {
-                                        "kind": "argument",
-                                        "children": [
-                                          {
-                                            "kind": "declref_expr",
-                                            "type": "$sSSypXSDXSaD",
-                                            "range": {
-                                              "start": 671,
-                                              "end": 671
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "decl_ref"
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "bang",
+                                    "start": 715,
+                                    "end": 716
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "argument_list"
                               }
                             ]
                           },
                           {
-                            "kind": "call_expr",
-                            "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                            "range": {
-                              "start": 671,
-                              "end": 671
-                            },
+                            "kind": "value_argument",
+                            "start": 718,
+                            "end": 732,
                             "children": [
                               {
-                                "kind": "dot_syntax_call_expr",
-                                "type": "$ss16IndexingIteratorVySSypXSDXSaGycD",
-                                "range": {
-                                  "start": 671,
-                                  "end": 671
-                                },
+                                "kind": "line_string_literal",
+                                "start": 718,
+                                "end": 732,
                                 "children": [
                                   {
-                                    "kind": "declref_expr",
-                                    "type": "$sys16IndexingIteratorVySSypXSDXSaGycSSypXSDXSancD",
+                                    "kind": "line_str_text",
+                                    "start": 719,
+                                    "end": 731
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 734,
+                            "end": 759,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 734,
+                                "end": 759,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 734,
+                                    "end": 758,
                                     "children": [
                                       {
-                                        "kind": "decl_ref",
+                                        "kind": "simple_identifier",
+                                        "start": 734,
+                                        "end": 739
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 739,
+                                        "end": 758,
                                         "children": [
                                           {
-                                            "kind": "substitution_map",
+                                            "kind": "value_arguments",
+                                            "start": 739,
+                                            "end": 758,
                                             "children": [
                                               {
-                                                "kind": "substitution"
-                                              },
-                                              {
-                                                "kind": "conformance",
-                                                "type": "$sxD",
+                                                "kind": "value_argument",
+                                                "start": 740,
+                                                "end": 757,
                                                 "children": [
                                                   {
-                                                    "kind": "specialized_conformance",
-                                                    "type": "$sSSypXSDXSaD"
+                                                    "kind": "line_string_literal",
+                                                    "start": 740,
+                                                    "end": 757,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 741,
+                                                        "end": 756
+                                                      }
+                                                    ]
                                                   }
                                                 ]
                                               }
@@ -5712,699 +1279,160 @@
                                     ]
                                   },
                                   {
-                                    "kind": "argument_list",
-                                    "children": [
-                                      {
-                                        "kind": "argument",
-                                        "children": [
-                                          {
-                                            "kind": "declref_expr",
-                                            "type": "$sSSypXSDXSaD",
-                                            "range": {
-                                              "start": 671,
-                                              "end": 671
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "decl_ref"
-                                              }
-                                            ]
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "bang",
+                                    "start": 758,
+                                    "end": 759
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "argument_list"
                               }
                             ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "call_expr",
-                    "type": "$sSSypXSDXSqD",
-                    "range": {
-                      "start": 658,
-                      "end": 658
-                    },
-                    "children": [
-                      {
-                        "kind": "dot_syntax_call_expr",
-                        "type": "$sSSypXSDXSqycD",
-                        "range": {
-                          "start": 658,
-                          "end": 658
-                        },
-                        "children": [
+                          },
                           {
-                            "kind": "declref_expr",
-                            "type": "$sySSypXSDXSqycs16IndexingIteratorVySSypXSDXSaGzcD",
+                            "kind": "value_argument",
+                            "start": 761,
+                            "end": 773,
                             "children": [
                               {
-                                "kind": "decl_ref",
+                                "kind": "line_string_literal",
+                                "start": 761,
+                                "end": 773,
                                 "children": [
                                   {
-                                    "kind": "substitution_map",
+                                    "kind": "line_str_text",
+                                    "start": 762,
+                                    "end": 772
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 775,
+                            "end": 795,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 775,
+                                "end": 795,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 775,
+                                    "end": 794,
                                     "children": [
                                       {
-                                        "kind": "substitution"
+                                        "kind": "simple_identifier",
+                                        "start": 775,
+                                        "end": 780
                                       },
                                       {
-                                        "kind": "conformance",
-                                        "type": "$sxD",
+                                        "kind": "call_suffix",
+                                        "start": 780,
+                                        "end": 794,
                                         "children": [
                                           {
-                                            "kind": "specialized_conformance",
-                                            "type": "$sSSypXSDXSaD"
+                                            "kind": "value_arguments",
+                                            "start": 780,
+                                            "end": 794,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 781,
+                                                "end": 793,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 781,
+                                                    "end": 793,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 782,
+                                                        "end": 792
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
                                           }
                                         ]
                                       }
                                     ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 794,
+                                    "end": 795
                                   }
                                 ]
                               }
                             ]
                           },
                           {
-                            "kind": "argument_list",
+                            "kind": "value_argument",
+                            "start": 797,
+                            "end": 812,
                             "children": [
                               {
-                                "kind": "argument",
+                                "kind": "line_string_literal",
+                                "start": 797,
+                                "end": 812,
                                 "children": [
                                   {
-                                    "kind": "inout_expr",
-                                    "type": "$ss16IndexingIteratorVySSypXSDXSaGzD",
-                                    "range": {
-                                      "start": 658,
-                                      "end": 658
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "declref_expr",
-                                        "type": "$ss16IndexingIteratorVySSypXSDXSaGD",
-                                        "range": {
-                                          "start": 658,
-                                          "end": 658
-                                        },
-                                        "children": [
-                                          {
-                                            "kind": "decl_ref"
-                                          }
-                                        ]
-                                      }
-                                    ]
+                                    "kind": "line_str_text",
+                                    "start": 798,
+                                    "end": 811
                                   }
                                 ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "kind": "argument_list"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "brace_stmt",
-                    "range": {
-                      "start": 678,
-                      "end": 844
-                    },
-                    "children": [
-                      {
-                        "kind": "call_expr",
-                        "type": "$sytD",
-                        "range": {
-                          "start": 684,
-                          "end": 842
-                        },
-                        "children": [
-                          {
-                            "kind": "declref_expr",
-                            "type": "$s_9separator10terminatoryypd_S2StcD",
-                            "range": {
-                              "start": 684,
-                              "end": 684
-                            },
-                            "children": [
-                              {
-                                "kind": "decl_ref"
                               }
                             ]
                           },
                           {
-                            "kind": "argument_list",
+                            "kind": "value_argument",
+                            "start": 814,
+                            "end": 842,
                             "children": [
                               {
-                                "kind": "argument",
+                                "kind": "postfix_expression",
+                                "start": 814,
+                                "end": 842,
                                 "children": [
                                   {
-                                    "kind": "vararg_expansion_expr",
-                                    "type": "$sypXSaD",
-                                    "range": {
-                                      "start": 690,
-                                      "end": 841
-                                    },
+                                    "kind": "call_expression",
+                                    "start": 814,
+                                    "end": 841,
                                     "children": [
                                       {
-                                        "kind": "array_expr",
-                                        "type": "$sypXSaD",
-                                        "range": {
-                                          "start": 690,
-                                          "end": 841
-                                        },
+                                        "kind": "simple_identifier",
+                                        "start": 814,
+                                        "end": 819
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 819,
+                                        "end": 841,
                                         "children": [
                                           {
-                                            "kind": "erasure_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 690,
-                                              "end": 690
-                                            },
+                                            "kind": "value_arguments",
+                                            "start": 819,
+                                            "end": 841,
                                             "children": [
                                               {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "string_literal_expr",
-                                                "type": "$sSSD",
-                                                "range": {
-                                                  "start": 690,
-                                                  "end": 690
-                                                },
+                                                "kind": "value_argument",
+                                                "start": 820,
+                                                "end": 840,
                                                 "children": [
                                                   {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "force_value_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 699,
-                                              "end": 715
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "subscript_expr",
-                                                "type": "$sypXSqD",
-                                                "range": {
-                                                  "start": 699,
-                                                  "end": 714
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref",
+                                                    "kind": "line_string_literal",
+                                                    "start": 820,
+                                                    "end": 840,
                                                     "children": [
                                                       {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "normal_conformance",
-                                                                "type": "$sSSD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sSSypXSDD",
-                                                    "range": {
-                                                      "start": 699,
-                                                      "end": 699
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "string_literal_expr",
-                                                            "type": "$sSSD",
-                                                            "range": {
-                                                              "start": 705,
-                                                              "end": 705
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "erasure_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 718,
-                                              "end": 718
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "string_literal_expr",
-                                                "type": "$sSSD",
-                                                "range": {
-                                                  "start": 718,
-                                                  "end": 718
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "force_value_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 734,
-                                              "end": 758
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "subscript_expr",
-                                                "type": "$sypXSqD",
-                                                "range": {
-                                                  "start": 734,
-                                                  "end": 757
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sSSypXSDD",
-                                                    "range": {
-                                                      "start": 734,
-                                                      "end": 734
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "string_literal_expr",
-                                                            "type": "$sSSD",
-                                                            "range": {
-                                                              "start": 740,
-                                                              "end": 740
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "normal_conformance",
-                                                                "type": "$sSSD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "erasure_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 761,
-                                              "end": 761
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "string_literal_expr",
-                                                "type": "$sSSD",
-                                                "range": {
-                                                  "start": 761,
-                                                  "end": 761
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "force_value_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 775,
-                                              "end": 794
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "subscript_expr",
-                                                "type": "$sypXSqD",
-                                                "range": {
-                                                  "start": 775,
-                                                  "end": 793
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "string_literal_expr",
-                                                            "type": "$sSSD",
-                                                            "range": {
-                                                              "start": 781,
-                                                              "end": 781
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "normal_conformance",
-                                                                "type": "$sSSD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sSSypXSDD",
-                                                    "range": {
-                                                      "start": 775,
-                                                      "end": 775
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "erasure_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 797,
-                                              "end": 797
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "builtin_conformance",
-                                                "type": "$sSSD"
-                                              },
-                                              {
-                                                "kind": "string_literal_expr",
-                                                "type": "$sSSD",
-                                                "range": {
-                                                  "start": 797,
-                                                  "end": 797
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "decl_ref"
-                                                  }
-                                                ]
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "force_value_expr",
-                                            "type": "$sypD",
-                                            "range": {
-                                              "start": 814,
-                                              "end": 841
-                                            },
-                                            "children": [
-                                              {
-                                                "kind": "subscript_expr",
-                                                "type": "$sypXSqD",
-                                                "range": {
-                                                  "start": 814,
-                                                  "end": 840
-                                                },
-                                                "children": [
-                                                  {
-                                                    "kind": "argument_list",
-                                                    "children": [
-                                                      {
-                                                        "kind": "argument",
-                                                        "children": [
-                                                          {
-                                                            "kind": "string_literal_expr",
-                                                            "type": "$sSSD",
-                                                            "range": {
-                                                              "start": 820,
-                                                              "end": 820
-                                                            },
-                                                            "children": [
-                                                              {
-                                                                "kind": "decl_ref"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "decl_ref",
-                                                    "children": [
-                                                      {
-                                                        "kind": "substitution_map",
-                                                        "children": [
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "substitution"
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sxD",
-                                                            "children": [
-                                                              {
-                                                                "kind": "normal_conformance",
-                                                                "type": "$sSSD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          },
-                                                          {
-                                                            "kind": "conformance",
-                                                            "type": "$sq_D",
-                                                            "children": [
-                                                              {
-                                                                "kind": "self_conformance",
-                                                                "type": "$sypD"
-                                                              }
-                                                            ]
-                                                          }
-                                                        ]
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "kind": "declref_expr",
-                                                    "type": "$sSSypXSDD",
-                                                    "range": {
-                                                      "start": 814,
-                                                      "end": 814
-                                                    },
-                                                    "children": [
-                                                      {
-                                                        "kind": "decl_ref"
+                                                        "kind": "line_str_text",
+                                                        "start": 821,
+                                                        "end": 839
                                                       }
                                                     ]
                                                   }
@@ -6415,42 +1443,11 @@
                                         ]
                                       }
                                     ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "argument",
-                                "children": [
+                                  },
                                   {
-                                    "kind": "default_argument_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 689,
-                                      "end": 689
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "argument",
-                                "children": [
-                                  {
-                                    "kind": "default_argument_expr",
-                                    "type": "$sSSD",
-                                    "range": {
-                                      "start": 689,
-                                      "end": 689
-                                    },
-                                    "children": [
-                                      {
-                                        "kind": "decl_ref"
-                                      }
-                                    ]
+                                    "kind": "bang",
+                                    "start": 841,
+                                    "end": 842
                                   }
                                 ]
                               }

--- a/tests/json-ast/x/swift/cross_join_filter.swift.json
+++ b/tests/json-ast/x/swift/cross_join_filter.swift.json
@@ -1,111 +1,800 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 90
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 415,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 90
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "nums"
-        }
+        "end": 91,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 79,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 79
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 82,
+            "end": 91,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              },
+              {
+                "kind": "integer_literal",
+                "start": 89,
+                "end": 90
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 92,
-          "end": 115
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 92,
-        "end": 115
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "letters"
-        }
+        "end": 116,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 92,
+            "end": 95
+          },
+          {
+            "kind": "pattern",
+            "start": 96,
+            "end": 103,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 96,
+                "end": 103
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 106,
+            "end": 116,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 107,
+                "end": 110,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 108,
+                    "end": 109
+                  }
+                ]
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 112,
+                "end": 115,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 113,
+                    "end": 114
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 96,
-        "end": 96
-      },
-      "interface_type": "$sSSXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 117,
-          "end": 338
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 117,
-        "end": 338
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "pairs"
-        }
+        "end": 339,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 117,
+            "end": 120
+          },
+          {
+            "kind": "pattern",
+            "start": 121,
+            "end": 126,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 121,
+                "end": 126
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 129,
+            "end": 339,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 129,
+                "end": 337,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 130,
+                    "end": 336,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 132,
+                        "end": 334,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 132,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 132,
+                                "end": 135
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 136,
+                                "end": 140,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 136,
+                                    "end": 140
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 140,
+                                "end": 157,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 142,
+                                    "end": 157,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 143,
+                                        "end": 156,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 144,
+                                            "end": 150,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 144,
+                                                "end": 150
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 152,
+                                            "end": 155,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 152,
+                                                "end": 155
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 160,
+                                "end": 162
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 163,
+                            "end": 322,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 167,
+                                "end": 168,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 167,
+                                    "end": 168
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 172,
+                                "end": 176
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 183,
+                                "end": 321,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 183,
+                                    "end": 320,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 187,
+                                        "end": 188,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 187,
+                                            "end": 188
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 192,
+                                        "end": 199
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 210,
+                                        "end": 319,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 210,
+                                            "end": 314,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 213,
+                                                "end": 237,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 214,
+                                                    "end": 236,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 214,
+                                                        "end": 231,
+                                                        "children": [
+                                                          {
+                                                            "kind": "multiplicative_expression",
+                                                            "start": 215,
+                                                            "end": 230,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 215,
+                                                                "end": 226,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 216,
+                                                                    "end": 225,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 216,
+                                                                        "end": 217
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 218,
+                                                                        "end": 221
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 222,
+                                                                        "end": 225,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 222,
+                                                                            "end": 225
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 229,
+                                                                "end": 230
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 235,
+                                                        "end": 236
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 252,
+                                                "end": 313,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 252,
+                                                    "end": 304,
+                                                    "children": [
+                                                      {
+                                                        "kind": "navigation_expression",
+                                                        "start": 252,
+                                                        "end": 263,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 252,
+                                                            "end": 256
+                                                          },
+                                                          {
+                                                            "kind": "navigation_suffix",
+                                                            "start": 256,
+                                                            "end": 263,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 257,
+                                                                "end": 263
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 263,
+                                                        "end": 304,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 263,
+                                                            "end": 304,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 264,
+                                                                "end": 303,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_literal",
+                                                                    "start": 264,
+                                                                    "end": 303,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 265,
+                                                                        "end": 268,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 266,
+                                                                            "end": 267
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 270,
+                                                                        "end": 281,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 271,
+                                                                            "end": 280,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 271,
+                                                                                "end": 272
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 273,
+                                                                                "end": 276
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 277,
+                                                                                "end": 280,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 277,
+                                                                                    "end": 280
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 283,
+                                                                        "end": 286,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 284,
+                                                                            "end": 285
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 288,
+                                                                        "end": 302,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 289,
+                                                                            "end": 301,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 289,
+                                                                                "end": 290
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 291,
+                                                                                "end": 294
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 295,
+                                                                                "end": 301,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 295,
+                                                                                    "end": 301
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 323,
+                            "end": 334,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 330,
+                                "end": 334
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 337,
+                "end": 339,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 337,
+                    "end": 339
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 121,
-        "end": 121
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 340,
-          "end": 366
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 340,
-        "end": 366
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 368,
-          "end": 413
-        }
+        "end": 367,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 340,
+            "end": 345
+          },
+          {
+            "kind": "call_suffix",
+            "start": 345,
+            "end": 367,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 345,
+                "end": 367,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 346,
+                    "end": 366,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 346,
+                        "end": 366,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 347,
+                            "end": 365
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 368,
-        "end": 413
+        "end": 414,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 372,
+            "end": 373,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 372,
+                "end": 373
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 377,
+            "end": 382
+          },
+          {
+            "kind": "statements",
+            "start": 389,
+            "end": 413,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 389,
+                "end": 412,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 389,
+                    "end": 394
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 394,
+                    "end": 412,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 394,
+                        "end": 412,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 395,
+                            "end": 402,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 395,
+                                "end": 402,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 395,
+                                    "end": 401,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 395,
+                                        "end": 396
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 396,
+                                        "end": 401,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 396,
+                                            "end": 401,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 397,
+                                                "end": 400,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 397,
+                                                    "end": 400,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 398,
+                                                        "end": 399
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 401,
+                                    "end": 402
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 404,
+                            "end": 411,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 404,
+                                "end": 411,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 404,
+                                    "end": 410,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 404,
+                                        "end": 405
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 405,
+                                        "end": 410,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 405,
+                                            "end": 410,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 406,
+                                                "end": 409,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 406,
+                                                    "end": 409,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 407,
+                                                        "end": 408
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 410,
+                                    "end": 411
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/cross_join_triple.swift.json
+++ b/tests/json-ast/x/swift/cross_join_triple.swift.json
@@ -1,138 +1,891 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 87
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 470,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 87
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "nums"
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 79,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 79
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 82,
+            "end": 88,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 89,
-          "end": 112
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 89,
-        "end": 112
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "letters"
-        }
+        "end": 113,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 89,
+            "end": 92
+          },
+          {
+            "kind": "pattern",
+            "start": 93,
+            "end": 100,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 93,
+                "end": 100
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 103,
+            "end": 113,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 104,
+                "end": 107,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 105,
+                    "end": 106
+                  }
+                ]
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 109,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 110,
+                    "end": 111
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 93,
-        "end": 93
-      },
-      "interface_type": "$sSSXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 114,
-          "end": 138
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 114,
-        "end": 138
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "bools"
-        }
+        "end": 139,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 114,
+            "end": 117
+          },
+          {
+            "kind": "pattern",
+            "start": 118,
+            "end": 123,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 118,
+                "end": 123
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 126,
+            "end": 139,
+            "children": [
+              {
+                "kind": "boolean_literal",
+                "start": 127,
+                "end": 131
+              },
+              {
+                "kind": "boolean_literal",
+                "start": 133,
+                "end": 138
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 118,
-        "end": 118
-      },
-      "interface_type": "$sSbXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 140,
-          "end": 368
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 140,
-        "end": 368
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "combos"
-        }
+        "end": 369,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 140,
+            "end": 143
+          },
+          {
+            "kind": "pattern",
+            "start": 144,
+            "end": 150,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 144,
+                "end": 150
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 153,
+            "end": 369,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 153,
+                "end": 367,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 154,
+                    "end": 366,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 156,
+                        "end": 364,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 156,
+                            "end": 186,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 156,
+                                "end": 159
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 160,
+                                "end": 164,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 160,
+                                    "end": 164
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 164,
+                                "end": 181,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 166,
+                                    "end": 181,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 167,
+                                        "end": 180,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 168,
+                                            "end": 174,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 168,
+                                                "end": 174
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 176,
+                                            "end": 179,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 176,
+                                                "end": 179
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 184,
+                                "end": 186
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 187,
+                            "end": 352,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 191,
+                                "end": 192,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 191,
+                                    "end": 192
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 196,
+                                "end": 200
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 207,
+                                "end": 351,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 207,
+                                    "end": 350,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 211,
+                                        "end": 212,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 211,
+                                            "end": 212
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 216,
+                                        "end": 223
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 234,
+                                        "end": 349,
+                                        "children": [
+                                          {
+                                            "kind": "for_statement",
+                                            "start": 234,
+                                            "end": 344,
+                                            "children": [
+                                              {
+                                                "kind": "pattern",
+                                                "start": 238,
+                                                "end": 239,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 238,
+                                                    "end": 239
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 243,
+                                                "end": 248
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 263,
+                                                "end": 343,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 263,
+                                                    "end": 334,
+                                                    "children": [
+                                                      {
+                                                        "kind": "navigation_expression",
+                                                        "start": 263,
+                                                        "end": 274,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 263,
+                                                            "end": 267
+                                                          },
+                                                          {
+                                                            "kind": "navigation_suffix",
+                                                            "start": 267,
+                                                            "end": 274,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 268,
+                                                                "end": 274
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 274,
+                                                        "end": 334,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 274,
+                                                            "end": 334,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 275,
+                                                                "end": 333,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_literal",
+                                                                    "start": 275,
+                                                                    "end": 333,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 276,
+                                                                        "end": 279,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 277,
+                                                                            "end": 278
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 281,
+                                                                        "end": 292,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 282,
+                                                                            "end": 291,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 282,
+                                                                                "end": 283
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 284,
+                                                                                "end": 287
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 288,
+                                                                                "end": 291,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 288,
+                                                                                    "end": 291
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 294,
+                                                                        "end": 297,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 295,
+                                                                            "end": 296
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 299,
+                                                                        "end": 313,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 300,
+                                                                            "end": 312,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 300,
+                                                                                "end": 301
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 302,
+                                                                                "end": 305
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 306,
+                                                                                "end": 312,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 306,
+                                                                                    "end": 312
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 315,
+                                                                        "end": 318,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 316,
+                                                                            "end": 317
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 320,
+                                                                        "end": 332,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 321,
+                                                                            "end": 331,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 321,
+                                                                                "end": 322
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 323,
+                                                                                "end": 326
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 327,
+                                                                                "end": 331,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 327,
+                                                                                    "end": 331
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 353,
+                            "end": 364,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 360,
+                                "end": 364
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 367,
+                "end": 369,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 367,
+                    "end": 369
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 144,
-        "end": 144
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 370,
-          "end": 411
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 370,
-        "end": 411
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 413,
-          "end": 468
-        }
+        "end": 412,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 370,
+            "end": 375
+          },
+          {
+            "kind": "call_suffix",
+            "start": 375,
+            "end": 412,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 375,
+                "end": 412,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 376,
+                    "end": 411,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 376,
+                        "end": 411,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 377,
+                            "end": 410
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 413,
-        "end": 468
+        "end": 469,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 417,
+            "end": 418,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 417,
+                "end": 418
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 422,
+            "end": 428
+          },
+          {
+            "kind": "statements",
+            "start": 435,
+            "end": 468,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 435,
+                "end": 467,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 435,
+                    "end": 440
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 440,
+                    "end": 467,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 440,
+                        "end": 467,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 441,
+                            "end": 448,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 441,
+                                "end": 448,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 441,
+                                    "end": 447,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 441,
+                                        "end": 442
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 442,
+                                        "end": 447,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 442,
+                                            "end": 447,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 443,
+                                                "end": 446,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 443,
+                                                    "end": 446,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 444,
+                                                        "end": 445
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 447,
+                                    "end": 448
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 450,
+                            "end": 457,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 450,
+                                "end": 457,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 450,
+                                    "end": 456,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 450,
+                                        "end": 451
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 451,
+                                        "end": 456,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 451,
+                                            "end": 456,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 452,
+                                                "end": 455,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 452,
+                                                    "end": 455,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 453,
+                                                        "end": 454
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 456,
+                                    "end": 457
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 459,
+                            "end": 466,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 459,
+                                "end": 466,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 459,
+                                    "end": 465,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 459,
+                                        "end": 460
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 460,
+                                        "end": 465,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 460,
+                                            "end": 465,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 461,
+                                                "end": 464,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 461,
+                                                    "end": 464,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 462,
+                                                        "end": 463
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 465,
+                                    "end": 466
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/dataset_sort_take_limit.swift.json
+++ b/tests/json-ast/x/swift/dataset_sort_take_limit.swift.json
@@ -1,91 +1,1747 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 896,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 352
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 352
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "products"
-        }
+        "end": 353,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 102,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 102
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 105,
+            "end": 353,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 106,
+                "end": 139,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 107,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 108,
+                        "end": 112
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 115,
+                    "end": 123,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 116,
+                        "end": 122
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 125,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 126,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 134,
+                    "end": 138
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 141,
+                "end": 177,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 142,
+                    "end": 148,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 143,
+                        "end": 147
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 150,
+                    "end": 162,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 151,
+                        "end": 161
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 164,
+                    "end": 171,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 165,
+                        "end": 170
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 173,
+                    "end": 176
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 179,
+                "end": 211,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 180,
+                    "end": 186,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 181,
+                        "end": 185
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 188,
+                    "end": 196,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 189,
+                        "end": 195
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 205,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 204
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 207,
+                    "end": 210
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 213,
+                "end": 246,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 214,
+                    "end": 220,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 215,
+                        "end": 219
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 222,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 223,
+                        "end": 230
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 233,
+                    "end": 240,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 234,
+                        "end": 239
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 242,
+                    "end": 245
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 248,
+                "end": 282,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 249,
+                    "end": 255,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 250,
+                        "end": 254
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 257,
+                    "end": 267,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 258,
+                        "end": 266
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 269,
+                    "end": 276,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 270,
+                        "end": 275
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 278,
+                    "end": 281
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 284,
+                "end": 314,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 285,
+                    "end": 291,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 286,
+                        "end": 290
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 293,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 294,
+                        "end": 299
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 302,
+                    "end": 309,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 303,
+                        "end": 308
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 311,
+                    "end": 313
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 316,
+                "end": 352,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 317,
+                    "end": 323,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 318,
+                        "end": 322
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 325,
+                    "end": 337,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 326,
+                        "end": 336
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 339,
+                    "end": 346,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 340,
+                        "end": 345
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 348,
+                    "end": 351
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 354,
-          "end": 719
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 354,
-        "end": 719
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "expensive"
-        }
+        "end": 720,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 354,
+            "end": 357
+          },
+          {
+            "kind": "pattern",
+            "start": 358,
+            "end": 367,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 358,
+                "end": 367
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 370,
+            "end": 720,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 370,
+                "end": 718,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 371,
+                    "end": 717,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 373,
+                        "end": 715,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 373,
+                            "end": 403,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 373,
+                                "end": 376
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 377,
+                                "end": 381,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 377,
+                                    "end": 381
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 381,
+                                "end": 398,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 383,
+                                    "end": 398,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 384,
+                                        "end": 397,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 385,
+                                            "end": 391,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 385,
+                                                "end": 391
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 393,
+                                            "end": 396,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 393,
+                                                "end": 396
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 401,
+                                "end": 403
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 404,
+                            "end": 444,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 408,
+                                "end": 409,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 408,
+                                    "end": 409
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 413,
+                                "end": 421
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 428,
+                                "end": 443,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 428,
+                                    "end": 442,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 428,
+                                        "end": 439,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 428,
+                                            "end": 432
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 432,
+                                            "end": 439,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 433,
+                                                "end": 439
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 439,
+                                        "end": 442,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 439,
+                                            "end": 442,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 440,
+                                                "end": 441,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 440,
+                                                    "end": 441
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "property_declaration",
+                            "start": 445,
+                            "end": 461,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 445,
+                                "end": 448
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 449,
+                                "end": 454,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 449,
+                                    "end": 454
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 457,
+                                "end": 461
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_expression",
+                            "start": 462,
+                            "end": 637,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 462,
+                                "end": 472,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 462,
+                                    "end": 467
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 467,
+                                    "end": 472,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 468,
+                                        "end": 472
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 473,
+                                "end": 637,
+                                "children": [
+                                  {
+                                    "kind": "lambda_literal",
+                                    "start": 473,
+                                    "end": 637,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_function_type",
+                                        "start": 475,
+                                        "end": 486,
+                                        "children": [
+                                          {
+                                            "kind": "lambda_function_type_parameters",
+                                            "start": 475,
+                                            "end": 486,
+                                            "children": [
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 475,
+                                                "end": 479,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 475,
+                                                    "end": 479
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 481,
+                                                "end": 486,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 481,
+                                                    "end": 486
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 490,
+                                        "end": 636,
+                                        "children": [
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 490,
+                                            "end": 502,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 490,
+                                                "end": 493
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 494,
+                                                "end": 495,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 494,
+                                                    "end": 495
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 498,
+                                                "end": 502
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 503,
+                                            "end": 535,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 503,
+                                                "end": 506
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 507,
+                                                "end": 510,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 507,
+                                                    "end": 510
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 513,
+                                                "end": 535,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 514,
+                                                    "end": 535,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 514,
+                                                        "end": 535,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 515,
+                                                            "end": 534,
+                                                            "children": [
+                                                              {
+                                                                "kind": "as_expression",
+                                                                "start": 515,
+                                                                "end": 534,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "postfix_expression",
+                                                                    "start": 515,
+                                                                    "end": 526,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "call_expression",
+                                                                        "start": 515,
+                                                                        "end": 525,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 515,
+                                                                            "end": 516
+                                                                          },
+                                                                          {
+                                                                            "kind": "call_suffix",
+                                                                            "start": 516,
+                                                                            "end": 525,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_arguments",
+                                                                                "start": 516,
+                                                                                "end": 525,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_argument",
+                                                                                    "start": 517,
+                                                                                    "end": 524,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 517,
+                                                                                        "end": 524,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 518,
+                                                                                            "end": 523
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "bang",
+                                                                        "start": 525,
+                                                                        "end": 526
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "as_operator",
+                                                                    "start": 527,
+                                                                    "end": 530
+                                                                  },
+                                                                  {
+                                                                    "kind": "user_type",
+                                                                    "start": 531,
+                                                                    "end": 534,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "type_identifier",
+                                                                        "start": 531,
+                                                                        "end": 534
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "assignment",
+                                            "start": 536,
+                                            "end": 545,
+                                            "children": [
+                                              {
+                                                "kind": "directly_assignable_expression",
+                                                "start": 536,
+                                                "end": 537,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 536,
+                                                    "end": 537
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 540,
+                                                "end": 545
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 546,
+                                            "end": 578,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 546,
+                                                "end": 549
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 550,
+                                                "end": 553,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 550,
+                                                    "end": 553
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 556,
+                                                "end": 578,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 557,
+                                                    "end": 578,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 557,
+                                                        "end": 578,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 558,
+                                                            "end": 577,
+                                                            "children": [
+                                                              {
+                                                                "kind": "as_expression",
+                                                                "start": 558,
+                                                                "end": 577,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "postfix_expression",
+                                                                    "start": 558,
+                                                                    "end": 569,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "call_expression",
+                                                                        "start": 558,
+                                                                        "end": 568,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 558,
+                                                                            "end": 559
+                                                                          },
+                                                                          {
+                                                                            "kind": "call_suffix",
+                                                                            "start": 559,
+                                                                            "end": 568,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_arguments",
+                                                                                "start": 559,
+                                                                                "end": 568,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_argument",
+                                                                                    "start": 560,
+                                                                                    "end": 567,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 560,
+                                                                                        "end": 567,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 561,
+                                                                                            "end": 566
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "bang",
+                                                                        "start": 568,
+                                                                        "end": 569
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "as_operator",
+                                                                    "start": 570,
+                                                                    "end": 573
+                                                                  },
+                                                                  {
+                                                                    "kind": "user_type",
+                                                                    "start": 574,
+                                                                    "end": 577,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "type_identifier",
+                                                                        "start": 574,
+                                                                        "end": 577
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "control_transfer_statement",
+                                            "start": 579,
+                                            "end": 635,
+                                            "children": [
+                                              {
+                                                "kind": "comparison_expression",
+                                                "start": 586,
+                                                "end": 635,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 586,
+                                                    "end": 609,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 586,
+                                                        "end": 592
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 592,
+                                                        "end": 609,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 592,
+                                                            "end": 609,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 593,
+                                                                "end": 608,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument_label",
+                                                                    "start": 593,
+                                                                    "end": 603,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 593,
+                                                                        "end": 603
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 605,
+                                                                    "end": 608
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 612,
+                                                    "end": 635,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 612,
+                                                        "end": 618
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 618,
+                                                        "end": 635,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 618,
+                                                            "end": 635,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 619,
+                                                                "end": 634,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument_label",
+                                                                    "start": 619,
+                                                                    "end": 629,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 619,
+                                                                        "end": 629
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 631,
+                                                                    "end": 634
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "assignment",
+                            "start": 638,
+                            "end": 671,
+                            "children": [
+                              {
+                                "kind": "directly_assignable_expression",
+                                "start": 638,
+                                "end": 643,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 638,
+                                    "end": 643
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_expression",
+                                "start": 646,
+                                "end": 671,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 646,
+                                    "end": 651
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 651,
+                                    "end": 671,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 651,
+                                        "end": 671,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 652,
+                                            "end": 670,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 652,
+                                                "end": 670,
+                                                "children": [
+                                                  {
+                                                    "kind": "navigation_expression",
+                                                    "start": 652,
+                                                    "end": 667,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 652,
+                                                        "end": 657
+                                                      },
+                                                      {
+                                                        "kind": "navigation_suffix",
+                                                        "start": 657,
+                                                        "end": 667,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 658,
+                                                            "end": 667
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 667,
+                                                    "end": 670,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 667,
+                                                        "end": 670,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 668,
+                                                            "end": 669,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 668,
+                                                                "end": 669
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "assignment",
+                            "start": 672,
+                            "end": 702,
+                            "children": [
+                              {
+                                "kind": "directly_assignable_expression",
+                                "start": 672,
+                                "end": 677,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 672,
+                                    "end": 677
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_expression",
+                                "start": 680,
+                                "end": 702,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 680,
+                                    "end": 685
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 685,
+                                    "end": 702,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 685,
+                                        "end": 702,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 686,
+                                            "end": 701,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 686,
+                                                "end": 701,
+                                                "children": [
+                                                  {
+                                                    "kind": "navigation_expression",
+                                                    "start": 686,
+                                                    "end": 698,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 686,
+                                                        "end": 691
+                                                      },
+                                                      {
+                                                        "kind": "navigation_suffix",
+                                                        "start": 691,
+                                                        "end": 698,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 692,
+                                                            "end": 698
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 698,
+                                                    "end": 701,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 698,
+                                                        "end": 701,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 699,
+                                                            "end": 700,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 699,
+                                                                "end": 700
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 703,
+                            "end": 715,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 710,
+                                "end": 715
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 718,
+                "end": 720,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 718,
+                    "end": 720
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 358,
-        "end": 358
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 721,
-          "end": 776
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 721,
-        "end": 776
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 778,
-          "end": 894
-        }
+        "end": 777,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 721,
+            "end": 726
+          },
+          {
+            "kind": "call_suffix",
+            "start": 726,
+            "end": 777,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 726,
+                "end": 777,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 727,
+                    "end": 776,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 727,
+                        "end": 776,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 728,
+                            "end": 775
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 778,
-        "end": 894
+        "end": 895,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 782,
+            "end": 786,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 782,
+                "end": 786
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 790,
+            "end": 799
+          },
+          {
+            "kind": "statements",
+            "start": 806,
+            "end": 894,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 806,
+                "end": 893,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 806,
+                    "end": 811
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 811,
+                    "end": 893,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 811,
+                        "end": 893,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 812,
+                            "end": 845,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 812,
+                                "end": 845,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 812,
+                                    "end": 818
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 818,
+                                    "end": 845,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 818,
+                                        "end": 845,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 819,
+                                            "end": 844,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument_label",
+                                                "start": 819,
+                                                "end": 829,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 819,
+                                                    "end": 829
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "postfix_expression",
+                                                "start": 831,
+                                                "end": 844,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 831,
+                                                    "end": 843,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 831,
+                                                        "end": 835
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 835,
+                                                        "end": 843,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 835,
+                                                            "end": 843,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 836,
+                                                                "end": 842,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_string_literal",
+                                                                    "start": 836,
+                                                                    "end": 842,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_str_text",
+                                                                        "start": 837,
+                                                                        "end": 841
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "bang",
+                                                    "start": 843,
+                                                    "end": 844
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 847,
+                            "end": 856,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 847,
+                                "end": 856,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 848,
+                                    "end": 855
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 858,
+                            "end": 892,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 858,
+                                "end": 892,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 858,
+                                    "end": 864
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 864,
+                                    "end": 892,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 864,
+                                        "end": 892,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 865,
+                                            "end": 891,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument_label",
+                                                "start": 865,
+                                                "end": 875,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 865,
+                                                    "end": 875
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "postfix_expression",
+                                                "start": 877,
+                                                "end": 891,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 877,
+                                                    "end": 890,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 877,
+                                                        "end": 881
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 881,
+                                                        "end": 890,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 881,
+                                                            "end": 890,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 882,
+                                                                "end": 889,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_string_literal",
+                                                                    "start": 882,
+                                                                    "end": 889,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_str_text",
+                                                                        "start": 883,
+                                                                        "end": 888
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "bang",
+                                                    "start": 890,
+                                                    "end": 891
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/for_list_collection.swift.json
+++ b/tests/json-ast/x/swift/for_list_collection.swift.json
@@ -1,17 +1,100 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 105
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 107,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 71,
-        "end": 105
+        "end": 106,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 80,
+            "end": 89,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 81,
+                "end": 82
+              },
+              {
+                "kind": "integer_literal",
+                "start": 84,
+                "end": 85
+              },
+              {
+                "kind": "integer_literal",
+                "start": 87,
+                "end": 88
+              }
+            ]
+          },
+          {
+            "kind": "statements",
+            "start": 96,
+            "end": 105,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 96,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 96,
+                    "end": 101
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 101,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 101,
+                        "end": 104,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 102,
+                            "end": 103,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 102,
+                                "end": 103
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/for_loop.swift.json
+++ b/tests/json-ast/x/swift/for_loop.swift.json
@@ -1,17 +1,95 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 101
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 103,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 71,
-        "end": 101
+        "end": 102,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "range_expression",
+            "start": 80,
+            "end": 85,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 80,
+                "end": 81
+              },
+              {
+                "kind": "integer_literal",
+                "start": 84,
+                "end": 85
+              }
+            ]
+          },
+          {
+            "kind": "statements",
+            "start": 92,
+            "end": 101,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 92,
+                "end": 100,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 92,
+                    "end": 97
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 97,
+                    "end": 100,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 97,
+                        "end": 100,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 98,
+                            "end": 99,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 98,
+                                "end": 99
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/for_map_collection.swift.json
+++ b/tests/json-ast/x/swift/for_map_collection.swift.json
@@ -1,44 +1,205 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 94
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 138,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 94
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 95,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 79,
+            "end": 95,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 80,
+                "end": 83,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 81,
+                    "end": 82
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 85,
+                "end": 86
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 88,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 89,
+                    "end": 90
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 93,
+                "end": 94
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 96,
-          "end": 136
-        }
-      },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 96,
-        "end": 136
+        "end": 137,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 100,
+            "end": 101,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 100,
+                "end": 101
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 105,
+            "end": 120,
+            "children": [
+              {
+                "kind": "navigation_expression",
+                "start": 105,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "navigation_expression",
+                    "start": 105,
+                    "end": 111,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 105,
+                        "end": 106
+                      },
+                      {
+                        "kind": "navigation_suffix",
+                        "start": 106,
+                        "end": 111,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 107,
+                            "end": 111
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "navigation_suffix",
+                    "start": 111,
+                    "end": 118,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 112,
+                        "end": 118
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 118,
+                "end": 120,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 118,
+                    "end": 120
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "statements",
+            "start": 127,
+            "end": 136,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 127,
+                "end": 135,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 127,
+                    "end": 132
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 132,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 132,
+                        "end": 135,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 133,
+                            "end": 134,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 133,
+                                "end": 134
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/fun_call.swift.json
+++ b/tests/json-ast/x/swift/fun_call.swift.json
@@ -1,58 +1,255 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "add"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 157,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 129,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "a"
-              }
-            },
-            "interface_type": "$sSiD"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 79
           },
           {
-            "name": {
-              "base_name": {
-                "name": "b"
+            "kind": "parameter",
+            "start": 80,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 80,
+                "end": 81
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 82,
+                "end": 83
+              },
+              {
+                "kind": "user_type",
+                "start": 85,
+                "end": 88,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 85,
+                    "end": 88
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "parameter",
+            "start": 90,
+            "end": 98,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 90,
+                "end": 91
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 92,
+                "end": 93
+              },
+              {
+                "kind": "user_type",
+                "start": 95,
+                "end": 98,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 95,
+                    "end": 98
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 103,
+            "end": 106,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 103,
+                "end": 106
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 107,
+            "end": 129,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 113,
+                "end": 128,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 113,
+                    "end": 127,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 120,
+                        "end": 127,
+                        "children": [
+                          {
+                            "kind": "additive_expression",
+                            "start": 121,
+                            "end": 126,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 121,
+                                "end": 122
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 125,
+                                "end": 126
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 107,
-          "end": 128
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 128
-      },
-      "result": "$sSiD",
-      "interface_type": "$syS2i_SitcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 130,
-          "end": 155
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 130,
-        "end": 155
+        "end": 156,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 130,
+            "end": 135
+          },
+          {
+            "kind": "call_suffix",
+            "start": 135,
+            "end": 156,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 135,
+                "end": 156,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 136,
+                    "end": 155,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 136,
+                        "end": 155,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 137,
+                            "end": 154,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 137,
+                                "end": 146,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 137,
+                                    "end": 140
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 140,
+                                    "end": 146,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 140,
+                                        "end": 146,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 141,
+                                            "end": 142,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 141,
+                                                "end": 142
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 144,
+                                            "end": 145,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 144,
+                                                "end": 145
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 147,
+                                "end": 150
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 151,
+                                "end": 154,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 151,
+                                    "end": 154
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/fun_expr_in_let.swift.json
+++ b/tests/json-ast/x/swift/fun_expr_in_let.swift.json
@@ -1,44 +1,228 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 113
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 142,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 113
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "square"
-        }
+        "end": 114,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 81,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 81
+              }
+            ]
+          },
+          {
+            "kind": "lambda_literal",
+            "start": 84,
+            "end": 114,
+            "children": [
+              {
+                "kind": "lambda_function_type",
+                "start": 86,
+                "end": 101,
+                "children": [
+                  {
+                    "kind": "lambda_function_type_parameters",
+                    "start": 87,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "lambda_parameter",
+                        "start": 87,
+                        "end": 93,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 87,
+                            "end": 88
+                          },
+                          {
+                            "kind": "user_type",
+                            "start": 90,
+                            "end": 93,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 90,
+                                "end": 93
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 98,
+                    "end": 101,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 98,
+                        "end": 101
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "statements",
+                "start": 105,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 105,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "multiplicative_expression",
+                        "start": 106,
+                        "end": 111,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 106,
+                            "end": 107
+                          },
+                          {
+                            "kind": "simple_identifier",
+                            "start": 110,
+                            "end": 111
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$syS2icD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 115,
-          "end": 140
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 115,
-        "end": 140
+        "end": 141,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 115,
+            "end": 120
+          },
+          {
+            "kind": "call_suffix",
+            "start": 120,
+            "end": 141,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 120,
+                "end": 141,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 121,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 121,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 122,
+                            "end": 139,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 122,
+                                "end": 131,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 122,
+                                    "end": 128
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 128,
+                                    "end": 131,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 128,
+                                        "end": 131,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 129,
+                                            "end": 130,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 129,
+                                                "end": 130
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 132,
+                                "end": 135
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 136,
+                                "end": 139,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 136,
+                                    "end": 139
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/fun_three_args.swift.json
+++ b/tests/json-ast/x/swift/fun_three_args.swift.json
@@ -1,66 +1,315 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "sum3"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 178,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 146,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "a"
-              }
-            },
-            "interface_type": "$sSiD"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 80
           },
           {
-            "name": {
-              "base_name": {
-                "name": "b"
+            "kind": "parameter",
+            "start": 81,
+            "end": 89,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 81,
+                "end": 82
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "user_type",
+                "start": 86,
+                "end": 89,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 86,
+                    "end": 89
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
           },
           {
-            "name": {
-              "base_name": {
-                "name": "c"
+            "kind": "parameter",
+            "start": 91,
+            "end": 99,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 91,
+                "end": 92
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "user_type",
+                "start": 96,
+                "end": 99,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 96,
+                    "end": 99
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "parameter",
+            "start": 101,
+            "end": 109,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 101,
+                "end": 102
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 103,
+                "end": 104
+              },
+              {
+                "kind": "user_type",
+                "start": 106,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 106,
+                    "end": 109
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 114,
+            "end": 117,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 114,
+                "end": 117
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 118,
+            "end": 146,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 124,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 124,
+                    "end": 144,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 131,
+                        "end": 144,
+                        "children": [
+                          {
+                            "kind": "additive_expression",
+                            "start": 132,
+                            "end": 143,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 132,
+                                "end": 139,
+                                "children": [
+                                  {
+                                    "kind": "additive_expression",
+                                    "start": 133,
+                                    "end": 138,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 133,
+                                        "end": 134
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 137,
+                                        "end": 138
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 142,
+                                "end": 143
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 118,
-          "end": 145
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 145
-      },
-      "result": "$sSiD",
-      "interface_type": "$syS2i_S2itcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 147,
-          "end": 176
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 147,
-        "end": 176
+        "end": 177,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 147,
+            "end": 152
+          },
+          {
+            "kind": "call_suffix",
+            "start": 152,
+            "end": 177,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 152,
+                "end": 177,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 153,
+                    "end": 176,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 153,
+                        "end": 176,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 154,
+                            "end": 175,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 154,
+                                "end": 167,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 154,
+                                    "end": 158
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 158,
+                                    "end": 167,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 158,
+                                        "end": 167,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 159,
+                                            "end": 160,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 159,
+                                                "end": 160
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 162,
+                                            "end": 163,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 162,
+                                                "end": 163
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 165,
+                                            "end": 166,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 165,
+                                                "end": 166
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 168,
+                                "end": 171
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 172,
+                                "end": 175,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 172,
+                                    "end": 175
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/go_auto.swift.json
+++ b/tests/json-ast/x/swift/go_auto.swift.json
@@ -1,172 +1,482 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 290,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "struct_decl",
-      "name": {
-        "base_name": {
-          "name": "testpkg"
-        }
-      },
-      "range": {
-        "start": 90,
-        "end": 223
-      },
-      "interface_type": "$s4main7testpkgVmD",
-      "access": "internal",
-      "members": [
-        {
-          "_kind": "func_decl",
-          "name": {
-            "base_name": {
-              "name": "Add"
-            }
-          },
-          "params": {
-            "params": [
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
               {
-                "name": {
-                  "base_name": {
-                    "name": "a"
-                  }
-                },
-                "interface_type": "$sSiD"
-              },
-              {
-                "name": {
-                  "base_name": {
-                    "name": "b"
-                  }
-                },
-                "interface_type": "$sSiD"
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
               }
             ]
-          },
-          "body": {
-            "range": {
-              "start": 154,
-              "end": 169
-            }
-          },
-          "range": {
-            "start": 111,
-            "end": 169
-          },
-          "result": "$sSiD",
-          "interface_type": "$syS2i_Sitc4main7testpkgVmcD",
-          "access": "internal"
-        },
-        {
-          "_kind": "pattern_binding_decl",
-          "range": {
-            "start": 175,
-            "end": 191
           }
-        },
-        {
-          "_kind": "var_decl",
-          "name": {
-            "base_name": {
-              "name": "Pi"
-            }
-          },
-          "range": {
-            "start": 186,
-            "end": 186
-          },
-          "interface_type": "$sSdD",
-          "access": "internal"
-        },
-        {
-          "_kind": "pattern_binding_decl",
-          "range": {
-            "start": 200,
-            "end": 220
-          }
-        },
-        {
-          "_kind": "var_decl",
-          "name": {
-            "base_name": {
-              "name": "Answer"
-            }
-          },
-          "range": {
-            "start": 211,
-            "end": 211
-          },
-          "interface_type": "$sSiD",
-          "access": "internal"
-        },
-        {
-          "_kind": "constructor_decl",
-          "name": {
-            "base_name": {
-              "name": ""
-            }
-          },
-          "params": {
-            "params": null
-          },
-          "body": {
-            "range": {
-              "start": 97,
-              "end": 97
-            }
-          },
-          "range": {
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 90,
+        "end": 224,
+        "children": [
+          {
+            "kind": "type_identifier",
             "start": 97,
-            "end": 97
+            "end": 104
           },
-          "interface_type": "$sy4main7testpkgVycACmcD",
-          "access": "internal"
-        }
-      ]
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 225,
-          "end": 248
-        }
+          {
+            "kind": "class_body",
+            "start": 105,
+            "end": 224,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 111,
+                "end": 170,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 111,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 111,
+                        "end": 117
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 123,
+                    "end": 126
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 127,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 127,
+                        "end": 128
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 129,
+                        "end": 130
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 132,
+                        "end": 135,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 132,
+                            "end": 135
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 137,
+                    "end": 145,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 137,
+                        "end": 138
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 139,
+                        "end": 140
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 142,
+                        "end": 145,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 142,
+                            "end": 145
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 150,
+                    "end": 153,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 150,
+                        "end": 153
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 154,
+                    "end": 170,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 156,
+                        "end": 168,
+                        "children": [
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 156,
+                            "end": 168,
+                            "children": [
+                              {
+                                "kind": "additive_expression",
+                                "start": 163,
+                                "end": 168,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 163,
+                                    "end": 164
+                                  },
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 167,
+                                    "end": 168
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 175,
+                "end": 195,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 175,
+                    "end": 181,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 175,
+                        "end": 181
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 182,
+                    "end": 185
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 186,
+                    "end": 188,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 186,
+                        "end": 188
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "real_literal",
+                    "start": 191,
+                    "end": 195
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 200,
+                "end": 222,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 200,
+                    "end": 206,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 200,
+                        "end": 206
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 207,
+                    "end": 210
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 211,
+                    "end": 217,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 211,
+                        "end": 217
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 220,
+                    "end": 222
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 225,
-        "end": 248
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 250,
-          "end": 266
-        }
+        "end": 249,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 225,
+            "end": 230
+          },
+          {
+            "kind": "call_suffix",
+            "start": 230,
+            "end": 249,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 230,
+                "end": 249,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 231,
+                    "end": 248,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 231,
+                        "end": 248,
+                        "children": [
+                          {
+                            "kind": "navigation_expression",
+                            "start": 231,
+                            "end": 242,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 231,
+                                "end": 238
+                              },
+                              {
+                                "kind": "navigation_suffix",
+                                "start": 238,
+                                "end": 242,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 239,
+                                    "end": 242
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 242,
+                            "end": 248,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 242,
+                                "end": 248,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 243,
+                                    "end": 244,
+                                    "children": [
+                                      {
+                                        "kind": "integer_literal",
+                                        "start": 243,
+                                        "end": 244
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 246,
+                                    "end": 247,
+                                    "children": [
+                                      {
+                                        "kind": "integer_literal",
+                                        "start": 246,
+                                        "end": 247
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 250,
-        "end": 266
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 268,
-          "end": 288
-        }
+        "end": 267,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 250,
+            "end": 255
+          },
+          {
+            "kind": "call_suffix",
+            "start": 255,
+            "end": 267,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 255,
+                "end": 267,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 256,
+                    "end": 266,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 256,
+                        "end": 266,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 256,
+                            "end": 263
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 263,
+                            "end": 266,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 264,
+                                "end": 266
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 268,
-        "end": 288
+        "end": 289,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 268,
+            "end": 273
+          },
+          {
+            "kind": "call_suffix",
+            "start": 273,
+            "end": 289,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 273,
+                "end": 289,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 274,
+                    "end": 288,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 274,
+                        "end": 288,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 274,
+                            "end": 281
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 281,
+                            "end": 288,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 282,
+                                "end": 288
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/group_by_join.swift.json
+++ b/tests/json-ast/x/swift/group_by_join.swift.json
@@ -1,111 +1,2431 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 140
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 1160,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 140
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
+        "end": 141,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 141,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 142,
-          "end": 244
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 142,
-        "end": 244
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
+        "end": 245,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 142,
+            "end": 145
+          },
+          {
+            "kind": "pattern",
+            "start": 146,
+            "end": 152,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 146,
+                "end": 152
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 155,
+            "end": 245,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 156,
+                "end": 184,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 157,
+                    "end": 161,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 158,
+                        "end": 160
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 163,
+                    "end": 166
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 168,
+                    "end": 180,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 169,
+                        "end": 179
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 182,
+                    "end": 183
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 186,
+                "end": 214,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 187,
+                    "end": 191,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 188,
+                        "end": 190
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 193,
+                    "end": 196
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 209
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 212,
+                    "end": 213
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 216,
+                "end": 244,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 217,
+                    "end": 221,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 218,
+                        "end": 220
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 223,
+                    "end": 226
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 228,
+                    "end": 240,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 229,
+                        "end": 239
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 242,
+                    "end": 243
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 146,
-        "end": 146
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 246,
-          "end": 1056
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 246,
-        "end": 1056
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "stats"
-        }
+        "end": 1057,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 246,
+            "end": 249
+          },
+          {
+            "kind": "pattern",
+            "start": 250,
+            "end": 255,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 250,
+                "end": 255
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 258,
+            "end": 1057,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 258,
+                "end": 1055,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 259,
+                    "end": 1054,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 261,
+                        "end": 1052,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 261,
+                            "end": 303,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 261,
+                                "end": 264
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 265,
+                                "end": 272,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 265,
+                                    "end": 272
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 272,
+                                "end": 297,
+                                "children": [
+                                  {
+                                    "kind": "dictionary_type",
+                                    "start": 274,
+                                    "end": 297,
+                                    "children": [
+                                      {
+                                        "kind": "user_type",
+                                        "start": 275,
+                                        "end": 281,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 275,
+                                            "end": 281
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 283,
+                                        "end": 296,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 284,
+                                            "end": 290,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 284,
+                                                "end": 290
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 292,
+                                            "end": 295,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 292,
+                                                "end": 295
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "dictionary_literal",
+                                "start": 300,
+                                "end": 303
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "property_declaration",
+                            "start": 304,
+                            "end": 334,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 304,
+                                "end": 307
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 308,
+                                "end": 312,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 308,
+                                    "end": 312
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 312,
+                                "end": 329,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 314,
+                                    "end": 329,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 315,
+                                        "end": 328,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 316,
+                                            "end": 322,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 316,
+                                                "end": 322
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 324,
+                                            "end": 327,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 324,
+                                                "end": 327
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 332,
+                                "end": 334
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 335,
+                            "end": 806,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 339,
+                                "end": 340,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 339,
+                                    "end": 340
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 344,
+                                "end": 350
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 357,
+                                "end": 805,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 357,
+                                    "end": 804,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 361,
+                                        "end": 362,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 361,
+                                            "end": 362
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 366,
+                                        "end": 375
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 386,
+                                        "end": 803,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 386,
+                                            "end": 798,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 389,
+                                                "end": 439,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 390,
+                                                    "end": 438,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 390,
+                                                        "end": 416,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 391,
+                                                            "end": 415,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 391,
+                                                                "end": 407,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 391,
+                                                                    "end": 406,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 391,
+                                                                        "end": 392
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 392,
+                                                                        "end": 406,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 392,
+                                                                            "end": 406,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 393,
+                                                                                "end": 405,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 393,
+                                                                                    "end": 405,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 394,
+                                                                                        "end": 404
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 406,
+                                                                    "end": 407
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 408,
+                                                                "end": 411
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 412,
+                                                                "end": 415,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 412,
+                                                                    "end": 415
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 420,
+                                                        "end": 438,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 421,
+                                                            "end": 437,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 421,
+                                                                "end": 429,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 421,
+                                                                    "end": 428,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 421,
+                                                                        "end": 422
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 422,
+                                                                        "end": 428,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 422,
+                                                                            "end": 428,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 423,
+                                                                                "end": 427,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 423,
+                                                                                    "end": 427,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 424,
+                                                                                        "end": 426
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 428,
+                                                                    "end": 429
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 430,
+                                                                "end": 433
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 434,
+                                                                "end": 437,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 434,
+                                                                    "end": 437
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 454,
+                                                "end": 797,
+                                                "children": [
+                                                  {
+                                                    "kind": "property_declaration",
+                                                    "start": 454,
+                                                    "end": 475,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_binding_pattern",
+                                                        "start": 454,
+                                                        "end": 457
+                                                      },
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 458,
+                                                        "end": 462,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 458,
+                                                            "end": 462
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "postfix_expression",
+                                                        "start": 465,
+                                                        "end": 475,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 465,
+                                                            "end": 474,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 465,
+                                                                "end": 466
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 466,
+                                                                "end": 474,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 466,
+                                                                    "end": 474,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 467,
+                                                                        "end": 473,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 467,
+                                                                            "end": 473,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 468,
+                                                                                "end": 472
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "bang",
+                                                            "start": 474,
+                                                            "end": 475
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "property_declaration",
+                                                    "start": 488,
+                                                    "end": 522,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_binding_pattern",
+                                                        "start": 488,
+                                                        "end": 491
+                                                      },
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 492,
+                                                        "end": 495,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 492,
+                                                            "end": 495
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_expression",
+                                                        "start": 498,
+                                                        "end": 522,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 498,
+                                                            "end": 504
+                                                          },
+                                                          {
+                                                            "kind": "call_suffix",
+                                                            "start": 504,
+                                                            "end": 522,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_arguments",
+                                                                "start": 504,
+                                                                "end": 522,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument",
+                                                                    "start": 505,
+                                                                    "end": 521,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument_label",
+                                                                        "start": 505,
+                                                                        "end": 515,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 505,
+                                                                            "end": 515
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 517,
+                                                                        "end": 521
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "property_declaration",
+                                                    "start": 535,
+                                                    "end": 586,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_binding_pattern",
+                                                        "start": 535,
+                                                        "end": 538
+                                                      },
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 539,
+                                                        "end": 541,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 539,
+                                                            "end": 541
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "nil_coalescing_expression",
+                                                        "start": 544,
+                                                        "end": 586,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 544,
+                                                            "end": 556,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 544,
+                                                                "end": 551
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 551,
+                                                                "end": 556,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 551,
+                                                                    "end": 556,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 552,
+                                                                        "end": 555,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 552,
+                                                                            "end": 555
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "dictionary_literal",
+                                                            "start": 560,
+                                                            "end": 586,
+                                                            "children": [
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 561,
+                                                                "end": 566,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 562,
+                                                                    "end": 565
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 568,
+                                                                "end": 572
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 574,
+                                                                "end": 581,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 575,
+                                                                    "end": 580
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "array_literal",
+                                                                "start": 583,
+                                                                "end": 585
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "property_declaration",
+                                                    "start": 599,
+                                                    "end": 644,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_binding_pattern",
+                                                        "start": 599,
+                                                        "end": 602
+                                                      },
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 603,
+                                                        "end": 608,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 603,
+                                                            "end": 608
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "type_annotation",
+                                                        "start": 608,
+                                                        "end": 623,
+                                                        "children": [
+                                                          {
+                                                            "kind": "dictionary_type",
+                                                            "start": 610,
+                                                            "end": 623,
+                                                            "children": [
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 611,
+                                                                "end": 617,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 611,
+                                                                    "end": 617
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 619,
+                                                                "end": 622,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 619,
+                                                                    "end": 622
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "dictionary_literal",
+                                                        "start": 626,
+                                                        "end": 644,
+                                                        "children": [
+                                                          {
+                                                            "kind": "line_string_literal",
+                                                            "start": 627,
+                                                            "end": 637,
+                                                            "children": [
+                                                              {
+                                                                "kind": "line_str_text",
+                                                                "start": 628,
+                                                                "end": 636
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "boolean_literal",
+                                                            "start": 639,
+                                                            "end": 643
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 657,
+                                                    "end": 671,
+                                                    "children": [
+                                                      {
+                                                        "kind": "directly_assignable_expression",
+                                                        "start": 657,
+                                                        "end": 667,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 657,
+                                                            "end": 667,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 657,
+                                                                "end": 662
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 662,
+                                                                "end": 667,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 662,
+                                                                    "end": 667,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 663,
+                                                                        "end": 666,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 663,
+                                                                            "end": 666,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 664,
+                                                                                "end": 665
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 670,
+                                                        "end": 671
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 684,
+                                                    "end": 698,
+                                                    "children": [
+                                                      {
+                                                        "kind": "directly_assignable_expression",
+                                                        "start": 684,
+                                                        "end": 694,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 684,
+                                                            "end": 694,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 684,
+                                                                "end": 689
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 689,
+                                                                "end": 694,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 689,
+                                                                    "end": 694,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 690,
+                                                                        "end": 693,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 690,
+                                                                            "end": 693,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 691,
+                                                                                "end": 692
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 697,
+                                                        "end": 698
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 711,
+                                                    "end": 758,
+                                                    "children": [
+                                                      {
+                                                        "kind": "directly_assignable_expression",
+                                                        "start": 711,
+                                                        "end": 722,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 711,
+                                                            "end": 722,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 711,
+                                                                "end": 713
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 713,
+                                                                "end": 722,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 713,
+                                                                    "end": 722,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 714,
+                                                                        "end": 721,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 714,
+                                                                            "end": 721,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 715,
+                                                                                "end": 720
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "additive_expression",
+                                                        "start": 725,
+                                                        "end": 758,
+                                                        "children": [
+                                                          {
+                                                            "kind": "tuple_expression",
+                                                            "start": 725,
+                                                            "end": 748,
+                                                            "children": [
+                                                              {
+                                                                "kind": "as_expression",
+                                                                "start": 726,
+                                                                "end": 747,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 726,
+                                                                    "end": 737,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 726,
+                                                                        "end": 728
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 728,
+                                                                        "end": 737,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 728,
+                                                                            "end": 737,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 729,
+                                                                                "end": 736,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 729,
+                                                                                    "end": 736,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 730,
+                                                                                        "end": 735
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "as_operator",
+                                                                    "start": 738,
+                                                                    "end": 741
+                                                                  },
+                                                                  {
+                                                                    "kind": "array_type",
+                                                                    "start": 742,
+                                                                    "end": 747,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 743,
+                                                                        "end": 746,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 743,
+                                                                            "end": 746
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "array_literal",
+                                                            "start": 751,
+                                                            "end": 758,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 752,
+                                                                "end": 757
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 771,
+                                                    "end": 788,
+                                                    "children": [
+                                                      {
+                                                        "kind": "directly_assignable_expression",
+                                                        "start": 771,
+                                                        "end": 783,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 771,
+                                                            "end": 783,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 771,
+                                                                "end": 778
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 778,
+                                                                "end": 783,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 778,
+                                                                    "end": 783,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 779,
+                                                                        "end": 782,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 779,
+                                                                            "end": 782
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 786,
+                                                        "end": 788
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "property_declaration",
+                            "start": 807,
+                            "end": 840,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 807,
+                                "end": 810
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 811,
+                                "end": 816,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 811,
+                                    "end": 816
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_expression",
+                                "start": 819,
+                                "end": 840,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 819,
+                                    "end": 824
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 824,
+                                    "end": 840,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 824,
+                                        "end": 840,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 825,
+                                            "end": 839,
+                                            "children": [
+                                              {
+                                                "kind": "navigation_expression",
+                                                "start": 825,
+                                                "end": 839,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 825,
+                                                    "end": 832
+                                                  },
+                                                  {
+                                                    "kind": "navigation_suffix",
+                                                    "start": 832,
+                                                    "end": 839,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 833,
+                                                        "end": 839
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_expression",
+                            "start": 841,
+                            "end": 923,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 841,
+                                "end": 851,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 841,
+                                    "end": 846
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 846,
+                                    "end": 851,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 847,
+                                        "end": 851
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 852,
+                                "end": 923,
+                                "children": [
+                                  {
+                                    "kind": "lambda_literal",
+                                    "start": 852,
+                                    "end": 923,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_function_type",
+                                        "start": 854,
+                                        "end": 858,
+                                        "children": [
+                                          {
+                                            "kind": "lambda_function_type_parameters",
+                                            "start": 854,
+                                            "end": 858,
+                                            "children": [
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 854,
+                                                "end": 855,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 854,
+                                                    "end": 855
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 857,
+                                                "end": 858,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 857,
+                                                    "end": 858
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 862,
+                                        "end": 921,
+                                        "children": [
+                                          {
+                                            "kind": "comparison_expression",
+                                            "start": 862,
+                                            "end": 921,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 862,
+                                                "end": 890,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 862,
+                                                    "end": 868
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 868,
+                                                    "end": 890,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 868,
+                                                        "end": 890,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 869,
+                                                            "end": 889,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument_label",
+                                                                "start": 869,
+                                                                "end": 879,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 869,
+                                                                    "end": 879
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 881,
+                                                                "end": 889,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 881,
+                                                                    "end": 882
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 882,
+                                                                    "end": 889,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 882,
+                                                                        "end": 889,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 883,
+                                                                            "end": 888,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 883,
+                                                                                "end": 888,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 884,
+                                                                                    "end": 887
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 893,
+                                                "end": 921,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 893,
+                                                    "end": 899
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 899,
+                                                    "end": 921,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 899,
+                                                        "end": 921,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 900,
+                                                            "end": 920,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument_label",
+                                                                "start": 900,
+                                                                "end": 910,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 900,
+                                                                    "end": 910
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 912,
+                                                                "end": 920,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 912,
+                                                                    "end": 913
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 913,
+                                                                    "end": 920,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 913,
+                                                                        "end": 920,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 914,
+                                                                            "end": 919,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 914,
+                                                                                "end": 919,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 915,
+                                                                                    "end": 918
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 924,
+                            "end": 1040,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 928,
+                                "end": 929,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 928,
+                                    "end": 929
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 933,
+                                "end": 938
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 945,
+                                "end": 1039,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 945,
+                                    "end": 1038,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 945,
+                                        "end": 956,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 945,
+                                            "end": 949
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 949,
+                                            "end": 956,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 950,
+                                                "end": 956
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 956,
+                                        "end": 1038,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 956,
+                                            "end": 1038,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 957,
+                                                "end": 1037,
+                                                "children": [
+                                                  {
+                                                    "kind": "dictionary_literal",
+                                                    "start": 957,
+                                                    "end": 1037,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_string_literal",
+                                                        "start": 958,
+                                                        "end": 964,
+                                                        "children": [
+                                                          {
+                                                            "kind": "line_str_text",
+                                                            "start": 959,
+                                                            "end": 963
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "postfix_expression",
+                                                        "start": 966,
+                                                        "end": 975,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 966,
+                                                            "end": 974,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 966,
+                                                                "end": 967
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 967,
+                                                                "end": 974,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 967,
+                                                                    "end": 974,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 968,
+                                                                        "end": 973,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 968,
+                                                                            "end": 973,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 969,
+                                                                                "end": 972
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "bang",
+                                                            "start": 974,
+                                                            "end": 975
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "line_string_literal",
+                                                        "start": 977,
+                                                        "end": 984,
+                                                        "children": [
+                                                          {
+                                                            "kind": "line_str_text",
+                                                            "start": 978,
+                                                            "end": 983
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 986,
+                                                        "end": 1036,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 987,
+                                                            "end": 1035,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 987,
+                                                                "end": 1027,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "navigation_expression",
+                                                                    "start": 988,
+                                                                    "end": 1026,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 988,
+                                                                        "end": 1020,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 989,
+                                                                            "end": 1019,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "call_expression",
+                                                                                "start": 989,
+                                                                                "end": 999,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "simple_identifier",
+                                                                                    "start": 989,
+                                                                                    "end": 990
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "call_suffix",
+                                                                                    "start": 990,
+                                                                                    "end": 999,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_arguments",
+                                                                                        "start": 990,
+                                                                                        "end": 999,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_argument",
+                                                                                            "start": 991,
+                                                                                            "end": 998,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_string_literal",
+                                                                                                "start": 991,
+                                                                                                "end": 998,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_str_text",
+                                                                                                    "start": 992,
+                                                                                                    "end": 997
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 1000,
+                                                                                "end": 1003
+                                                                              },
+                                                                              {
+                                                                                "kind": "array_type",
+                                                                                "start": 1004,
+                                                                                "end": 1019,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "dictionary_type",
+                                                                                    "start": 1005,
+                                                                                    "end": 1018,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "user_type",
+                                                                                        "start": 1006,
+                                                                                        "end": 1012,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "type_identifier",
+                                                                                            "start": 1006,
+                                                                                            "end": 1012
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "user_type",
+                                                                                        "start": 1014,
+                                                                                        "end": 1017,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "type_identifier",
+                                                                                            "start": 1014,
+                                                                                            "end": 1017
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "navigation_suffix",
+                                                                        "start": 1020,
+                                                                        "end": 1026,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 1021,
+                                                                            "end": 1026
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 1028,
+                                                                "end": 1031
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 1032,
+                                                                "end": 1035,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 1032,
+                                                                    "end": 1035
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 1041,
+                            "end": 1052,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 1048,
+                                "end": 1052
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 1055,
+                "end": 1057,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 1055,
+                    "end": 1057
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 250,
-        "end": 250
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 1058,
-          "end": 1093
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 1058,
-        "end": 1093
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 1095,
-          "end": 1158
-        }
+        "end": 1094,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 1058,
+            "end": 1063
+          },
+          {
+            "kind": "call_suffix",
+            "start": 1063,
+            "end": 1094,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 1063,
+                "end": 1094,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 1064,
+                    "end": 1093,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 1064,
+                        "end": 1093,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 1065,
+                            "end": 1092
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 1095,
-        "end": 1158
+        "end": 1159,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 1099,
+            "end": 1100,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 1099,
+                "end": 1100
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 1104,
+            "end": 1109
+          },
+          {
+            "kind": "statements",
+            "start": 1116,
+            "end": 1158,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 1116,
+                "end": 1157,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 1116,
+                    "end": 1121
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 1121,
+                    "end": 1157,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 1121,
+                        "end": 1157,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 1122,
+                            "end": 1132,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 1122,
+                                "end": 1132,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 1122,
+                                    "end": 1131,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 1122,
+                                        "end": 1123
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 1123,
+                                        "end": 1131,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 1123,
+                                            "end": 1131,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 1124,
+                                                "end": 1130,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 1124,
+                                                    "end": 1130,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 1125,
+                                                        "end": 1129
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 1131,
+                                    "end": 1132
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 1134,
+                            "end": 1143,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 1134,
+                                "end": 1143,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 1135,
+                                    "end": 1142
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 1145,
+                            "end": 1156,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 1145,
+                                "end": 1156,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 1145,
+                                    "end": 1155,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 1145,
+                                        "end": 1146
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 1146,
+                                        "end": 1155,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 1146,
+                                            "end": 1155,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 1147,
+                                                "end": 1154,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 1147,
+                                                    "end": 1154,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 1148,
+                                                        "end": 1153
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 1155,
+                                    "end": 1156
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/if_else.swift.json
+++ b/tests/json-ast/x/swift/if_else.swift.json
@@ -1,44 +1,214 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 151,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 149
-        }
-      },
-      "range": {
+      {
+        "kind": "if_statement",
         "start": 81,
-        "end": 149
+        "end": 150,
+        "children": [
+          {
+            "kind": "tuple_expression",
+            "start": 84,
+            "end": 101,
+            "children": [
+              {
+                "kind": "comparison_expression",
+                "start": 85,
+                "end": 100,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 85,
+                    "end": 96,
+                    "children": [
+                      {
+                        "kind": "as_expression",
+                        "start": 86,
+                        "end": 95,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 86,
+                            "end": 87
+                          },
+                          {
+                            "kind": "as_operator",
+                            "start": 88,
+                            "end": 91
+                          },
+                          {
+                            "kind": "user_type",
+                            "start": 92,
+                            "end": 95,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 92,
+                                "end": 95
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 99,
+                    "end": 100
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "statements",
+            "start": 108,
+            "end": 121,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 108,
+                "end": 120,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 108,
+                    "end": 113
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 113,
+                    "end": 120,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 113,
+                        "end": 120,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 114,
+                            "end": 119,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 114,
+                                "end": 119,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 115,
+                                    "end": 118
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "else",
+            "start": 123,
+            "end": 127
+          },
+          {
+            "kind": "statements",
+            "start": 134,
+            "end": 149,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 134,
+                "end": 148,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 134,
+                    "end": 139
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 139,
+                    "end": 148,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 139,
+                        "end": 148,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 140,
+                            "end": 147,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 140,
+                                "end": 147,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 141,
+                                    "end": 146
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/if_then_else.swift.json
+++ b/tests/json-ast/x/swift/if_then_else.swift.json
@@ -1,71 +1,260 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 165,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 81,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 81
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 82,
-          "end": 139
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 82,
-        "end": 139
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "msg"
-        }
+        "end": 140,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 82,
+            "end": 85
+          },
+          {
+            "kind": "pattern",
+            "start": 86,
+            "end": 89,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 86,
+                "end": 89
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 92,
+            "end": 140,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 93,
+                "end": 139,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 93,
+                    "end": 128,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 94,
+                        "end": 127,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 94,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "comparison_expression",
+                                "start": 95,
+                                "end": 111,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 95,
+                                    "end": 106,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 96,
+                                        "end": 105,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 96,
+                                            "end": 97
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 98,
+                                            "end": 101
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 102,
+                                            "end": 105,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 102,
+                                                "end": 105
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 109,
+                                    "end": 111
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 115,
+                            "end": 120,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 116,
+                                "end": 119
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 123,
+                            "end": 127,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 124,
+                                "end": 126
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 129,
+                    "end": 132
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 133,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 133,
+                        "end": 139
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 86,
-        "end": 86
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 141,
-          "end": 163
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 141,
-        "end": 163
+        "end": 164,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 141,
+            "end": 146
+          },
+          {
+            "kind": "call_suffix",
+            "start": 146,
+            "end": 164,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 146,
+                "end": 164,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 147,
+                    "end": 163,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 147,
+                        "end": 163,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 148,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 148,
+                                "end": 151
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 152,
+                                "end": 155
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 156,
+                                "end": 162,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 156,
+                                    "end": 162
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/if_then_else_nested.swift.json
+++ b/tests/json-ast/x/swift/if_then_else_nested.swift.json
@@ -1,71 +1,341 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 200,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 174
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 81,
-        "end": 174
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "msg"
-        }
+        "end": 175,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 81,
+            "end": 84
+          },
+          {
+            "kind": "pattern",
+            "start": 85,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 88
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 91,
+            "end": 175,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 92,
+                "end": 174,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 92,
+                    "end": 163,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 93,
+                        "end": 162,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 93,
+                            "end": 111,
+                            "children": [
+                              {
+                                "kind": "comparison_expression",
+                                "start": 94,
+                                "end": 110,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 94,
+                                    "end": 105,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 95,
+                                        "end": 104,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 95,
+                                            "end": 96
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 97,
+                                            "end": 100
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 101,
+                                            "end": 104,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 101,
+                                                "end": 104
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 108,
+                                    "end": 110
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 114,
+                            "end": 119,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 115,
+                                "end": 118
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 122,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "ternary_expression",
+                                "start": 123,
+                                "end": 161,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 123,
+                                    "end": 140,
+                                    "children": [
+                                      {
+                                        "kind": "comparison_expression",
+                                        "start": 124,
+                                        "end": 139,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 124,
+                                            "end": 135,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 125,
+                                                "end": 134,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 125,
+                                                    "end": 126
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 127,
+                                                    "end": 130
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 131,
+                                                    "end": 134,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 131,
+                                                        "end": 134
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 138,
+                                            "end": 139
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 143,
+                                    "end": 151,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 144,
+                                        "end": 150
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 154,
+                                    "end": 161,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 155,
+                                        "end": 160
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 164,
+                    "end": 167
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 168,
+                    "end": 174,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 168,
+                        "end": 174
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 85,
-        "end": 85
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 176,
-          "end": 198
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 176,
-        "end": 198
+        "end": 199,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 176,
+            "end": 181
+          },
+          {
+            "kind": "call_suffix",
+            "start": 181,
+            "end": 199,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 181,
+                "end": 199,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 182,
+                    "end": 198,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 182,
+                        "end": 198,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 183,
+                            "end": 197,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 183,
+                                "end": 186
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 187,
+                                "end": 190
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 191,
+                                "end": 197,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 191,
+                                    "end": 197
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/in_operator.swift.json
+++ b/tests/json-ast/x/swift/in_operator.swift.json
@@ -1,57 +1,318 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 88
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 152,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 88
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "xs"
-        }
+        "end": 89,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 80,
+            "end": 89,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 81,
+                "end": 82
+              },
+              {
+                "kind": "integer_literal",
+                "start": 84,
+                "end": 85
+              },
+              {
+                "kind": "integer_literal",
+                "start": 87,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 112
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 90,
-        "end": 112
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 114,
-          "end": 150
-        }
+        "end": 113,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 90,
+            "end": 95
+          },
+          {
+            "kind": "call_suffix",
+            "start": 95,
+            "end": 113,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 95,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 96,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 96,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 97,
+                            "end": 111,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 97,
+                                "end": 108,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 97,
+                                    "end": 99
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 99,
+                                    "end": 108,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 100,
+                                        "end": 108
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 108,
+                                "end": 111,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 108,
+                                    "end": 111,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 109,
+                                        "end": 110,
+                                        "children": [
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 109,
+                                            "end": 110
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 114,
-        "end": 150
+        "end": 151,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 114,
+            "end": 119
+          },
+          {
+            "kind": "call_suffix",
+            "start": 119,
+            "end": 151,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 119,
+                "end": 151,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 120,
+                    "end": 150,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 120,
+                        "end": 150,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 121,
+                            "end": 149,
+                            "children": [
+                              {
+                                "kind": "bang",
+                                "start": 121,
+                                "end": 122
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 122,
+                                "end": 149,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 122,
+                                    "end": 149,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 123,
+                                        "end": 148,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 123,
+                                            "end": 148,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 123,
+                                                "end": 139,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 124,
+                                                    "end": 138,
+                                                    "children": [
+                                                      {
+                                                        "kind": "navigation_expression",
+                                                        "start": 124,
+                                                        "end": 135,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 124,
+                                                            "end": 126
+                                                          },
+                                                          {
+                                                            "kind": "navigation_suffix",
+                                                            "start": 126,
+                                                            "end": 135,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 127,
+                                                                "end": 135
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 135,
+                                                        "end": 138,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 135,
+                                                            "end": 138,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 136,
+                                                                "end": 137,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "integer_literal",
+                                                                    "start": 136,
+                                                                    "end": 137
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 140,
+                                                "end": 143
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 144,
+                                                "end": 148,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 144,
+                                                    "end": 148
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/in_operator_extended.swift.json
+++ b/tests/json-ast/x/swift/in_operator_extended.swift.json
@@ -1,190 +1,1140 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 88
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 436,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 88
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "xs"
-        }
+        "end": 89,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 80,
+            "end": 89,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 81,
+                "end": 82
+              },
+              {
+                "kind": "integer_literal",
+                "start": 84,
+                "end": 85
+              },
+              {
+                "kind": "integer_literal",
+                "start": 87,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 227
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 227
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "ys"
-        }
+        "end": 228,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 96,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 96
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 99,
+            "end": 228,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 99,
+                "end": 226,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 100,
+                    "end": 225,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 102,
+                        "end": 223,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 102,
+                            "end": 122,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 102,
+                                "end": 105
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 106,
+                                "end": 110,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 106,
+                                    "end": 110
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 110,
+                                "end": 117,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 112,
+                                    "end": 117,
+                                    "children": [
+                                      {
+                                        "kind": "user_type",
+                                        "start": 113,
+                                        "end": 116,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 113,
+                                            "end": 116
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 120,
+                                "end": 122
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 123,
+                            "end": 211,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 127,
+                                "end": 128,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 127,
+                                    "end": 128
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 132,
+                                "end": 134
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 141,
+                                "end": 210,
+                                "children": [
+                                  {
+                                    "kind": "if_statement",
+                                    "start": 141,
+                                    "end": 209,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 144,
+                                        "end": 168,
+                                        "children": [
+                                          {
+                                            "kind": "equality_expression",
+                                            "start": 145,
+                                            "end": 167,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 145,
+                                                "end": 162,
+                                                "children": [
+                                                  {
+                                                    "kind": "multiplicative_expression",
+                                                    "start": 146,
+                                                    "end": 161,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 146,
+                                                        "end": 157,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 147,
+                                                            "end": 156,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 147,
+                                                                "end": 148
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 149,
+                                                                "end": 152
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 153,
+                                                                "end": 156,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 153,
+                                                                    "end": 156
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 160,
+                                                        "end": 161
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 166,
+                                                "end": 167
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 179,
+                                        "end": 208,
+                                        "children": [
+                                          {
+                                            "kind": "call_expression",
+                                            "start": 179,
+                                            "end": 203,
+                                            "children": [
+                                              {
+                                                "kind": "navigation_expression",
+                                                "start": 179,
+                                                "end": 190,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 179,
+                                                    "end": 183
+                                                  },
+                                                  {
+                                                    "kind": "navigation_suffix",
+                                                    "start": 183,
+                                                    "end": 190,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 184,
+                                                        "end": 190
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_suffix",
+                                                "start": 190,
+                                                "end": 203,
+                                                "children": [
+                                                  {
+                                                    "kind": "value_arguments",
+                                                    "start": 190,
+                                                    "end": 203,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_argument",
+                                                        "start": 191,
+                                                        "end": 202,
+                                                        "children": [
+                                                          {
+                                                            "kind": "tuple_expression",
+                                                            "start": 191,
+                                                            "end": 202,
+                                                            "children": [
+                                                              {
+                                                                "kind": "as_expression",
+                                                                "start": 192,
+                                                                "end": 201,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 192,
+                                                                    "end": 193
+                                                                  },
+                                                                  {
+                                                                    "kind": "as_operator",
+                                                                    "start": 194,
+                                                                    "end": 197
+                                                                  },
+                                                                  {
+                                                                    "kind": "user_type",
+                                                                    "start": 198,
+                                                                    "end": 201,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "type_identifier",
+                                                                        "start": 198,
+                                                                        "end": 201
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 212,
+                            "end": 223,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 219,
+                                "end": 223
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 226,
+                "end": 228,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 226,
+                    "end": 228
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 229,
-          "end": 251
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 229,
-        "end": 251
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 253,
-          "end": 275
-        }
+        "end": 252,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 229,
+            "end": 234
+          },
+          {
+            "kind": "call_suffix",
+            "start": 234,
+            "end": 252,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 234,
+                "end": 252,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 235,
+                    "end": 251,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 235,
+                        "end": 251,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 236,
+                            "end": 250,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 236,
+                                "end": 247,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 236,
+                                    "end": 238
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 238,
+                                    "end": 247,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 239,
+                                        "end": 247
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 247,
+                                "end": 250,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 247,
+                                    "end": 250,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 248,
+                                        "end": 249,
+                                        "children": [
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 248,
+                                            "end": 249
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 253,
-        "end": 275
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 277,
-          "end": 292
-        }
+        "end": 276,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 253,
+            "end": 258
+          },
+          {
+            "kind": "call_suffix",
+            "start": 258,
+            "end": 276,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 258,
+                "end": 276,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 259,
+                    "end": 275,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 259,
+                        "end": 275,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 260,
+                            "end": 274,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 260,
+                                "end": 271,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 260,
+                                    "end": 262
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 262,
+                                    "end": 271,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 263,
+                                        "end": 271
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 271,
+                                "end": 274,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 271,
+                                    "end": 274,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 272,
+                                        "end": 273,
+                                        "children": [
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 272,
+                                            "end": 273
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 277,
-        "end": 292
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 293,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 277,
+            "end": 280
+          },
+          {
+            "kind": "pattern",
+            "start": 281,
+            "end": 282,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 281,
+                "end": 282
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 285,
+            "end": 293,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 286,
+                "end": 289,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 287,
+                    "end": 288
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 291,
+                "end": 292
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 281,
-        "end": 281
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 294,
-          "end": 315
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 294,
-        "end": 315
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 317,
-          "end": 338
-        }
+        "end": 316,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 294,
+            "end": 299
+          },
+          {
+            "kind": "call_suffix",
+            "start": 299,
+            "end": 316,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 299,
+                "end": 316,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 300,
+                    "end": 315,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 300,
+                        "end": 315,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 301,
+                            "end": 314,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 301,
+                                "end": 307,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 301,
+                                    "end": 302
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 302,
+                                    "end": 307,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 302,
+                                        "end": 307,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 303,
+                                            "end": 306,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 303,
+                                                "end": 306,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 304,
+                                                    "end": 305
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 308,
+                                "end": 310
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 317,
-        "end": 338
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 340,
-          "end": 348
-        }
+        "end": 339,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 317,
+            "end": 322
+          },
+          {
+            "kind": "call_suffix",
+            "start": 322,
+            "end": 339,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 322,
+                "end": 339,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 323,
+                    "end": 338,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 323,
+                        "end": 338,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 324,
+                            "end": 337,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 324,
+                                "end": 330,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 324,
+                                    "end": 325
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 325,
+                                    "end": 330,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 325,
+                                        "end": 330,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 326,
+                                            "end": 329,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 326,
+                                                "end": 329,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 327,
+                                                    "end": 328
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 331,
+                                "end": 333
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 340,
-        "end": 348
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s"
-        }
+        "end": 355,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 340,
+            "end": 343
+          },
+          {
+            "kind": "pattern",
+            "start": 344,
+            "end": 345,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 344,
+                "end": 345
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 348,
+            "end": 355,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 349,
+                "end": 354
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 344,
-        "end": 344
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 356,
-          "end": 394
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 356,
-        "end": 394
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 396,
-          "end": 434
-        }
+        "end": 395,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 356,
+            "end": 361
+          },
+          {
+            "kind": "call_suffix",
+            "start": 361,
+            "end": 395,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 361,
+                "end": 395,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 362,
+                    "end": 394,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 362,
+                        "end": 394,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 363,
+                            "end": 393,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 363,
+                                "end": 386,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 363,
+                                    "end": 377,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 364,
+                                        "end": 376,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 364,
+                                            "end": 365
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 366,
+                                            "end": 369
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 370,
+                                            "end": 376,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 370,
+                                                "end": 376
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 377,
+                                    "end": 386,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 378,
+                                        "end": 386
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 386,
+                                "end": 393,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 386,
+                                    "end": 393,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 387,
+                                        "end": 392,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 387,
+                                            "end": 392,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 388,
+                                                "end": 391
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 396,
-        "end": 434
+        "end": 435,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 396,
+            "end": 401
+          },
+          {
+            "kind": "call_suffix",
+            "start": 401,
+            "end": 435,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 401,
+                "end": 435,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 402,
+                    "end": 434,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 402,
+                        "end": 434,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 403,
+                            "end": 433,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 403,
+                                "end": 426,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 403,
+                                    "end": 417,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 404,
+                                        "end": 416,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 404,
+                                            "end": 405
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 406,
+                                            "end": 409
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 410,
+                                            "end": 416,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 410,
+                                                "end": 416
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 417,
+                                    "end": 426,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 418,
+                                        "end": 426
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 426,
+                                "end": 433,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 426,
+                                    "end": 433,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 427,
+                                        "end": 432,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 427,
+                                            "end": 432,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 428,
+                                                "end": 431
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/inner_join.swift.json
+++ b/tests/json-ast/x/swift/inner_join.swift.json
@@ -1,111 +1,1547 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 170
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 826,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 170
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
+        "end": 171,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 171,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 142,
+                "end": 170,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 143,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 144,
+                        "end": 146
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 149,
+                    "end": 150
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 152,
+                    "end": 158,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 153,
+                        "end": 157
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 160,
+                    "end": 169,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 161,
+                        "end": 168
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 172,
-          "end": 359
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 172,
-        "end": 359
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
+        "end": 360,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 172,
+            "end": 175
+          },
+          {
+            "kind": "pattern",
+            "start": 176,
+            "end": 182,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 176,
+                "end": 182
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 185,
+            "end": 360,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 186,
+                "end": 228,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 187,
+                    "end": 191,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 188,
+                        "end": 190
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 193,
+                    "end": 196
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 209
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 212,
+                    "end": 213
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 215,
+                    "end": 222,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 216,
+                        "end": 221
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 224,
+                    "end": 227
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 230,
+                "end": 272,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 231,
+                    "end": 235,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 232,
+                        "end": 234
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 237,
+                    "end": 240
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 242,
+                    "end": 254,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 243,
+                        "end": 253
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 256,
+                    "end": 257
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 259,
+                    "end": 266,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 260,
+                        "end": 265
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 268,
+                    "end": 271
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 274,
+                "end": 316,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 275,
+                    "end": 279,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 276,
+                        "end": 278
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 281,
+                    "end": 284
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 286,
+                    "end": 298,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 287,
+                        "end": 297
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 300,
+                    "end": 301
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 303,
+                    "end": 310,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 304,
+                        "end": 309
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 312,
+                    "end": 315
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 318,
+                "end": 359,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 319,
+                    "end": 323,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 320,
+                        "end": 322
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 325,
+                    "end": 328
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 330,
+                    "end": 342,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 331,
+                        "end": 341
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 344,
+                    "end": 345
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 347,
+                    "end": 354,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 348,
+                        "end": 353
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 356,
+                    "end": 358
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 176,
-        "end": 176
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 361,
-          "end": 665
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 361,
-        "end": 665
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
+        "end": 666,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 361,
+            "end": 364
+          },
+          {
+            "kind": "pattern",
+            "start": 365,
+            "end": 371,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 365,
+                "end": 371
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 374,
+            "end": 666,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 374,
+                "end": 664,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 375,
+                    "end": 663,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 377,
+                        "end": 661,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 377,
+                            "end": 407,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 377,
+                                "end": 380
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 381,
+                                "end": 385,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 381,
+                                    "end": 385
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 385,
+                                "end": 402,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 387,
+                                    "end": 402,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 388,
+                                        "end": 401,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 389,
+                                            "end": 395,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 389,
+                                                "end": 395
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 397,
+                                            "end": 400,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 397,
+                                                "end": 400
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 405,
+                                "end": 407
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 408,
+                            "end": 649,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 412,
+                                "end": 413,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 412,
+                                    "end": 413
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 417,
+                                "end": 423
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 430,
+                                "end": 648,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 430,
+                                    "end": 647,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 434,
+                                        "end": 435,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 434,
+                                            "end": 435
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 439,
+                                        "end": 448
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 459,
+                                        "end": 646,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 459,
+                                            "end": 641,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 462,
+                                                "end": 512,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 463,
+                                                    "end": 511,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 463,
+                                                        "end": 489,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 464,
+                                                            "end": 488,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 464,
+                                                                "end": 480,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 464,
+                                                                    "end": 479,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 464,
+                                                                        "end": 465
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 465,
+                                                                        "end": 479,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 465,
+                                                                            "end": 479,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 466,
+                                                                                "end": 478,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 466,
+                                                                                    "end": 478,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 467,
+                                                                                        "end": 477
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 479,
+                                                                    "end": 480
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 481,
+                                                                "end": 484
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 485,
+                                                                "end": 488,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 485,
+                                                                    "end": 488
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 493,
+                                                        "end": 511,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 494,
+                                                            "end": 510,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 494,
+                                                                "end": 502,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 494,
+                                                                    "end": 501,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 494,
+                                                                        "end": 495
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 495,
+                                                                        "end": 501,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 495,
+                                                                            "end": 501,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 496,
+                                                                                "end": 500,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 496,
+                                                                                    "end": 500,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 497,
+                                                                                        "end": 499
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 501,
+                                                                    "end": 502
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 503,
+                                                                "end": 506
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 507,
+                                                                "end": 510,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 507,
+                                                                    "end": 510
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 527,
+                                                "end": 640,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 527,
+                                                    "end": 631,
+                                                    "children": [
+                                                      {
+                                                        "kind": "navigation_expression",
+                                                        "start": 527,
+                                                        "end": 538,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 527,
+                                                            "end": 531
+                                                          },
+                                                          {
+                                                            "kind": "navigation_suffix",
+                                                            "start": 531,
+                                                            "end": 538,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 532,
+                                                                "end": 538
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 538,
+                                                        "end": 631,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 538,
+                                                            "end": 631,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 539,
+                                                                "end": 630,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_literal",
+                                                                    "start": 539,
+                                                                    "end": 630,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 540,
+                                                                        "end": 549,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 541,
+                                                                            "end": 548
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 551,
+                                                                        "end": 569,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 552,
+                                                                            "end": 568,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 552,
+                                                                                "end": 560,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 552,
+                                                                                    "end": 559,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 552,
+                                                                                        "end": 553
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 553,
+                                                                                        "end": 559,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 553,
+                                                                                            "end": 559,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 554,
+                                                                                                "end": 558,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 554,
+                                                                                                    "end": 558,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 555,
+                                                                                                        "end": 557
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 559,
+                                                                                    "end": 560
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 561,
+                                                                                "end": 564
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 565,
+                                                                                "end": 568,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 565,
+                                                                                    "end": 568
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 571,
+                                                                        "end": 585,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 572,
+                                                                            "end": 584
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 587,
+                                                                        "end": 597,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 587,
+                                                                            "end": 596,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 587,
+                                                                                "end": 588
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 588,
+                                                                                "end": 596,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 588,
+                                                                                    "end": 596,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 589,
+                                                                                        "end": 595,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 589,
+                                                                                            "end": 595,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 590,
+                                                                                                "end": 594
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 596,
+                                                                            "end": 597
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 599,
+                                                                        "end": 606,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 600,
+                                                                            "end": 605
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 608,
+                                                                        "end": 629,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 609,
+                                                                            "end": 628,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 609,
+                                                                                "end": 620,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 609,
+                                                                                    "end": 619,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 609,
+                                                                                        "end": 610
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 610,
+                                                                                        "end": 619,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 610,
+                                                                                            "end": 619,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 611,
+                                                                                                "end": 618,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 611,
+                                                                                                    "end": 618,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 612,
+                                                                                                        "end": 617
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 619,
+                                                                                    "end": 620
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 621,
+                                                                                "end": 624
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 625,
+                                                                                "end": 628,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 625,
+                                                                                    "end": 628
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 650,
+                            "end": 661,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 657,
+                                "end": 661
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 664,
+                "end": 666,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 664,
+                    "end": 666
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 365,
-        "end": 365
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 667,
-          "end": 708
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 667,
-        "end": 708
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 710,
-          "end": 824
-        }
+        "end": 709,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 667,
+            "end": 672
+          },
+          {
+            "kind": "call_suffix",
+            "start": 672,
+            "end": 709,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 672,
+                "end": 709,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 673,
+                    "end": 708,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 673,
+                        "end": 708,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 674,
+                            "end": 707
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 710,
-        "end": 824
+        "end": 825,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 714,
+            "end": 719,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 714,
+                "end": 719
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 723,
+            "end": 729
+          },
+          {
+            "kind": "statements",
+            "start": 736,
+            "end": 824,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 736,
+                "end": 823,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 736,
+                    "end": 741
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 741,
+                    "end": 823,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 741,
+                        "end": 823,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 742,
+                            "end": 749,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 742,
+                                "end": 749,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 743,
+                                    "end": 748
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 751,
+                            "end": 768,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 751,
+                                "end": 768,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 751,
+                                    "end": 767,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 751,
+                                        "end": 756
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 756,
+                                        "end": 767,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 756,
+                                            "end": 767,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 757,
+                                                "end": 766,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 757,
+                                                    "end": 766,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 758,
+                                                        "end": 765
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 767,
+                                    "end": 768
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 770,
+                            "end": 774,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 770,
+                                "end": 774,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 771,
+                                    "end": 773
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 776,
+                            "end": 798,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 776,
+                                "end": 798,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 776,
+                                    "end": 797,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 776,
+                                        "end": 781
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 781,
+                                        "end": 797,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 781,
+                                            "end": 797,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 782,
+                                                "end": 796,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 782,
+                                                    "end": 796,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 783,
+                                                        "end": 795
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 797,
+                                    "end": 798
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 800,
+                            "end": 805,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 800,
+                                "end": 805,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 801,
+                                    "end": 804
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 807,
+                            "end": 822,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 807,
+                                "end": 822,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 807,
+                                    "end": 821,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 807,
+                                        "end": 812
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 812,
+                                        "end": 821,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 812,
+                                            "end": 821,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 813,
+                                                "end": 820,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 813,
+                                                    "end": 820,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 814,
+                                                        "end": 819
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 821,
+                                    "end": 822
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/join_multi.swift.json
+++ b/tests/json-ast/x/swift/join_multi.swift.json
@@ -1,138 +1,1478 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 140
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 776,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 140
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
+        "end": 141,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 141,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 142,
-          "end": 214
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 142,
-        "end": 214
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
+        "end": 215,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 142,
+            "end": 145
+          },
+          {
+            "kind": "pattern",
+            "start": 146,
+            "end": 152,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 146,
+                "end": 152
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 155,
+            "end": 215,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 156,
+                "end": 184,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 157,
+                    "end": 161,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 158,
+                        "end": 160
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 163,
+                    "end": 166
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 168,
+                    "end": 180,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 169,
+                        "end": 179
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 182,
+                    "end": 183
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 186,
+                "end": 214,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 187,
+                    "end": 191,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 188,
+                        "end": 190
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 193,
+                    "end": 196
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 209
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 212,
+                    "end": 213
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 146,
-        "end": 146
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 216,
-          "end": 287
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 216,
-        "end": 287
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "items"
-        }
+        "end": 288,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 216,
+            "end": 219
+          },
+          {
+            "kind": "pattern",
+            "start": 220,
+            "end": 225,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 220,
+                "end": 225
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 228,
+            "end": 288,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 229,
+                "end": 257,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 230,
+                    "end": 239,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 231,
+                        "end": 238
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 241,
+                    "end": 244
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 246,
+                    "end": 251,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 247,
+                        "end": 250
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 253,
+                    "end": 256,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 254,
+                        "end": 255
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 259,
+                "end": 287,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 260,
+                    "end": 269,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 261,
+                        "end": 268
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 271,
+                    "end": 274
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 276,
+                    "end": 281,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 277,
+                        "end": 280
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 283,
+                    "end": 286,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 284,
+                        "end": 285
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 220,
-        "end": 220
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 289,
-          "end": 678
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 289,
-        "end": 678
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
+        "end": 679,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 289,
+            "end": 292
+          },
+          {
+            "kind": "pattern",
+            "start": 293,
+            "end": 299,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 293,
+                "end": 299
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 302,
+            "end": 679,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 302,
+                "end": 677,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 303,
+                    "end": 676,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 305,
+                        "end": 674,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 305,
+                            "end": 335,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 305,
+                                "end": 308
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 309,
+                                "end": 313,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 309,
+                                    "end": 313
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 313,
+                                "end": 330,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 315,
+                                    "end": 330,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 316,
+                                        "end": 329,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 317,
+                                            "end": 323,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 317,
+                                                "end": 323
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 325,
+                                            "end": 328,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 325,
+                                                "end": 328
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 333,
+                                "end": 335
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 336,
+                            "end": 662,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 340,
+                                "end": 341,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 340,
+                                    "end": 341
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 345,
+                                "end": 351
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 358,
+                                "end": 661,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 358,
+                                    "end": 660,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 362,
+                                        "end": 363,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 362,
+                                            "end": 363
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 367,
+                                        "end": 376
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 387,
+                                        "end": 659,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 387,
+                                            "end": 654,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 390,
+                                                "end": 440,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 391,
+                                                    "end": 439,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 391,
+                                                        "end": 417,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 392,
+                                                            "end": 416,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 392,
+                                                                "end": 408,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 392,
+                                                                    "end": 407,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 392,
+                                                                        "end": 393
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 393,
+                                                                        "end": 407,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 393,
+                                                                            "end": 407,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 394,
+                                                                                "end": 406,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 394,
+                                                                                    "end": 406,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 395,
+                                                                                        "end": 405
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 407,
+                                                                    "end": 408
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 409,
+                                                                "end": 412
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 413,
+                                                                "end": 416,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 413,
+                                                                    "end": 416
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 421,
+                                                        "end": 439,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 422,
+                                                            "end": 438,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 422,
+                                                                "end": 430,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 422,
+                                                                    "end": 429,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 422,
+                                                                        "end": 423
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 423,
+                                                                        "end": 429,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 423,
+                                                                            "end": 429,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 424,
+                                                                                "end": 428,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 424,
+                                                                                    "end": 428,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 425,
+                                                                                        "end": 427
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 429,
+                                                                    "end": 430
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 431,
+                                                                "end": 434
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 435,
+                                                                "end": 438,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 435,
+                                                                    "end": 438
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 455,
+                                                "end": 653,
+                                                "children": [
+                                                  {
+                                                    "kind": "for_statement",
+                                                    "start": 455,
+                                                    "end": 644,
+                                                    "children": [
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 459,
+                                                        "end": 460,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 459,
+                                                            "end": 460
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 464,
+                                                        "end": 469
+                                                      },
+                                                      {
+                                                        "kind": "statements",
+                                                        "start": 488,
+                                                        "end": 643,
+                                                        "children": [
+                                                          {
+                                                            "kind": "if_statement",
+                                                            "start": 488,
+                                                            "end": 630,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 491,
+                                                                "end": 538,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "equality_expression",
+                                                                    "start": 492,
+                                                                    "end": 537,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 492,
+                                                                        "end": 510,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 493,
+                                                                            "end": 509,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 493,
+                                                                                "end": 501,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 493,
+                                                                                    "end": 500,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 493,
+                                                                                        "end": 494
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 494,
+                                                                                        "end": 500,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 494,
+                                                                                            "end": 500,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 495,
+                                                                                                "end": 499,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 495,
+                                                                                                    "end": 499,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 496,
+                                                                                                        "end": 498
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 500,
+                                                                                    "end": 501
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 502,
+                                                                                "end": 505
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 506,
+                                                                                "end": 509,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 506,
+                                                                                    "end": 509
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 514,
+                                                                        "end": 537,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 515,
+                                                                            "end": 536,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 515,
+                                                                                "end": 528,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 515,
+                                                                                    "end": 527,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 515,
+                                                                                        "end": 516
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 516,
+                                                                                        "end": 527,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 516,
+                                                                                            "end": 527,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 517,
+                                                                                                "end": 526,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 517,
+                                                                                                    "end": 526,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 518,
+                                                                                                        "end": 525
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 527,
+                                                                                    "end": 528
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 529,
+                                                                                "end": 532
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 533,
+                                                                                "end": 536,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 533,
+                                                                                    "end": 536
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "statements",
+                                                                "start": 561,
+                                                                "end": 629,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 561,
+                                                                    "end": 612,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "navigation_expression",
+                                                                        "start": 561,
+                                                                        "end": 572,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 561,
+                                                                            "end": 565
+                                                                          },
+                                                                          {
+                                                                            "kind": "navigation_suffix",
+                                                                            "start": 565,
+                                                                            "end": 572,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 566,
+                                                                                "end": 572
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 572,
+                                                                        "end": 612,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 572,
+                                                                            "end": 612,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 573,
+                                                                                "end": 611,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "dictionary_literal",
+                                                                                    "start": 573,
+                                                                                    "end": 611,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 574,
+                                                                                        "end": 580,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 575,
+                                                                                            "end": 579
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "postfix_expression",
+                                                                                        "start": 582,
+                                                                                        "end": 592,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "call_expression",
+                                                                                            "start": 582,
+                                                                                            "end": 591,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "simple_identifier",
+                                                                                                "start": 582,
+                                                                                                "end": 583
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "call_suffix",
+                                                                                                "start": 583,
+                                                                                                "end": 591,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "value_arguments",
+                                                                                                    "start": 583,
+                                                                                                    "end": 591,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "value_argument",
+                                                                                                        "start": 584,
+                                                                                                        "end": 590,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "line_string_literal",
+                                                                                                            "start": 584,
+                                                                                                            "end": 590,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "line_str_text",
+                                                                                                                "start": 585,
+                                                                                                                "end": 589
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "bang",
+                                                                                            "start": 591,
+                                                                                            "end": 592
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 594,
+                                                                                        "end": 599,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 595,
+                                                                                            "end": 598
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "postfix_expression",
+                                                                                        "start": 601,
+                                                                                        "end": 610,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "call_expression",
+                                                                                            "start": 601,
+                                                                                            "end": 609,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "simple_identifier",
+                                                                                                "start": 601,
+                                                                                                "end": 602
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "call_suffix",
+                                                                                                "start": 602,
+                                                                                                "end": 609,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "value_arguments",
+                                                                                                    "start": 602,
+                                                                                                    "end": 609,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "value_argument",
+                                                                                                        "start": 603,
+                                                                                                        "end": 608,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "line_string_literal",
+                                                                                                            "start": 603,
+                                                                                                            "end": 608,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "line_str_text",
+                                                                                                                "start": 604,
+                                                                                                                "end": 607
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "bang",
+                                                                                            "start": 609,
+                                                                                            "end": 610
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 663,
+                            "end": 674,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 670,
+                                "end": 674
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 677,
+                "end": 679,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 677,
+                    "end": 679
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 293,
-        "end": 293
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 680,
-          "end": 706
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 680,
-        "end": 706
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 708,
-          "end": 774
-        }
+        "end": 707,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 680,
+            "end": 685
+          },
+          {
+            "kind": "call_suffix",
+            "start": 685,
+            "end": 707,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 685,
+                "end": 707,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 686,
+                    "end": 706,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 686,
+                        "end": 706,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 687,
+                            "end": 705
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 708,
-        "end": 774
+        "end": 775,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 712,
+            "end": 713,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 712,
+                "end": 713
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 717,
+            "end": 723
+          },
+          {
+            "kind": "statements",
+            "start": 730,
+            "end": 774,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 730,
+                "end": 773,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 730,
+                    "end": 735
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 735,
+                    "end": 773,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 735,
+                        "end": 773,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 736,
+                            "end": 746,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 736,
+                                "end": 746,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 736,
+                                    "end": 745,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 736,
+                                        "end": 737
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 737,
+                                        "end": 745,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 737,
+                                            "end": 745,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 738,
+                                                "end": 744,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 738,
+                                                    "end": 744,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 739,
+                                                        "end": 743
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 745,
+                                    "end": 746
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 748,
+                            "end": 761,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 748,
+                                "end": 761,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 749,
+                                    "end": 760
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 763,
+                            "end": 772,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 763,
+                                "end": 772,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 763,
+                                    "end": 771,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 763,
+                                        "end": 764
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 764,
+                                        "end": 771,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 764,
+                                            "end": 771,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 765,
+                                                "end": 770,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 765,
+                                                    "end": 770,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 766,
+                                                        "end": 769
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 771,
+                                    "end": 772
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/left_join.swift.json
+++ b/tests/json-ast/x/swift/left_join.swift.json
@@ -1,111 +1,1741 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 140
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 884,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 140
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
+        "end": 141,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 141,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 142,
-          "end": 241
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 142,
-        "end": 241
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
+        "end": 242,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 142,
+            "end": 145
+          },
+          {
+            "kind": "pattern",
+            "start": 146,
+            "end": 152,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 146,
+                "end": 152
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 155,
+            "end": 242,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 156,
+                "end": 198,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 157,
+                    "end": 161,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 158,
+                        "end": 160
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 163,
+                    "end": 166
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 168,
+                    "end": 180,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 169,
+                        "end": 179
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 182,
+                    "end": 183
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 185,
+                    "end": 192,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 186,
+                        "end": 191
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 194,
+                    "end": 197
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 200,
+                "end": 241,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 201,
+                    "end": 205,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 202,
+                        "end": 204
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 207,
+                    "end": 210
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 212,
+                    "end": 224,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 213,
+                        "end": 223
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 226,
+                    "end": 227
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 229,
+                    "end": 236,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 230,
+                        "end": 235
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 238,
+                    "end": 240
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 146,
-        "end": 146
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 243,
-          "end": 735
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 243,
-        "end": 735
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
+        "end": 736,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 243,
+            "end": 246
+          },
+          {
+            "kind": "pattern",
+            "start": 247,
+            "end": 253,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 247,
+                "end": 253
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 256,
+            "end": 736,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 256,
+                "end": 734,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 257,
+                    "end": 733,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 259,
+                        "end": 731,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 259,
+                            "end": 289,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 259,
+                                "end": 262
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 263,
+                                "end": 267,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 263,
+                                    "end": 267
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 267,
+                                "end": 284,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 269,
+                                    "end": 284,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 270,
+                                        "end": 283,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 271,
+                                            "end": 277,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 271,
+                                                "end": 277
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 279,
+                                            "end": 282,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 279,
+                                                "end": 282
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 287,
+                                "end": 289
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 290,
+                            "end": 719,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 294,
+                                "end": 295,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 294,
+                                    "end": 295
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 299,
+                                "end": 305
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 312,
+                                "end": 718,
+                                "children": [
+                                  {
+                                    "kind": "property_declaration",
+                                    "start": 312,
+                                    "end": 331,
+                                    "children": [
+                                      {
+                                        "kind": "value_binding_pattern",
+                                        "start": 312,
+                                        "end": 315
+                                      },
+                                      {
+                                        "kind": "pattern",
+                                        "start": 316,
+                                        "end": 323,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 316,
+                                            "end": 323
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "boolean_literal",
+                                        "start": 326,
+                                        "end": 331
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 336,
+                                    "end": 567,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 340,
+                                        "end": 341,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 340,
+                                            "end": 341
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 345,
+                                        "end": 354
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 365,
+                                        "end": 566,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 365,
+                                            "end": 561,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 368,
+                                                "end": 418,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 369,
+                                                    "end": 417,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 369,
+                                                        "end": 395,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 370,
+                                                            "end": 394,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 370,
+                                                                "end": 386,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 370,
+                                                                    "end": 385,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 370,
+                                                                        "end": 371
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 371,
+                                                                        "end": 385,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 371,
+                                                                            "end": 385,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 372,
+                                                                                "end": 384,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 372,
+                                                                                    "end": 384,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 373,
+                                                                                        "end": 383
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 385,
+                                                                    "end": 386
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 387,
+                                                                "end": 390
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 391,
+                                                                "end": 394,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 391,
+                                                                    "end": 394
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 399,
+                                                        "end": 417,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 400,
+                                                            "end": 416,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 400,
+                                                                "end": 408,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 400,
+                                                                    "end": 407,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 400,
+                                                                        "end": 401
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 401,
+                                                                        "end": 407,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 401,
+                                                                            "end": 407,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 402,
+                                                                                "end": 406,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 402,
+                                                                                    "end": 406,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 403,
+                                                                                        "end": 405
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 407,
+                                                                    "end": 408
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 409,
+                                                                "end": 412
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 413,
+                                                                "end": 416,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 413,
+                                                                    "end": 416
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 433,
+                                                "end": 560,
+                                                "children": [
+                                                  {
+                                                    "kind": "assignment",
+                                                    "start": 433,
+                                                    "end": 447,
+                                                    "children": [
+                                                      {
+                                                        "kind": "directly_assignable_expression",
+                                                        "start": 433,
+                                                        "end": 440,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 433,
+                                                            "end": 440
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "boolean_literal",
+                                                        "start": 443,
+                                                        "end": 447
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 460,
+                                                    "end": 551,
+                                                    "children": [
+                                                      {
+                                                        "kind": "navigation_expression",
+                                                        "start": 460,
+                                                        "end": 471,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 460,
+                                                            "end": 464
+                                                          },
+                                                          {
+                                                            "kind": "navigation_suffix",
+                                                            "start": 464,
+                                                            "end": 471,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 465,
+                                                                "end": 471
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 471,
+                                                        "end": 551,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 471,
+                                                            "end": 551,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 472,
+                                                                "end": 550,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "dictionary_literal",
+                                                                    "start": 472,
+                                                                    "end": 550,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 473,
+                                                                        "end": 482,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 474,
+                                                                            "end": 481
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 484,
+                                                                        "end": 502,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 485,
+                                                                            "end": 501,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 485,
+                                                                                "end": 493,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 485,
+                                                                                    "end": 492,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 485,
+                                                                                        "end": 486
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 486,
+                                                                                        "end": 492,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 486,
+                                                                                            "end": 492,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 487,
+                                                                                                "end": 491,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 487,
+                                                                                                    "end": 491,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 488,
+                                                                                                        "end": 490
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 492,
+                                                                                    "end": 493
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 494,
+                                                                                "end": 497
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 498,
+                                                                                "end": 501,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 498,
+                                                                                    "end": 501
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 504,
+                                                                        "end": 514,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 505,
+                                                                            "end": 513
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 516,
+                                                                        "end": 517
+                                                                      },
+                                                                      {
+                                                                        "kind": "line_string_literal",
+                                                                        "start": 519,
+                                                                        "end": 526,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_str_text",
+                                                                            "start": 520,
+                                                                            "end": 525
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 528,
+                                                                        "end": 549,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 529,
+                                                                            "end": 548,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 529,
+                                                                                "end": 540,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 529,
+                                                                                    "end": 539,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 529,
+                                                                                        "end": 530
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 530,
+                                                                                        "end": 539,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 530,
+                                                                                            "end": 539,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 531,
+                                                                                                "end": 538,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 531,
+                                                                                                    "end": 538,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 532,
+                                                                                                        "end": 537
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 539,
+                                                                                    "end": 540
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 541,
+                                                                                "end": 544
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 545,
+                                                                                "end": 548,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 545,
+                                                                                    "end": 548
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "if_statement",
+                                    "start": 572,
+                                    "end": 717,
+                                    "children": [
+                                      {
+                                        "kind": "prefix_expression",
+                                        "start": 575,
+                                        "end": 583,
+                                        "children": [
+                                          {
+                                            "kind": "bang",
+                                            "start": 575,
+                                            "end": 576
+                                          },
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 576,
+                                            "end": 583
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 594,
+                                        "end": 716,
+                                        "children": [
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 594,
+                                            "end": 611,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 594,
+                                                "end": 597
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 598,
+                                                "end": 599,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 598,
+                                                    "end": 599
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "type_annotation",
+                                                "start": 599,
+                                                "end": 605,
+                                                "children": [
+                                                  {
+                                                    "kind": "optional_type",
+                                                    "start": 601,
+                                                    "end": 605,
+                                                    "children": [
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 601,
+                                                        "end": 604,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 601,
+                                                            "end": 604
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "call_expression",
+                                            "start": 620,
+                                            "end": 711,
+                                            "children": [
+                                              {
+                                                "kind": "navigation_expression",
+                                                "start": 620,
+                                                "end": 631,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 620,
+                                                    "end": 624
+                                                  },
+                                                  {
+                                                    "kind": "navigation_suffix",
+                                                    "start": 624,
+                                                    "end": 631,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 625,
+                                                        "end": 631
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "call_suffix",
+                                                "start": 631,
+                                                "end": 711,
+                                                "children": [
+                                                  {
+                                                    "kind": "value_arguments",
+                                                    "start": 631,
+                                                    "end": 711,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_argument",
+                                                        "start": 632,
+                                                        "end": 710,
+                                                        "children": [
+                                                          {
+                                                            "kind": "dictionary_literal",
+                                                            "start": 632,
+                                                            "end": 710,
+                                                            "children": [
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 633,
+                                                                "end": 642,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 634,
+                                                                    "end": 641
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 644,
+                                                                "end": 662,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 645,
+                                                                    "end": 661,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 645,
+                                                                        "end": 653,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 645,
+                                                                            "end": 652,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 645,
+                                                                                "end": 646
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 646,
+                                                                                "end": 652,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 646,
+                                                                                    "end": 652,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 647,
+                                                                                        "end": 651,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 647,
+                                                                                            "end": 651,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 648,
+                                                                                                "end": 650
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 652,
+                                                                            "end": 653
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 654,
+                                                                        "end": 657
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 658,
+                                                                        "end": 661,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 658,
+                                                                            "end": 661
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 664,
+                                                                "end": 674,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 665,
+                                                                    "end": 673
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 676,
+                                                                "end": 677
+                                                              },
+                                                              {
+                                                                "kind": "line_string_literal",
+                                                                "start": 679,
+                                                                "end": 686,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_str_text",
+                                                                    "start": 680,
+                                                                    "end": 685
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 688,
+                                                                "end": 709,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "as_expression",
+                                                                    "start": 689,
+                                                                    "end": 708,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "postfix_expression",
+                                                                        "start": 689,
+                                                                        "end": 700,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "call_expression",
+                                                                            "start": 689,
+                                                                            "end": 699,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 689,
+                                                                                "end": 690
+                                                                              },
+                                                                              {
+                                                                                "kind": "call_suffix",
+                                                                                "start": 690,
+                                                                                "end": 699,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "value_arguments",
+                                                                                    "start": 690,
+                                                                                    "end": 699,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "value_argument",
+                                                                                        "start": 691,
+                                                                                        "end": 698,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_string_literal",
+                                                                                            "start": 691,
+                                                                                            "end": 698,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "line_str_text",
+                                                                                                "start": 692,
+                                                                                                "end": 697
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "kind": "bang",
+                                                                            "start": 699,
+                                                                            "end": 700
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "as_operator",
+                                                                        "start": 701,
+                                                                        "end": 704
+                                                                      },
+                                                                      {
+                                                                        "kind": "user_type",
+                                                                        "start": 705,
+                                                                        "end": 708,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "type_identifier",
+                                                                            "start": 705,
+                                                                            "end": 708
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 720,
+                            "end": 731,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 727,
+                                "end": 731
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 734,
+                "end": 736,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 734,
+                    "end": 736
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 247,
-        "end": 247
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 737,
-          "end": 762
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 737,
-        "end": 762
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 764,
-          "end": 882
-        }
+        "end": 763,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 737,
+            "end": 742
+          },
+          {
+            "kind": "call_suffix",
+            "start": 742,
+            "end": 763,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 742,
+                "end": 763,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 743,
+                    "end": 762,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 743,
+                        "end": 762,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 744,
+                            "end": 761
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 764,
-        "end": 882
+        "end": 883,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 768,
+            "end": 773,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 768,
+                "end": 773
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 777,
+            "end": 783
+          },
+          {
+            "kind": "statements",
+            "start": 790,
+            "end": 882,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 790,
+                "end": 881,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 790,
+                    "end": 795
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 795,
+                    "end": 881,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 795,
+                        "end": 881,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 796,
+                            "end": 803,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 796,
+                                "end": 803,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 797,
+                                    "end": 802
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 805,
+                            "end": 822,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 805,
+                                "end": 822,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 805,
+                                    "end": 821,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 805,
+                                        "end": 810
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 810,
+                                        "end": 821,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 810,
+                                            "end": 821,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 811,
+                                                "end": 820,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 811,
+                                                    "end": 820,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 812,
+                                                        "end": 819
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 821,
+                                    "end": 822
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 824,
+                            "end": 834,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 824,
+                                "end": 834,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 825,
+                                    "end": 833
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 836,
+                            "end": 854,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 836,
+                                "end": 854,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 836,
+                                    "end": 853,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 836,
+                                        "end": 841
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 841,
+                                        "end": 853,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 841,
+                                            "end": 853,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 842,
+                                                "end": 852,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 842,
+                                                    "end": 852,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 843,
+                                                        "end": 851
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 853,
+                                    "end": 854
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 856,
+                            "end": 863,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 856,
+                                "end": 863,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 857,
+                                    "end": 862
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 865,
+                            "end": 880,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 865,
+                                "end": 880,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 865,
+                                    "end": 879,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 865,
+                                        "end": 870
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 870,
+                                        "end": 879,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 870,
+                                            "end": 879,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 871,
+                                                "end": 878,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 871,
+                                                    "end": 878,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 872,
+                                                        "end": 877
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 879,
+                                    "end": 880
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/left_join_multi.swift.json
+++ b/tests/json-ast/x/swift/left_join_multi.swift.json
@@ -1,138 +1,1523 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 140
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 776,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 140
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "customers"
-        }
+        "end": 141,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 84,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 84
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 87,
+            "end": 141,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 88,
+                "end": 114,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 89,
+                    "end": 93,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 90,
+                        "end": 92
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 95,
+                    "end": 96
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 98,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 99,
+                        "end": 103
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 106,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 107,
+                        "end": 112
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 116,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 117,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 118,
+                        "end": 120
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 123,
+                    "end": 124
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 126,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 127,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 134,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 135,
+                        "end": 138
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 142,
-          "end": 214
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 142,
-        "end": 214
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "orders"
-        }
+        "end": 215,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 142,
+            "end": 145
+          },
+          {
+            "kind": "pattern",
+            "start": 146,
+            "end": 152,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 146,
+                "end": 152
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 155,
+            "end": 215,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 156,
+                "end": 184,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 157,
+                    "end": 161,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 158,
+                        "end": 160
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 163,
+                    "end": 166
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 168,
+                    "end": 180,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 169,
+                        "end": 179
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 182,
+                    "end": 183
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 186,
+                "end": 214,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 187,
+                    "end": 191,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 188,
+                        "end": 190
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 193,
+                    "end": 196
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 198,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 199,
+                        "end": 209
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 212,
+                    "end": 213
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 146,
-        "end": 146
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 216,
-          "end": 257
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 216,
-        "end": 257
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "items"
-        }
+        "end": 258,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 216,
+            "end": 219
+          },
+          {
+            "kind": "pattern",
+            "start": 220,
+            "end": 225,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 220,
+                "end": 225
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 228,
+            "end": 258,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 229,
+                "end": 257,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 230,
+                    "end": 239,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 231,
+                        "end": 238
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 241,
+                    "end": 244
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 246,
+                    "end": 251,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 247,
+                        "end": 250
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 253,
+                    "end": 256,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 254,
+                        "end": 255
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 220,
-        "end": 220
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 259,
-          "end": 672
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 259,
-        "end": 672
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
+        "end": 673,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 259,
+            "end": 262
+          },
+          {
+            "kind": "pattern",
+            "start": 263,
+            "end": 269,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 263,
+                "end": 269
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 272,
+            "end": 673,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 272,
+                "end": 671,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 273,
+                    "end": 670,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 275,
+                        "end": 668,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 275,
+                            "end": 305,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 275,
+                                "end": 278
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 279,
+                                "end": 283,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 279,
+                                    "end": 283
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 283,
+                                "end": 300,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 285,
+                                    "end": 300,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 286,
+                                        "end": 299,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 287,
+                                            "end": 293,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 287,
+                                                "end": 293
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 295,
+                                            "end": 298,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 295,
+                                                "end": 298
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 303,
+                                "end": 305
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 306,
+                            "end": 656,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 310,
+                                "end": 311,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 310,
+                                    "end": 311
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 315,
+                                "end": 321
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 328,
+                                "end": 655,
+                                "children": [
+                                  {
+                                    "kind": "for_statement",
+                                    "start": 328,
+                                    "end": 654,
+                                    "children": [
+                                      {
+                                        "kind": "pattern",
+                                        "start": 332,
+                                        "end": 333,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 332,
+                                            "end": 333
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 337,
+                                        "end": 346
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 357,
+                                        "end": 653,
+                                        "children": [
+                                          {
+                                            "kind": "if_statement",
+                                            "start": 357,
+                                            "end": 648,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 360,
+                                                "end": 410,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 361,
+                                                    "end": 409,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 361,
+                                                        "end": 387,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 362,
+                                                            "end": 386,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 362,
+                                                                "end": 378,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 362,
+                                                                    "end": 377,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 362,
+                                                                        "end": 363
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 363,
+                                                                        "end": 377,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 363,
+                                                                            "end": 377,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 364,
+                                                                                "end": 376,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 364,
+                                                                                    "end": 376,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 365,
+                                                                                        "end": 375
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 377,
+                                                                    "end": 378
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 379,
+                                                                "end": 382
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 383,
+                                                                "end": 386,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 383,
+                                                                    "end": 386
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 391,
+                                                        "end": 409,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 392,
+                                                            "end": 408,
+                                                            "children": [
+                                                              {
+                                                                "kind": "postfix_expression",
+                                                                "start": 392,
+                                                                "end": 400,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 392,
+                                                                    "end": 399,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 392,
+                                                                        "end": 393
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 393,
+                                                                        "end": 399,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 393,
+                                                                            "end": 399,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 394,
+                                                                                "end": 398,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_string_literal",
+                                                                                    "start": 394,
+                                                                                    "end": 398,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_str_text",
+                                                                                        "start": 395,
+                                                                                        "end": 397
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "bang",
+                                                                    "start": 399,
+                                                                    "end": 400
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 401,
+                                                                "end": 404
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 405,
+                                                                "end": 408,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 405,
+                                                                    "end": 408
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "statements",
+                                                "start": 425,
+                                                "end": 647,
+                                                "children": [
+                                                  {
+                                                    "kind": "for_statement",
+                                                    "start": 425,
+                                                    "end": 638,
+                                                    "children": [
+                                                      {
+                                                        "kind": "pattern",
+                                                        "start": 429,
+                                                        "end": 430,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 429,
+                                                            "end": 430
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 434,
+                                                        "end": 439
+                                                      },
+                                                      {
+                                                        "kind": "statements",
+                                                        "start": 458,
+                                                        "end": 637,
+                                                        "children": [
+                                                          {
+                                                            "kind": "if_statement",
+                                                            "start": 458,
+                                                            "end": 624,
+                                                            "children": [
+                                                              {
+                                                                "kind": "tuple_expression",
+                                                                "start": 461,
+                                                                "end": 508,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "equality_expression",
+                                                                    "start": 462,
+                                                                    "end": 507,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 462,
+                                                                        "end": 480,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 463,
+                                                                            "end": 479,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 463,
+                                                                                "end": 471,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 463,
+                                                                                    "end": 470,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 463,
+                                                                                        "end": 464
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 464,
+                                                                                        "end": 470,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 464,
+                                                                                            "end": 470,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 465,
+                                                                                                "end": 469,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 465,
+                                                                                                    "end": 469,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 466,
+                                                                                                        "end": 468
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 470,
+                                                                                    "end": 471
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 472,
+                                                                                "end": 475
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 476,
+                                                                                "end": 479,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 476,
+                                                                                    "end": 479
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "tuple_expression",
+                                                                        "start": 484,
+                                                                        "end": 507,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "as_expression",
+                                                                            "start": 485,
+                                                                            "end": 506,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "postfix_expression",
+                                                                                "start": 485,
+                                                                                "end": 498,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "call_expression",
+                                                                                    "start": 485,
+                                                                                    "end": 497,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 485,
+                                                                                        "end": 486
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "call_suffix",
+                                                                                        "start": 486,
+                                                                                        "end": 497,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "value_arguments",
+                                                                                            "start": 486,
+                                                                                            "end": 497,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "value_argument",
+                                                                                                "start": 487,
+                                                                                                "end": 496,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "line_string_literal",
+                                                                                                    "start": 487,
+                                                                                                    "end": 496,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "line_str_text",
+                                                                                                        "start": 488,
+                                                                                                        "end": 495
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "bang",
+                                                                                    "start": 497,
+                                                                                    "end": 498
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "kind": "as_operator",
+                                                                                "start": 499,
+                                                                                "end": 502
+                                                                              },
+                                                                              {
+                                                                                "kind": "user_type",
+                                                                                "start": 503,
+                                                                                "end": 506,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "type_identifier",
+                                                                                    "start": 503,
+                                                                                    "end": 506
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "statements",
+                                                                "start": 531,
+                                                                "end": 623,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 531,
+                                                                    "end": 606,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "navigation_expression",
+                                                                        "start": 531,
+                                                                        "end": 542,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 531,
+                                                                            "end": 535
+                                                                          },
+                                                                          {
+                                                                            "kind": "navigation_suffix",
+                                                                            "start": 535,
+                                                                            "end": 542,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 536,
+                                                                                "end": 542
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 542,
+                                                                        "end": 606,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 542,
+                                                                            "end": 606,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 543,
+                                                                                "end": 605,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "dictionary_literal",
+                                                                                    "start": 543,
+                                                                                    "end": 605,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 544,
+                                                                                        "end": 553,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 545,
+                                                                                            "end": 552
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "tuple_expression",
+                                                                                        "start": 555,
+                                                                                        "end": 573,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "as_expression",
+                                                                                            "start": 556,
+                                                                                            "end": 572,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "postfix_expression",
+                                                                                                "start": 556,
+                                                                                                "end": 564,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "call_expression",
+                                                                                                    "start": 556,
+                                                                                                    "end": 563,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "simple_identifier",
+                                                                                                        "start": 556,
+                                                                                                        "end": 557
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "kind": "call_suffix",
+                                                                                                        "start": 557,
+                                                                                                        "end": 563,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "value_arguments",
+                                                                                                            "start": 557,
+                                                                                                            "end": 563,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "value_argument",
+                                                                                                                "start": 558,
+                                                                                                                "end": 562,
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "kind": "line_string_literal",
+                                                                                                                    "start": 558,
+                                                                                                                    "end": 562,
+                                                                                                                    "children": [
+                                                                                                                      {
+                                                                                                                        "kind": "line_str_text",
+                                                                                                                        "start": 559,
+                                                                                                                        "end": 561
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "kind": "bang",
+                                                                                                    "start": 563,
+                                                                                                    "end": 564
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "as_operator",
+                                                                                                "start": 565,
+                                                                                                "end": 568
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "user_type",
+                                                                                                "start": 569,
+                                                                                                "end": 572,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "type_identifier",
+                                                                                                    "start": 569,
+                                                                                                    "end": 572
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 575,
+                                                                                        "end": 581,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 576,
+                                                                                            "end": 580
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "postfix_expression",
+                                                                                        "start": 583,
+                                                                                        "end": 593,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "call_expression",
+                                                                                            "start": 583,
+                                                                                            "end": 592,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "simple_identifier",
+                                                                                                "start": 583,
+                                                                                                "end": 584
+                                                                                              },
+                                                                                              {
+                                                                                                "kind": "call_suffix",
+                                                                                                "start": 584,
+                                                                                                "end": 592,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "value_arguments",
+                                                                                                    "start": 584,
+                                                                                                    "end": 592,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "value_argument",
+                                                                                                        "start": 585,
+                                                                                                        "end": 591,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "line_string_literal",
+                                                                                                            "start": 585,
+                                                                                                            "end": 591,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "line_str_text",
+                                                                                                                "start": 586,
+                                                                                                                "end": 590
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "bang",
+                                                                                            "start": 592,
+                                                                                            "end": 593
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "line_string_literal",
+                                                                                        "start": 595,
+                                                                                        "end": 601,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "line_str_text",
+                                                                                            "start": 596,
+                                                                                            "end": 600
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "kind": "simple_identifier",
+                                                                                        "start": 603,
+                                                                                        "end": 604
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 657,
+                            "end": 668,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 664,
+                                "end": 668
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 671,
+                "end": 673,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 671,
+                    "end": 673
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 263,
-        "end": 263
-      },
-      "interface_type": "$sSSypXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 674,
-          "end": 705
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 674,
-        "end": 705
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 707,
-          "end": 774
-        }
+        "end": 706,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 674,
+            "end": 679
+          },
+          {
+            "kind": "call_suffix",
+            "start": 679,
+            "end": 706,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 679,
+                "end": 706,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 680,
+                    "end": 705,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 680,
+                        "end": 705,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 681,
+                            "end": 704
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "for_statement",
         "start": 707,
-        "end": 774
+        "end": 775,
+        "children": [
+          {
+            "kind": "pattern",
+            "start": 711,
+            "end": 712,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 711,
+                "end": 712
+              }
+            ]
+          },
+          {
+            "kind": "simple_identifier",
+            "start": 716,
+            "end": 722
+          },
+          {
+            "kind": "statements",
+            "start": 729,
+            "end": 774,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 729,
+                "end": 773,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 729,
+                    "end": 734
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 734,
+                    "end": 773,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 734,
+                        "end": 773,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 735,
+                            "end": 748,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 735,
+                                "end": 748,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 735,
+                                    "end": 747,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 735,
+                                        "end": 736
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 736,
+                                        "end": 747,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 736,
+                                            "end": 747,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 737,
+                                                "end": 746,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 737,
+                                                    "end": 746,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 738,
+                                                        "end": 745
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 747,
+                                    "end": 748
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 750,
+                            "end": 760,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 750,
+                                "end": 760,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 750,
+                                    "end": 759,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 750,
+                                        "end": 751
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 751,
+                                        "end": 759,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 751,
+                                            "end": 759,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 752,
+                                                "end": 758,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 752,
+                                                    "end": 758,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 753,
+                                                        "end": 757
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 759,
+                                    "end": 760
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "value_argument",
+                            "start": 762,
+                            "end": 772,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 762,
+                                "end": 772,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 762,
+                                    "end": 771,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 762,
+                                        "end": 763
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 763,
+                                        "end": 771,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 763,
+                                            "end": 771,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 764,
+                                                "end": 770,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 764,
+                                                    "end": 770,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 765,
+                                                        "end": 769
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 771,
+                                    "end": 772
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/len_builtin.swift.json
+++ b/tests/json-ast/x/swift/len_builtin.swift.json
@@ -1,17 +1,52 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 78
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 80,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 78
+        "end": 79,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 79,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 79,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 78,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 78
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/len_map.swift.json
+++ b/tests/json-ast/x/swift/len_map.swift.json
@@ -1,17 +1,52 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 78
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 80,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 78
+        "end": 79,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 79,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 79,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 78,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 78
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/len_string.swift.json
+++ b/tests/json-ast/x/swift/len_string.swift.json
@@ -1,17 +1,52 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 78
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 80,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 78
+        "end": 79,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 79,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 79,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 78,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 78
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/let_and_print.swift.json
+++ b/tests/json-ast/x/swift/let_and_print.swift.json
@@ -1,71 +1,191 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 128,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "a"
-        }
+        "end": 81,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 81
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 82,
-          "end": 90
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 82,
-        "end": 90
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "b"
-        }
+        "end": 92,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 82,
+            "end": 85
+          },
+          {
+            "kind": "pattern",
+            "start": 86,
+            "end": 87,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 86,
+                "end": 87
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 90,
+            "end": 92
+          }
+        ]
       },
-      "range": {
-        "start": 86,
-        "end": 86
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 93,
-          "end": 126
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 93,
-        "end": 126
+        "end": 127,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 93,
+            "end": 98
+          },
+          {
+            "kind": "call_suffix",
+            "start": 98,
+            "end": 127,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 98,
+                "end": 127,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 99,
+                    "end": 126,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 99,
+                        "end": 126,
+                        "children": [
+                          {
+                            "kind": "additive_expression",
+                            "start": 100,
+                            "end": 125,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 100,
+                                "end": 111,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 101,
+                                    "end": 110,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 101,
+                                        "end": 102
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 103,
+                                        "end": 106
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 107,
+                                        "end": 110,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 107,
+                                            "end": 110
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "tuple_expression",
+                                "start": 114,
+                                "end": 125,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 115,
+                                    "end": 124,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 115,
+                                        "end": 116
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 117,
+                                        "end": 120
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 121,
+                                        "end": 124,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 121,
+                                            "end": 124
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/list_assign.swift.json
+++ b/tests/json-ast/x/swift/list_assign.swift.json
@@ -1,57 +1,214 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 87
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 126,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 87
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "nums"
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 79,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 79
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 82,
+            "end": 88,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 89,
-          "end": 99
-        }
-      },
-      "range": {
+      {
+        "kind": "assignment",
         "start": 89,
-        "end": 99
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 101,
-          "end": 124
-        }
+        "end": 100,
+        "children": [
+          {
+            "kind": "directly_assignable_expression",
+            "start": 89,
+            "end": 96,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 89,
+                "end": 96,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 89,
+                    "end": 93
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 93,
+                    "end": 96,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 93,
+                        "end": 96,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 94,
+                            "end": 95,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 94,
+                                "end": 95
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 99,
+            "end": 100
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 101,
-        "end": 124
+        "end": 125,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 101,
+            "end": 106
+          },
+          {
+            "kind": "call_suffix",
+            "start": 106,
+            "end": 125,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 106,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 107,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 107,
+                        "end": 124,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 108,
+                            "end": 123,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 108,
+                                "end": 115,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 108,
+                                    "end": 112
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 112,
+                                    "end": 115,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 112,
+                                        "end": 115,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 113,
+                                            "end": 114,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 113,
+                                                "end": 114
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 116,
+                                "end": 119
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 120,
+                                "end": 123,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 120,
+                                    "end": 123
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/list_index.swift.json
+++ b/tests/json-ast/x/swift/list_index.swift.json
@@ -1,44 +1,162 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 91
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 116,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 91
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "xs"
-        }
+        "end": 92,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 80,
+            "end": 92,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 81,
+                "end": 83
+              },
+              {
+                "kind": "integer_literal",
+                "start": 85,
+                "end": 87
+              },
+              {
+                "kind": "integer_literal",
+                "start": 89,
+                "end": 91
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 93,
-          "end": 114
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 93,
-        "end": 114
+        "end": 115,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 93,
+            "end": 98
+          },
+          {
+            "kind": "call_suffix",
+            "start": 98,
+            "end": 115,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 98,
+                "end": 115,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 99,
+                    "end": 114,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 99,
+                        "end": 114,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 100,
+                            "end": 113,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 100,
+                                "end": 105,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 100,
+                                    "end": 102
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 102,
+                                    "end": 105,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 102,
+                                        "end": 105,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 103,
+                                            "end": 104,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 103,
+                                                "end": 104
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 106,
+                                "end": 109
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 110,
+                                "end": 113,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 110,
+                                    "end": 113
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/list_nested_assign.swift.json
+++ b/tests/json-ast/x/swift/list_nested_assign.swift.json
@@ -1,57 +1,304 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 99
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 148,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 99
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "matrix"
-        }
+        "end": 100,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 81,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 81
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 84,
+            "end": 100,
+            "children": [
+              {
+                "kind": "array_literal",
+                "start": 85,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "integer_literal",
+                    "start": 86,
+                    "end": 87
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 89,
+                    "end": 90
+                  }
+                ]
+              },
+              {
+                "kind": "array_literal",
+                "start": 93,
+                "end": 99,
+                "children": [
+                  {
+                    "kind": "integer_literal",
+                    "start": 94,
+                    "end": 95
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 97,
+                    "end": 98
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 101,
-          "end": 116
-        }
-      },
-      "range": {
+      {
+        "kind": "assignment",
         "start": 101,
-        "end": 116
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 118,
-          "end": 146
-        }
+        "end": 117,
+        "children": [
+          {
+            "kind": "directly_assignable_expression",
+            "start": 101,
+            "end": 113,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 101,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 101,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 101,
+                        "end": 107
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 107,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 107,
+                            "end": 110,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 108,
+                                "end": 109,
+                                "children": [
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 108,
+                                    "end": 109
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 110,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 110,
+                        "end": 113,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 111,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 111,
+                                "end": 112
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 116,
+            "end": 117
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 118,
-        "end": 146
+        "end": 147,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 118,
+            "end": 123
+          },
+          {
+            "kind": "call_suffix",
+            "start": 123,
+            "end": 147,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 123,
+                "end": 147,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 124,
+                    "end": 146,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 124,
+                        "end": 146,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 125,
+                            "end": 145,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 125,
+                                "end": 137,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 125,
+                                    "end": 134,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 125,
+                                        "end": 131
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 131,
+                                        "end": 134,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 131,
+                                            "end": 134,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 132,
+                                                "end": 133,
+                                                "children": [
+                                                  {
+                                                    "kind": "integer_literal",
+                                                    "start": 132,
+                                                    "end": 133
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 134,
+                                    "end": 137,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 134,
+                                        "end": 137,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 135,
+                                            "end": 136,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 135,
+                                                "end": 136
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 138,
+                                "end": 141
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 142,
+                                "end": 145,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 142,
+                                    "end": 145
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_assign.swift.json
+++ b/tests/json-ast/x/swift/map_assign.swift.json
@@ -1,57 +1,247 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 95
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 147,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 95
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "scores"
-        }
+        "end": 96,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 81,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 81
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 84,
+            "end": 96,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 85,
+                "end": 92,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 86,
+                    "end": 91
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 94,
+                "end": 95
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 97,
-          "end": 113
-        }
-      },
-      "range": {
+      {
+        "kind": "assignment",
         "start": 97,
-        "end": 113
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 115,
-          "end": 145
-        }
+        "end": 114,
+        "children": [
+          {
+            "kind": "directly_assignable_expression",
+            "start": 97,
+            "end": 110,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 97,
+                "end": 110,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 97,
+                    "end": 103
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 103,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 103,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 104,
+                            "end": 109,
+                            "children": [
+                              {
+                                "kind": "line_string_literal",
+                                "start": 104,
+                                "end": 109,
+                                "children": [
+                                  {
+                                    "kind": "line_str_text",
+                                    "start": 105,
+                                    "end": 108
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 113,
+            "end": 114
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 115,
-        "end": 145
+        "end": 146,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 115,
+            "end": 120
+          },
+          {
+            "kind": "call_suffix",
+            "start": 120,
+            "end": 146,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 120,
+                "end": 146,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 121,
+                    "end": 145,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 121,
+                        "end": 145,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 122,
+                            "end": 144,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 122,
+                                "end": 136,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 122,
+                                    "end": 135,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 122,
+                                        "end": 128
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 128,
+                                        "end": 135,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 128,
+                                            "end": 135,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 129,
+                                                "end": 134,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 129,
+                                                    "end": 134,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 130,
+                                                        "end": 133
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 135,
+                                    "end": 136
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 137,
+                                "end": 140
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 141,
+                                "end": 144,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 141,
+                                    "end": 144
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_in_operator.swift.json
+++ b/tests/json-ast/x/swift/map_in_operator.swift.json
@@ -1,57 +1,259 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 94
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 138,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 94
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 95,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 79,
+            "end": 95,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 80,
+                "end": 81
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 83,
+                "end": 86,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 84,
+                    "end": 85
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 88,
+                "end": 89
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 91,
+                "end": 94,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 92,
+                    "end": 93
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiSSXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 96,
-          "end": 115
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 96,
-        "end": 115
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 117,
-          "end": 136
-        }
+        "end": 116,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 96,
+            "end": 101
+          },
+          {
+            "kind": "call_suffix",
+            "start": 101,
+            "end": 116,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 101,
+                "end": 116,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 102,
+                    "end": 115,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 102,
+                        "end": 115,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 103,
+                            "end": 114,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 103,
+                                "end": 107,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 103,
+                                    "end": 104
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 104,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 104,
+                                        "end": 107,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 105,
+                                            "end": 106,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 105,
+                                                "end": 106
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 108,
+                                "end": 110
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 117,
-        "end": 136
+        "end": 137,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 117,
+            "end": 122
+          },
+          {
+            "kind": "call_suffix",
+            "start": 122,
+            "end": 137,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 122,
+                "end": 137,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 123,
+                    "end": 136,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 123,
+                        "end": 136,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 124,
+                            "end": 135,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 124,
+                                "end": 128,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 124,
+                                    "end": 125
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 125,
+                                    "end": 128,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 125,
+                                        "end": 128,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 126,
+                                            "end": 127,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 126,
+                                                "end": 127
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 129,
+                                "end": 131
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_index.swift.json
+++ b/tests/json-ast/x/swift/map_index.swift.json
@@ -1,44 +1,200 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 94
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 121,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 94
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 95,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 79,
+            "end": 95,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 80,
+                "end": 83,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 81,
+                    "end": 82
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 85,
+                "end": 86
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 88,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 89,
+                    "end": 90
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 93,
+                "end": 94
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 96,
-          "end": 119
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 96,
-        "end": 119
+        "end": 120,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 96,
+            "end": 101
+          },
+          {
+            "kind": "call_suffix",
+            "start": 101,
+            "end": 120,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 101,
+                "end": 120,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 102,
+                    "end": 119,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 102,
+                        "end": 119,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 103,
+                            "end": 118,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 103,
+                                "end": 110,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 103,
+                                    "end": 109,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 103,
+                                        "end": 104
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 104,
+                                        "end": 109,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 104,
+                                            "end": 109,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 105,
+                                                "end": 108,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 105,
+                                                    "end": 108,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 106,
+                                                        "end": 107
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 109,
+                                    "end": 110
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 111,
+                                "end": 114
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 115,
+                                "end": 118,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 115,
+                                    "end": 118
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_int_key.swift.json
+++ b/tests/json-ast/x/swift/map_int_key.swift.json
@@ -1,44 +1,193 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 94
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 122,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 94
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 95,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 79,
+            "end": 95,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 80,
+                "end": 81
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 83,
+                "end": 86,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 84,
+                    "end": 85
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 88,
+                "end": 89
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 91,
+                "end": 94,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 92,
+                    "end": 93
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiSSXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 96,
-          "end": 120
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 96,
-        "end": 120
+        "end": 121,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 96,
+            "end": 101
+          },
+          {
+            "kind": "call_suffix",
+            "start": 101,
+            "end": 121,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 101,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 102,
+                    "end": 120,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 102,
+                        "end": 120,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 103,
+                            "end": 119,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 103,
+                                "end": 108,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 103,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 103,
+                                        "end": 104
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 104,
+                                        "end": 107,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 104,
+                                            "end": 107,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 105,
+                                                "end": 106,
+                                                "children": [
+                                                  {
+                                                    "kind": "integer_literal",
+                                                    "start": 105,
+                                                    "end": 106
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 107,
+                                    "end": 108
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 109,
+                                "end": 112
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 113,
+                                "end": 119,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 113,
+                                    "end": 119
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_literal_dynamic.swift.json
+++ b/tests/json-ast/x/swift/map_literal_dynamic.swift.json
@@ -1,98 +1,415 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 180,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 89
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 81,
-        "end": 89
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "y"
-        }
+        "end": 90,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 81,
+            "end": 84
+          },
+          {
+            "kind": "pattern",
+            "start": 85,
+            "end": 86,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 86
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 89,
+            "end": 90
+          }
+        ]
       },
-      "range": {
-        "start": 85,
-        "end": 85
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 91,
-          "end": 134
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 91,
-        "end": 134
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 135,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 91,
+            "end": 94
+          },
+          {
+            "kind": "pattern",
+            "start": 95,
+            "end": 96,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 95,
+                "end": 96
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 99,
+            "end": 135,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 100,
+                "end": 103,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 101,
+                    "end": 102
+                  }
+                ]
+              },
+              {
+                "kind": "tuple_expression",
+                "start": 105,
+                "end": 116,
+                "children": [
+                  {
+                    "kind": "as_expression",
+                    "start": 106,
+                    "end": 115,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 106,
+                        "end": 107
+                      },
+                      {
+                        "kind": "as_operator",
+                        "start": 108,
+                        "end": 111
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 112,
+                        "end": 115,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 112,
+                            "end": 115
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 118,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 119,
+                    "end": 120
+                  }
+                ]
+              },
+              {
+                "kind": "tuple_expression",
+                "start": 123,
+                "end": 134,
+                "children": [
+                  {
+                    "kind": "as_expression",
+                    "start": 124,
+                    "end": 133,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 124,
+                        "end": 125
+                      },
+                      {
+                        "kind": "as_operator",
+                        "start": 126,
+                        "end": 129
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 130,
+                        "end": 133,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 130,
+                            "end": 133
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 95,
-        "end": 95
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 136,
-          "end": 178
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 136,
-        "end": 178
+        "end": 179,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 136,
+            "end": 141
+          },
+          {
+            "kind": "call_suffix",
+            "start": 141,
+            "end": 179,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 141,
+                "end": 179,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 142,
+                    "end": 159,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 142,
+                        "end": 159,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 143,
+                            "end": 158,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 143,
+                                "end": 150,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 143,
+                                    "end": 149,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 143,
+                                        "end": 144
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 144,
+                                        "end": 149,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 144,
+                                            "end": 149,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 145,
+                                                "end": 148,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 145,
+                                                    "end": 148,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 146,
+                                                        "end": 147
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 149,
+                                    "end": 150
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 151,
+                                "end": 154
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 155,
+                                "end": 158,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 155,
+                                    "end": 158
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 161,
+                    "end": 178,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 161,
+                        "end": 178,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 162,
+                            "end": 177,
+                            "children": [
+                              {
+                                "kind": "postfix_expression",
+                                "start": 162,
+                                "end": 169,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 162,
+                                    "end": 168,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 162,
+                                        "end": 163
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 163,
+                                        "end": 168,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 163,
+                                            "end": 168,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 164,
+                                                "end": 167,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 164,
+                                                    "end": 167,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 165,
+                                                        "end": 166
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "bang",
+                                    "start": 168,
+                                    "end": 169
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 170,
+                                "end": 173
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 174,
+                                "end": 177,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 174,
+                                    "end": 177
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/map_membership.swift.json
+++ b/tests/json-ast/x/swift/map_membership.swift.json
@@ -1,57 +1,273 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 94
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 142,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 94
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "m"
-        }
+        "end": 95,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 79,
+            "end": 95,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 80,
+                "end": 83,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 81,
+                    "end": 82
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 85,
+                "end": 86
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 88,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 89,
+                    "end": 90
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 93,
+                "end": 94
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSSiXSDD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 96,
-          "end": 117
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 96,
-        "end": 117
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 119,
-          "end": 140
-        }
+        "end": 118,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 96,
+            "end": 101
+          },
+          {
+            "kind": "call_suffix",
+            "start": 101,
+            "end": 118,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 101,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 102,
+                    "end": 117,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 102,
+                        "end": 117,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 103,
+                            "end": 116,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 103,
+                                "end": 109,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 103,
+                                    "end": 104
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 104,
+                                    "end": 109,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 104,
+                                        "end": 109,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 105,
+                                            "end": 108,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 105,
+                                                "end": 108,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 106,
+                                                    "end": 107
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 110,
+                                "end": 112
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 119,
-        "end": 140
+        "end": 141,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 119,
+            "end": 124
+          },
+          {
+            "kind": "call_suffix",
+            "start": 124,
+            "end": 141,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 124,
+                "end": 141,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 125,
+                    "end": 140,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 125,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "infix_expression",
+                            "start": 126,
+                            "end": 139,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 126,
+                                "end": 132,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 126,
+                                    "end": 127
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 127,
+                                    "end": 132,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 127,
+                                        "end": 132,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 128,
+                                            "end": 131,
+                                            "children": [
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 128,
+                                                "end": 131,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 129,
+                                                    "end": 130
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "custom_operator",
+                                "start": 133,
+                                "end": 135
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/match_expr.swift.json
+++ b/tests/json-ast/x/swift/match_expr.swift.json
@@ -1,71 +1,422 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 237,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 209
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 81,
-        "end": 209
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "label"
-        }
+        "end": 210,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 81,
+            "end": 84
+          },
+          {
+            "kind": "pattern",
+            "start": 85,
+            "end": 90,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 90
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 93,
+            "end": 210,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 94,
+                "end": 209,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 94,
+                    "end": 198,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 95,
+                        "end": 197,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 95,
+                            "end": 113,
+                            "children": [
+                              {
+                                "kind": "equality_expression",
+                                "start": 96,
+                                "end": 112,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 96,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 97,
+                                        "end": 106,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 97,
+                                            "end": 98
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 99,
+                                            "end": 102
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 103,
+                                            "end": 106,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 103,
+                                                "end": 106
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 111,
+                                    "end": 112
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 116,
+                            "end": 121,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 117,
+                                "end": 120
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 124,
+                            "end": 197,
+                            "children": [
+                              {
+                                "kind": "ternary_expression",
+                                "start": 125,
+                                "end": 196,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 125,
+                                    "end": 143,
+                                    "children": [
+                                      {
+                                        "kind": "equality_expression",
+                                        "start": 126,
+                                        "end": 142,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 126,
+                                            "end": 137,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 127,
+                                                "end": 136,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 127,
+                                                    "end": 128
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 129,
+                                                    "end": 132
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 133,
+                                                    "end": 136,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 133,
+                                                        "end": 136
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 141,
+                                            "end": 142
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 146,
+                                    "end": 151,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 147,
+                                        "end": 150
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 154,
+                                    "end": 196,
+                                    "children": [
+                                      {
+                                        "kind": "ternary_expression",
+                                        "start": 155,
+                                        "end": 195,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 155,
+                                            "end": 173,
+                                            "children": [
+                                              {
+                                                "kind": "equality_expression",
+                                                "start": 156,
+                                                "end": 172,
+                                                "children": [
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 156,
+                                                    "end": 167,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 157,
+                                                        "end": 166,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 157,
+                                                            "end": 158
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 159,
+                                                            "end": 162
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 163,
+                                                            "end": 166,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 163,
+                                                                "end": 166
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "integer_literal",
+                                                    "start": 171,
+                                                    "end": 172
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 176,
+                                            "end": 183,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 177,
+                                                "end": 182
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 186,
+                                            "end": 195,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 187,
+                                                "end": 194
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 199,
+                    "end": 202
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 203,
+                    "end": 209,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 203,
+                        "end": 209
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 85,
-        "end": 85
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 211,
-          "end": 235
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 211,
-        "end": 235
+        "end": 236,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 211,
+            "end": 216
+          },
+          {
+            "kind": "call_suffix",
+            "start": 216,
+            "end": 236,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 216,
+                "end": 236,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 217,
+                    "end": 235,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 217,
+                        "end": 235,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 218,
+                            "end": 234,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 218,
+                                "end": 223
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 224,
+                                "end": 227
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 228,
+                                "end": 234,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 228,
+                                    "end": 234
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/match_full.swift.json
+++ b/tests/json-ast/x/swift/match_full.swift.json
@@ -1,264 +1,1594 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 770,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
-      },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 209
-        }
-      },
-      "range": {
-        "start": 81,
-        "end": 209
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "label"
-        }
-      },
-      "range": {
-        "start": 85,
-        "end": 85
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 211,
-          "end": 235
-        }
-      },
-      "range": {
-        "start": 211,
-        "end": 235
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 237,
-          "end": 247
-        }
-      },
-      "range": {
-        "start": 237,
-        "end": 247
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "day"
-        }
-      },
-      "range": {
-        "start": 241,
-        "end": 241
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 253,
-          "end": 414
-        }
-      },
-      "range": {
-        "start": 253,
-        "end": 414
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "mood"
-        }
-      },
-      "range": {
-        "start": 257,
-        "end": 257
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 416,
-          "end": 439
-        }
-      },
-      "range": {
-        "start": 416,
-        "end": 439
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 441,
-          "end": 450
-        }
-      },
-      "range": {
-        "start": 441,
-        "end": 450
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "ok"
-        }
-      },
-      "range": {
-        "start": 445,
-        "end": 445
-      },
-      "interface_type": "$sSbD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 455,
-          "end": 565
-        }
-      },
-      "range": {
-        "start": 455,
-        "end": 565
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "status"
-        }
-      },
-      "range": {
-        "start": 459,
-        "end": 459
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 567,
-          "end": 592
-        }
-      },
-      "range": {
-        "start": 567,
-        "end": 592
-      }
-    },
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "classify"
-        }
-      },
-      "params": {
-        "params": [
+        "end": 80,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "n"
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 628,
-          "end": 704
-        }
+      {
+        "kind": "property_declaration",
+        "start": 81,
+        "end": 210,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 81,
+            "end": 84
+          },
+          {
+            "kind": "pattern",
+            "start": 85,
+            "end": 90,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 90
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 93,
+            "end": 210,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 94,
+                "end": 209,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 94,
+                    "end": 198,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 95,
+                        "end": 197,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 95,
+                            "end": 113,
+                            "children": [
+                              {
+                                "kind": "equality_expression",
+                                "start": 96,
+                                "end": 112,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 96,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 97,
+                                        "end": 106,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 97,
+                                            "end": 98
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 99,
+                                            "end": 102
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 103,
+                                            "end": 106,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 103,
+                                                "end": 106
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "integer_literal",
+                                    "start": 111,
+                                    "end": 112
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 116,
+                            "end": 121,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 117,
+                                "end": 120
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 124,
+                            "end": 197,
+                            "children": [
+                              {
+                                "kind": "ternary_expression",
+                                "start": 125,
+                                "end": 196,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 125,
+                                    "end": 143,
+                                    "children": [
+                                      {
+                                        "kind": "equality_expression",
+                                        "start": 126,
+                                        "end": 142,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 126,
+                                            "end": 137,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 127,
+                                                "end": 136,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 127,
+                                                    "end": 128
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 129,
+                                                    "end": 132
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 133,
+                                                    "end": 136,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 133,
+                                                        "end": 136
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 141,
+                                            "end": 142
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 146,
+                                    "end": 151,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 147,
+                                        "end": 150
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 154,
+                                    "end": 196,
+                                    "children": [
+                                      {
+                                        "kind": "ternary_expression",
+                                        "start": 155,
+                                        "end": 195,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 155,
+                                            "end": 173,
+                                            "children": [
+                                              {
+                                                "kind": "equality_expression",
+                                                "start": 156,
+                                                "end": 172,
+                                                "children": [
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 156,
+                                                    "end": 167,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 157,
+                                                        "end": 166,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 157,
+                                                            "end": 158
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 159,
+                                                            "end": 162
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 163,
+                                                            "end": 166,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 163,
+                                                                "end": 166
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "integer_literal",
+                                                    "start": 171,
+                                                    "end": 172
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 176,
+                                            "end": 183,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 177,
+                                                "end": 182
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 186,
+                                            "end": 195,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 187,
+                                                "end": 194
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 199,
+                    "end": 202
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 203,
+                    "end": 209,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 203,
+                        "end": 209
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
+        "start": 211,
+        "end": 236,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 211,
+            "end": 216
+          },
+          {
+            "kind": "call_suffix",
+            "start": 216,
+            "end": 236,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 216,
+                "end": 236,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 217,
+                    "end": 235,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 217,
+                        "end": 235,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 218,
+                            "end": 234,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 218,
+                                "end": 223
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 224,
+                                "end": 227
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 228,
+                                "end": 234,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 228,
+                                    "end": 234
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 237,
+        "end": 252,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 237,
+            "end": 240
+          },
+          {
+            "kind": "pattern",
+            "start": 241,
+            "end": 244,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 241,
+                "end": 244
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 247,
+            "end": 252,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 248,
+                "end": 251
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 253,
+        "end": 415,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 253,
+            "end": 256
+          },
+          {
+            "kind": "pattern",
+            "start": 257,
+            "end": 261,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 257,
+                "end": 261
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 264,
+            "end": 415,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 265,
+                "end": 414,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 265,
+                    "end": 403,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 266,
+                        "end": 402,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 266,
+                            "end": 293,
+                            "children": [
+                              {
+                                "kind": "equality_expression",
+                                "start": 267,
+                                "end": 292,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 267,
+                                    "end": 283,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 268,
+                                        "end": 282,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 268,
+                                            "end": 271
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 272,
+                                            "end": 275
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 276,
+                                            "end": 282,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 276,
+                                                "end": 282
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 287,
+                                    "end": 292,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 288,
+                                        "end": 291
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 296,
+                            "end": 303,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 297,
+                                "end": 302
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 306,
+                            "end": 402,
+                            "children": [
+                              {
+                                "kind": "ternary_expression",
+                                "start": 307,
+                                "end": 401,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 307,
+                                    "end": 334,
+                                    "children": [
+                                      {
+                                        "kind": "equality_expression",
+                                        "start": 308,
+                                        "end": 333,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 308,
+                                            "end": 324,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 309,
+                                                "end": 323,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 309,
+                                                    "end": 312
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 313,
+                                                    "end": 316
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 317,
+                                                    "end": 323,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 317,
+                                                        "end": 323
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 328,
+                                            "end": 333,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 329,
+                                                "end": 332
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 337,
+                                    "end": 346,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 338,
+                                        "end": 345
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 349,
+                                    "end": 401,
+                                    "children": [
+                                      {
+                                        "kind": "ternary_expression",
+                                        "start": 350,
+                                        "end": 400,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 350,
+                                            "end": 377,
+                                            "children": [
+                                              {
+                                                "kind": "equality_expression",
+                                                "start": 351,
+                                                "end": 376,
+                                                "children": [
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 351,
+                                                    "end": 367,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 352,
+                                                        "end": 366,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 352,
+                                                            "end": 355
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 356,
+                                                            "end": 359
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 360,
+                                                            "end": 366,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 360,
+                                                                "end": 366
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 371,
+                                                    "end": 376,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 372,
+                                                        "end": 375
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 380,
+                                            "end": 389,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 381,
+                                                "end": 388
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 392,
+                                            "end": 400,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 393,
+                                                "end": 399
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 404,
+                    "end": 407
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 408,
+                    "end": 414,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 408,
+                        "end": 414
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 416,
+        "end": 440,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 416,
+            "end": 421
+          },
+          {
+            "kind": "call_suffix",
+            "start": 421,
+            "end": 440,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 421,
+                "end": 440,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 422,
+                    "end": 439,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 422,
+                        "end": 439,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 423,
+                            "end": 438,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 423,
+                                "end": 427
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 428,
+                                "end": 431
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 432,
+                                "end": 438,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 432,
+                                    "end": 438
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 441,
+        "end": 454,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 441,
+            "end": 444
+          },
+          {
+            "kind": "pattern",
+            "start": 445,
+            "end": 447,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 445,
+                "end": 447
+              }
+            ]
+          },
+          {
+            "kind": "boolean_literal",
+            "start": 450,
+            "end": 454
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 455,
+        "end": 566,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 455,
+            "end": 458
+          },
+          {
+            "kind": "pattern",
+            "start": 459,
+            "end": 465,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 459,
+                "end": 465
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 468,
+            "end": 566,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 469,
+                "end": 565,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 469,
+                    "end": 554,
+                    "children": [
+                      {
+                        "kind": "ternary_expression",
+                        "start": 470,
+                        "end": 553,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 470,
+                            "end": 493,
+                            "children": [
+                              {
+                                "kind": "equality_expression",
+                                "start": 471,
+                                "end": 492,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 471,
+                                    "end": 484,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 472,
+                                        "end": 483,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 472,
+                                            "end": 474
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 475,
+                                            "end": 478
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 479,
+                                            "end": 483,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 479,
+                                                "end": 483
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "boolean_literal",
+                                    "start": 488,
+                                    "end": 492
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "line_string_literal",
+                            "start": 496,
+                            "end": 507,
+                            "children": [
+                              {
+                                "kind": "line_str_text",
+                                "start": 497,
+                                "end": 506
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "tuple_expression",
+                            "start": 510,
+                            "end": 553,
+                            "children": [
+                              {
+                                "kind": "ternary_expression",
+                                "start": 511,
+                                "end": 552,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 511,
+                                    "end": 535,
+                                    "children": [
+                                      {
+                                        "kind": "equality_expression",
+                                        "start": 512,
+                                        "end": 534,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 512,
+                                            "end": 525,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 513,
+                                                "end": 524,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 513,
+                                                    "end": 515
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 516,
+                                                    "end": 519
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 520,
+                                                    "end": 524,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 520,
+                                                        "end": 524
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "boolean_literal",
+                                            "start": 529,
+                                            "end": 534
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 538,
+                                    "end": 546,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 539,
+                                        "end": 545
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 555,
+                    "end": 558
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 559,
+                    "end": 565,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 559,
+                        "end": 565
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 567,
+        "end": 593,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 567,
+            "end": 572
+          },
+          {
+            "kind": "call_suffix",
+            "start": 572,
+            "end": 593,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 572,
+                "end": 593,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 573,
+                    "end": 592,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 573,
+                        "end": 592,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 574,
+                            "end": 591,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 574,
+                                "end": 580
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 581,
+                                "end": 584
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 585,
+                                "end": 591,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 585,
+                                    "end": 591
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_declaration",
         "start": 594,
-        "end": 704
+        "end": 705,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 599,
+            "end": 607
+          },
+          {
+            "kind": "parameter",
+            "start": 608,
+            "end": 616,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 608,
+                "end": 609
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 610,
+                "end": 611
+              },
+              {
+                "kind": "user_type",
+                "start": 613,
+                "end": 616,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 613,
+                    "end": 616
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 621,
+            "end": 627,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 621,
+                "end": 627
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 628,
+            "end": 705,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 634,
+                "end": 704,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 634,
+                    "end": 703,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 641,
+                        "end": 703,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 642,
+                            "end": 702,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 642,
+                                "end": 691,
+                                "children": [
+                                  {
+                                    "kind": "ternary_expression",
+                                    "start": 643,
+                                    "end": 690,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 643,
+                                        "end": 651,
+                                        "children": [
+                                          {
+                                            "kind": "equality_expression",
+                                            "start": 644,
+                                            "end": 650,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 644,
+                                                "end": 645
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 649,
+                                                "end": 650
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "line_string_literal",
+                                        "start": 654,
+                                        "end": 660,
+                                        "children": [
+                                          {
+                                            "kind": "line_str_text",
+                                            "start": 655,
+                                            "end": 659
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 663,
+                                        "end": 690,
+                                        "children": [
+                                          {
+                                            "kind": "ternary_expression",
+                                            "start": 664,
+                                            "end": 689,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 664,
+                                                "end": 672,
+                                                "children": [
+                                                  {
+                                                    "kind": "equality_expression",
+                                                    "start": 665,
+                                                    "end": 671,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 665,
+                                                        "end": 666
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 670,
+                                                        "end": 671
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 675,
+                                                "end": 680,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 676,
+                                                    "end": 679
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "line_string_literal",
+                                                "start": 683,
+                                                "end": 689,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_str_text",
+                                                    "start": 684,
+                                                    "end": 688
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 692,
+                                "end": 695
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 696,
+                                "end": 702,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 696,
+                                    "end": 702
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "result": "$sSSD",
-      "interface_type": "$sySSSicD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 706,
-          "end": 736
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 706,
-        "end": 736
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 738,
-          "end": 768
-        }
+        "end": 737,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 706,
+            "end": 711
+          },
+          {
+            "kind": "call_suffix",
+            "start": 711,
+            "end": 737,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 711,
+                "end": 737,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 712,
+                    "end": 736,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 712,
+                        "end": 736,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 713,
+                            "end": 735,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 713,
+                                "end": 724,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 713,
+                                    "end": 721
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 721,
+                                    "end": 724,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 721,
+                                        "end": 724,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 722,
+                                            "end": 723,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 722,
+                                                "end": 723
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 725,
+                                "end": 728
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 729,
+                                "end": 735,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 729,
+                                    "end": 735
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 738,
-        "end": 768
+        "end": 769,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 738,
+            "end": 743
+          },
+          {
+            "kind": "call_suffix",
+            "start": 743,
+            "end": 769,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 743,
+                "end": 769,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 744,
+                    "end": 768,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 744,
+                        "end": 768,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 745,
+                            "end": 767,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 745,
+                                "end": 756,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 745,
+                                    "end": 753
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 753,
+                                    "end": 756,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 753,
+                                        "end": 756,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 754,
+                                            "end": 755,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 754,
+                                                "end": 755
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 757,
+                                "end": 760
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 761,
+                                "end": 767,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 761,
+                                    "end": 767
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/math_ops.swift.json
+++ b/tests/json-ast/x/swift/math_ops.swift.json
@@ -1,43 +1,128 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 99,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 88
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 80,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 80,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 79,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 79
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 81,
-        "end": 88
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 97
-        }
+        "end": 89,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 81,
+            "end": 86
+          },
+          {
+            "kind": "call_suffix",
+            "start": 86,
+            "end": 89,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 86,
+                "end": 89,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 87,
+                    "end": 88,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 87,
+                        "end": 88
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 90,
-        "end": 97
+        "end": 98,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 90,
+            "end": 95
+          },
+          {
+            "kind": "call_suffix",
+            "start": 95,
+            "end": 98,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 95,
+                "end": 98,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 96,
+                    "end": 97,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 96,
+                        "end": 97
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/membership.swift.json
+++ b/tests/json-ast/x/swift/membership.swift.json
@@ -1,57 +1,254 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 90
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 144,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 90
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "nums"
-        }
+        "end": 91,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 79,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 79
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 82,
+            "end": 91,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              },
+              {
+                "kind": "integer_literal",
+                "start": 89,
+                "end": 90
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 92,
-          "end": 116
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 92,
-        "end": 116
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 118,
-          "end": 142
-        }
+        "end": 117,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 92,
+            "end": 97
+          },
+          {
+            "kind": "call_suffix",
+            "start": 97,
+            "end": 117,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 97,
+                "end": 117,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 98,
+                    "end": 116,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 98,
+                        "end": 116,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 99,
+                            "end": 115,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 99,
+                                "end": 112,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 99,
+                                    "end": 103
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 103,
+                                    "end": 112,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 104,
+                                        "end": 112
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 112,
+                                "end": 115,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 112,
+                                    "end": 115,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 113,
+                                        "end": 114,
+                                        "children": [
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 113,
+                                            "end": 114
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 118,
-        "end": 142
+        "end": 143,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 118,
+            "end": 123
+          },
+          {
+            "kind": "call_suffix",
+            "start": 123,
+            "end": 143,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 123,
+                "end": 143,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 124,
+                    "end": 142,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 124,
+                        "end": 142,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 125,
+                            "end": 141,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 125,
+                                "end": 138,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 125,
+                                    "end": 129
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 129,
+                                    "end": 138,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 130,
+                                        "end": 138
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 138,
+                                "end": 141,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 138,
+                                    "end": 141,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 139,
+                                        "end": 140,
+                                        "children": [
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 139,
+                                            "end": 140
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/min_max_builtin.swift.json
+++ b/tests/json-ast/x/swift/min_max_builtin.swift.json
@@ -1,57 +1,312 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 90
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 154,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 90
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "nums"
-        }
+        "end": 91,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 79,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 79
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 82,
+            "end": 91,
+            "children": [
+              {
+                "kind": "integer_literal",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "integer_literal",
+                "start": 86,
+                "end": 87
+              },
+              {
+                "kind": "integer_literal",
+                "start": 89,
+                "end": 90
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 92,
-          "end": 121
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 92,
-        "end": 121
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 123,
-          "end": 152
-        }
+        "end": 122,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 92,
+            "end": 97
+          },
+          {
+            "kind": "call_suffix",
+            "start": 97,
+            "end": 122,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 97,
+                "end": 122,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 98,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 98,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 99,
+                            "end": 120,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 99,
+                                "end": 112,
+                                "children": [
+                                  {
+                                    "kind": "postfix_expression",
+                                    "start": 100,
+                                    "end": 111,
+                                    "children": [
+                                      {
+                                        "kind": "call_expression",
+                                        "start": 100,
+                                        "end": 110,
+                                        "children": [
+                                          {
+                                            "kind": "navigation_expression",
+                                            "start": 100,
+                                            "end": 108,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 100,
+                                                "end": 104
+                                              },
+                                              {
+                                                "kind": "navigation_suffix",
+                                                "start": 104,
+                                                "end": 108,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 105,
+                                                    "end": 108
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "call_suffix",
+                                            "start": 108,
+                                            "end": 110,
+                                            "children": [
+                                              {
+                                                "kind": "value_arguments",
+                                                "start": 108,
+                                                "end": 110
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "bang",
+                                        "start": 110,
+                                        "end": 111
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 113,
+                                "end": 116
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 117,
+                                "end": 120,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 117,
+                                    "end": 120
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 123,
-        "end": 152
+        "end": 153,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 123,
+            "end": 128
+          },
+          {
+            "kind": "call_suffix",
+            "start": 128,
+            "end": 153,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 128,
+                "end": 153,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 129,
+                    "end": 152,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 129,
+                        "end": 152,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 130,
+                            "end": 151,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 130,
+                                "end": 143,
+                                "children": [
+                                  {
+                                    "kind": "postfix_expression",
+                                    "start": 131,
+                                    "end": 142,
+                                    "children": [
+                                      {
+                                        "kind": "call_expression",
+                                        "start": 131,
+                                        "end": 141,
+                                        "children": [
+                                          {
+                                            "kind": "navigation_expression",
+                                            "start": 131,
+                                            "end": 139,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 131,
+                                                "end": 135
+                                              },
+                                              {
+                                                "kind": "navigation_suffix",
+                                                "start": 135,
+                                                "end": 139,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 136,
+                                                    "end": 139
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "call_suffix",
+                                            "start": 139,
+                                            "end": 141,
+                                            "children": [
+                                              {
+                                                "kind": "value_arguments",
+                                                "start": 139,
+                                                "end": 141
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "bang",
+                                        "start": 141,
+                                        "end": 142
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 144,
+                                "end": 147
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 148,
+                                "end": 151,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 148,
+                                    "end": 151
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/nested_function.swift.json
+++ b/tests/json-ast/x/swift/nested_function.swift.json
@@ -1,50 +1,326 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "outer"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 212,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 185,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "x"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 81
+          },
+          {
+            "kind": "parameter",
+            "start": 82,
+            "end": 90,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 82,
+                "end": 83
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 84,
+                "end": 85
+              },
+              {
+                "kind": "user_type",
+                "start": 87,
+                "end": 90,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 87,
+                    "end": 90
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 95,
+            "end": 98,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 95,
+                "end": 98
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 99,
+            "end": 185,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 105,
+                "end": 184,
+                "children": [
+                  {
+                    "kind": "function_declaration",
+                    "start": 105,
+                    "end": 163,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 110,
+                        "end": 115
+                      },
+                      {
+                        "kind": "parameter",
+                        "start": 116,
+                        "end": 124,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 116,
+                            "end": 117
+                          },
+                          {
+                            "kind": "simple_identifier",
+                            "start": 118,
+                            "end": 119
+                          },
+                          {
+                            "kind": "user_type",
+                            "start": 121,
+                            "end": 124,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 121,
+                                "end": 124
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 129,
+                        "end": 132,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 129,
+                            "end": 132
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "function_body",
+                        "start": 133,
+                        "end": 163,
+                        "children": [
+                          {
+                            "kind": "statements",
+                            "start": 143,
+                            "end": 162,
+                            "children": [
+                              {
+                                "kind": "control_transfer_statement",
+                                "start": 143,
+                                "end": 157,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 150,
+                                    "end": 157,
+                                    "children": [
+                                      {
+                                        "kind": "additive_expression",
+                                        "start": 151,
+                                        "end": 156,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 151,
+                                            "end": 152
+                                          },
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 155,
+                                            "end": 156
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 168,
+                    "end": 183,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 175,
+                        "end": 183,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 175,
+                            "end": 180
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 180,
+                            "end": 183,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 180,
+                                "end": 183,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 181,
+                                    "end": 182,
+                                    "children": [
+                                      {
+                                        "kind": "integer_literal",
+                                        "start": 181,
+                                        "end": 182
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 99,
-          "end": 184
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 184
-      },
-      "result": "$sSiD",
-      "interface_type": "$syS2icD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 186,
-          "end": 210
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 186,
-        "end": 210
+        "end": 211,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 186,
+            "end": 191
+          },
+          {
+            "kind": "call_suffix",
+            "start": 191,
+            "end": 211,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 191,
+                "end": 211,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 192,
+                    "end": 210,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 192,
+                        "end": 210,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 193,
+                            "end": 209,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 193,
+                                "end": 201,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 193,
+                                    "end": 198
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 198,
+                                    "end": 201,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 198,
+                                        "end": 201,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 199,
+                                            "end": 200,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 199,
+                                                "end": 200
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 202,
+                                "end": 205
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 206,
+                                "end": 209,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 206,
+                                    "end": 209
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/order_by_map.swift.json
+++ b/tests/json-ast/x/swift/order_by_map.swift.json
@@ -1,78 +1,1256 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 537,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 154
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 154
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "data"
-        }
+        "end": 155,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 98,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 98
+              }
+            ]
+          },
+          {
+            "kind": "array_literal",
+            "start": 101,
+            "end": 155,
+            "children": [
+              {
+                "kind": "dictionary_literal",
+                "start": 102,
+                "end": 118,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 103,
+                    "end": 106,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 104,
+                        "end": 105
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 108,
+                    "end": 109
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 111,
+                    "end": 114,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 112,
+                        "end": 113
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 116,
+                    "end": 117
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 120,
+                "end": 136,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 121,
+                    "end": 124,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 122,
+                        "end": 123
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 126,
+                    "end": 127
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 129,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 130,
+                        "end": 131
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 134,
+                    "end": 135
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 138,
+                "end": 154,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 139,
+                    "end": 142,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 140,
+                        "end": 141
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 144,
+                    "end": 145
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 147,
+                    "end": 150,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 148,
+                        "end": 149
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 152,
+                    "end": 153
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 156,
-          "end": 501
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 156,
-        "end": 501
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "sorted"
-        }
+        "end": 502,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 156,
+            "end": 159
+          },
+          {
+            "kind": "pattern",
+            "start": 160,
+            "end": 166,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 160,
+                "end": 166
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 169,
+            "end": 502,
+            "children": [
+              {
+                "kind": "tuple_expression",
+                "start": 169,
+                "end": 500,
+                "children": [
+                  {
+                    "kind": "lambda_literal",
+                    "start": 170,
+                    "end": 499,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 172,
+                        "end": 497,
+                        "children": [
+                          {
+                            "kind": "property_declaration",
+                            "start": 172,
+                            "end": 202,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 172,
+                                "end": 175
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 176,
+                                "end": 180,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 176,
+                                    "end": 180
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "type_annotation",
+                                "start": 180,
+                                "end": 197,
+                                "children": [
+                                  {
+                                    "kind": "array_type",
+                                    "start": 182,
+                                    "end": 197,
+                                    "children": [
+                                      {
+                                        "kind": "dictionary_type",
+                                        "start": 183,
+                                        "end": 196,
+                                        "children": [
+                                          {
+                                            "kind": "user_type",
+                                            "start": 184,
+                                            "end": 190,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 184,
+                                                "end": 190
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 192,
+                                            "end": 195,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 192,
+                                                "end": 195
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "array_literal",
+                                "start": 200,
+                                "end": 202
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "for_statement",
+                            "start": 203,
+                            "end": 239,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 207,
+                                "end": 208,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 207,
+                                    "end": 208
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 212,
+                                "end": 216
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 223,
+                                "end": 238,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 223,
+                                    "end": 237,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 223,
+                                        "end": 234,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 223,
+                                            "end": 227
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 227,
+                                            "end": 234,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 228,
+                                                "end": 234
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 234,
+                                        "end": 237,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 234,
+                                            "end": 237,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 235,
+                                                "end": 236,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 235,
+                                                    "end": 236
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "property_declaration",
+                            "start": 240,
+                            "end": 256,
+                            "children": [
+                              {
+                                "kind": "value_binding_pattern",
+                                "start": 240,
+                                "end": 243
+                              },
+                              {
+                                "kind": "pattern",
+                                "start": 244,
+                                "end": 249,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 244,
+                                    "end": 249
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "simple_identifier",
+                                "start": 252,
+                                "end": 256
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_expression",
+                            "start": 257,
+                            "end": 484,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 257,
+                                "end": 267,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 257,
+                                    "end": 262
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 262,
+                                    "end": 267,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 263,
+                                        "end": 267
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 268,
+                                "end": 484,
+                                "children": [
+                                  {
+                                    "kind": "lambda_literal",
+                                    "start": 268,
+                                    "end": 484,
+                                    "children": [
+                                      {
+                                        "kind": "lambda_function_type",
+                                        "start": 270,
+                                        "end": 281,
+                                        "children": [
+                                          {
+                                            "kind": "lambda_function_type_parameters",
+                                            "start": 270,
+                                            "end": 281,
+                                            "children": [
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 270,
+                                                "end": 274,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 270,
+                                                    "end": 274
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "lambda_parameter",
+                                                "start": 276,
+                                                "end": 281,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 276,
+                                                    "end": 281
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 285,
+                                        "end": 483,
+                                        "children": [
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 285,
+                                            "end": 297,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 285,
+                                                "end": 288
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 289,
+                                                "end": 290,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 289,
+                                                    "end": 290
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 293,
+                                                "end": 297
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 298,
+                                            "end": 356,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 298,
+                                                "end": 301
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 302,
+                                                "end": 305,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 302,
+                                                    "end": 305
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "dictionary_literal",
+                                                "start": 308,
+                                                "end": 356,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 309,
+                                                    "end": 312,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 310,
+                                                        "end": 311
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 314,
+                                                    "end": 331,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 315,
+                                                        "end": 330,
+                                                        "children": [
+                                                          {
+                                                            "kind": "postfix_expression",
+                                                            "start": 315,
+                                                            "end": 322,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 315,
+                                                                "end": 321,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 315,
+                                                                    "end": 316
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 316,
+                                                                    "end": 321,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 316,
+                                                                        "end": 321,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 317,
+                                                                            "end": 320,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 317,
+                                                                                "end": 320,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 318,
+                                                                                    "end": 319
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "bang",
+                                                                "start": 321,
+                                                                "end": 322
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 323,
+                                                            "end": 326
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 327,
+                                                            "end": 330,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 327,
+                                                                "end": 330
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 333,
+                                                    "end": 336,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 334,
+                                                        "end": 335
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 338,
+                                                    "end": 355,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 339,
+                                                        "end": 354,
+                                                        "children": [
+                                                          {
+                                                            "kind": "postfix_expression",
+                                                            "start": 339,
+                                                            "end": 346,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 339,
+                                                                "end": 345,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 339,
+                                                                    "end": 340
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 340,
+                                                                    "end": 345,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 340,
+                                                                        "end": 345,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 341,
+                                                                            "end": 344,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 341,
+                                                                                "end": 344,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 342,
+                                                                                    "end": 343
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "bang",
+                                                                "start": 345,
+                                                                "end": 346
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 347,
+                                                            "end": 350
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 351,
+                                                            "end": 354,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 351,
+                                                                "end": 354
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "assignment",
+                                            "start": 357,
+                                            "end": 366,
+                                            "children": [
+                                              {
+                                                "kind": "directly_assignable_expression",
+                                                "start": 357,
+                                                "end": 358,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 357,
+                                                    "end": 358
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 361,
+                                                "end": 366
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "property_declaration",
+                                            "start": 367,
+                                            "end": 425,
+                                            "children": [
+                                              {
+                                                "kind": "value_binding_pattern",
+                                                "start": 367,
+                                                "end": 370
+                                              },
+                                              {
+                                                "kind": "pattern",
+                                                "start": 371,
+                                                "end": 374,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 371,
+                                                    "end": 374
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "dictionary_literal",
+                                                "start": 377,
+                                                "end": 425,
+                                                "children": [
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 378,
+                                                    "end": 381,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 379,
+                                                        "end": 380
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 383,
+                                                    "end": 400,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 384,
+                                                        "end": 399,
+                                                        "children": [
+                                                          {
+                                                            "kind": "postfix_expression",
+                                                            "start": 384,
+                                                            "end": 391,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 384,
+                                                                "end": 390,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 384,
+                                                                    "end": 385
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 385,
+                                                                    "end": 390,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 385,
+                                                                        "end": 390,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 386,
+                                                                            "end": 389,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 386,
+                                                                                "end": 389,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 387,
+                                                                                    "end": 388
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "bang",
+                                                                "start": 390,
+                                                                "end": 391
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 392,
+                                                            "end": 395
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 396,
+                                                            "end": 399,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 396,
+                                                                "end": 399
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "line_string_literal",
+                                                    "start": 402,
+                                                    "end": 405,
+                                                    "children": [
+                                                      {
+                                                        "kind": "line_str_text",
+                                                        "start": 403,
+                                                        "end": 404
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "tuple_expression",
+                                                    "start": 407,
+                                                    "end": 424,
+                                                    "children": [
+                                                      {
+                                                        "kind": "as_expression",
+                                                        "start": 408,
+                                                        "end": 423,
+                                                        "children": [
+                                                          {
+                                                            "kind": "postfix_expression",
+                                                            "start": 408,
+                                                            "end": 415,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 408,
+                                                                "end": 414,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 408,
+                                                                    "end": 409
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 409,
+                                                                    "end": 414,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 409,
+                                                                        "end": 414,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 410,
+                                                                            "end": 413,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_string_literal",
+                                                                                "start": 410,
+                                                                                "end": 413,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "line_str_text",
+                                                                                    "start": 411,
+                                                                                    "end": 412
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "bang",
+                                                                "start": 414,
+                                                                "end": 415
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "as_operator",
+                                                            "start": 416,
+                                                            "end": 419
+                                                          },
+                                                          {
+                                                            "kind": "user_type",
+                                                            "start": 420,
+                                                            "end": 423,
+                                                            "children": [
+                                                              {
+                                                                "kind": "type_identifier",
+                                                                "start": 420,
+                                                                "end": 423
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "control_transfer_statement",
+                                            "start": 426,
+                                            "end": 482,
+                                            "children": [
+                                              {
+                                                "kind": "comparison_expression",
+                                                "start": 433,
+                                                "end": 482,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 433,
+                                                    "end": 456,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 433,
+                                                        "end": 439
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 439,
+                                                        "end": 456,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 439,
+                                                            "end": 456,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 440,
+                                                                "end": 455,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument_label",
+                                                                    "start": 440,
+                                                                    "end": 450,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 440,
+                                                                        "end": 450
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 452,
+                                                                    "end": 455
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 459,
+                                                    "end": 482,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 459,
+                                                        "end": 465
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 465,
+                                                        "end": 482,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 465,
+                                                            "end": 482,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 466,
+                                                                "end": 481,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument_label",
+                                                                    "start": 466,
+                                                                    "end": 476,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 466,
+                                                                        "end": 476
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 478,
+                                                                    "end": 481
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 485,
+                            "end": 497,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 492,
+                                "end": 497
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "call_suffix",
+                "start": 500,
+                "end": 502,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 500,
+                    "end": 502
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 160,
-        "end": 160
-      },
-      "interface_type": "$sSSSiXSDXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 503,
-          "end": 535
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 503,
-        "end": 535
+        "end": 536,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 503,
+            "end": 508
+          },
+          {
+            "kind": "call_suffix",
+            "start": 508,
+            "end": 536,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 508,
+                "end": 536,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 509,
+                    "end": 535,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 509,
+                        "end": 535,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 509,
+                            "end": 515
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 515,
+                            "end": 535,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 515,
+                                "end": 535,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 516,
+                                    "end": 534,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument_label",
+                                        "start": 516,
+                                        "end": 526,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 516,
+                                            "end": 526
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 528,
+                                        "end": 534
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/print_hello.swift.json
+++ b/tests/json-ast/x/swift/print_hello.swift.json
@@ -1,17 +1,59 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 84
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 86,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 84
+        "end": 85,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 85,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 85,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 84,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 77,
+                        "end": 84,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 78,
+                            "end": 83
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/pure_fold.swift.json
+++ b/tests/json-ast/x/swift/pure_fold.swift.json
@@ -1,50 +1,233 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "triple"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 156,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 122,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "x"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 82
+          },
+          {
+            "kind": "parameter",
+            "start": 83,
+            "end": 91,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 86
+              },
+              {
+                "kind": "user_type",
+                "start": 88,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 88,
+                    "end": 91
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 96,
+            "end": 99,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 96,
+                "end": 99
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 100,
+            "end": 122,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 106,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 106,
+                    "end": 120,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 113,
+                        "end": 120,
+                        "children": [
+                          {
+                            "kind": "multiplicative_expression",
+                            "start": 114,
+                            "end": 119,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 114,
+                                "end": 115
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 118,
+                                "end": 119
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 100,
-          "end": 121
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 121
-      },
-      "result": "$sSiD",
-      "interface_type": "$syS2icD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 123,
-          "end": 154
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 123,
-        "end": 154
+        "end": 155,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 123,
+            "end": 128
+          },
+          {
+            "kind": "call_suffix",
+            "start": 128,
+            "end": 155,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 128,
+                "end": 155,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 129,
+                    "end": 154,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 129,
+                        "end": 154,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 130,
+                            "end": 153,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 130,
+                                "end": 145,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 130,
+                                    "end": 136
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 136,
+                                    "end": 145,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 136,
+                                        "end": 145,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 137,
+                                            "end": 144,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 137,
+                                                "end": 144,
+                                                "children": [
+                                                  {
+                                                    "kind": "additive_expression",
+                                                    "start": 138,
+                                                    "end": 143,
+                                                    "children": [
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 138,
+                                                        "end": 139
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 142,
+                                                        "end": 143
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 146,
+                                "end": 149
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 150,
+                                "end": 153,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 150,
+                                    "end": 153
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/pure_global_fold.swift.json
+++ b/tests/json-ast/x/swift/pure_global_fold.swift.json
@@ -1,77 +1,274 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 164,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "k"
-        }
-      },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "inc"
-        }
-      },
-      "params": {
-        "params": [
+        "end": 80,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "x"
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 107,
-          "end": 138
-        }
-      },
-      "range": {
+      {
+        "kind": "function_declaration",
         "start": 81,
-        "end": 138
+        "end": 139,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 86,
+            "end": 89
+          },
+          {
+            "kind": "parameter",
+            "start": 90,
+            "end": 98,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 90,
+                "end": 91
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 92,
+                "end": 93
+              },
+              {
+                "kind": "user_type",
+                "start": 95,
+                "end": 98,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 95,
+                    "end": 98
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 103,
+            "end": 106,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 103,
+                "end": 106
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 107,
+            "end": 139,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 113,
+                "end": 138,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 113,
+                    "end": 137,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 120,
+                        "end": 137,
+                        "children": [
+                          {
+                            "kind": "additive_expression",
+                            "start": 121,
+                            "end": 136,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 121,
+                                "end": 122
+                              },
+                              {
+                                "kind": "tuple_expression",
+                                "start": 125,
+                                "end": 136,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 126,
+                                    "end": 135,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 126,
+                                        "end": 127
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 128,
+                                        "end": 131
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 132,
+                                        "end": 135,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 132,
+                                            "end": 135
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "result": "$sSiD",
-      "interface_type": "$syS2icD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 140,
-          "end": 162
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 140,
-        "end": 162
+        "end": 163,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 140,
+            "end": 145
+          },
+          {
+            "kind": "call_suffix",
+            "start": 145,
+            "end": 163,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 145,
+                "end": 163,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 146,
+                    "end": 162,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 146,
+                        "end": 162,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 147,
+                            "end": 161,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 147,
+                                "end": 153,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 147,
+                                    "end": 150
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 150,
+                                    "end": 153,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 150,
+                                        "end": 153,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 151,
+                                            "end": 152,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 151,
+                                                "end": 152
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 154,
+                                "end": 157
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 158,
+                                "end": 161,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 158,
+                                    "end": 161
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/python_auto.swift.json
+++ b/tests/json-ast/x/swift/python_auto.swift.json
@@ -1,0 +1,402 @@
+{
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 248,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
+        "start": 71,
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 90,
+        "end": 209,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 97,
+            "end": 101
+          },
+          {
+            "kind": "class_body",
+            "start": 102,
+            "end": 209,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 108,
+                "end": 177,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 108,
+                    "end": 114,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 108,
+                        "end": 114
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 120,
+                    "end": 124
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 125,
+                    "end": 136,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 125,
+                        "end": 126
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 127,
+                        "end": 128
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 130,
+                        "end": 136,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 130,
+                            "end": 136
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 141,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 141,
+                        "end": 147
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 148,
+                    "end": 177,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 150,
+                        "end": 175,
+                        "children": [
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 150,
+                            "end": 175,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 157,
+                                "end": 175,
+                                "children": [
+                                  {
+                                    "kind": "navigation_expression",
+                                    "start": 157,
+                                    "end": 172,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 157,
+                                        "end": 167
+                                      },
+                                      {
+                                        "kind": "navigation_suffix",
+                                        "start": 167,
+                                        "end": 172,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 168,
+                                            "end": 172
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 172,
+                                    "end": 175,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 172,
+                                        "end": 175,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 173,
+                                            "end": 174,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 173,
+                                                "end": 174
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "property_declaration",
+                "start": 182,
+                "end": 207,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 182,
+                    "end": 188,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 182,
+                        "end": 188
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 189,
+                    "end": 192
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 193,
+                    "end": 195,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 193,
+                        "end": 195
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "navigation_expression",
+                    "start": 198,
+                    "end": 207,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 198,
+                        "end": 204
+                      },
+                      {
+                        "kind": "navigation_suffix",
+                        "start": 204,
+                        "end": 207,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 205,
+                            "end": 207
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 210,
+        "end": 232,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 210,
+            "end": 215
+          },
+          {
+            "kind": "call_suffix",
+            "start": 215,
+            "end": 232,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 215,
+                "end": 232,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 216,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 216,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "navigation_expression",
+                            "start": 216,
+                            "end": 225,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 216,
+                                "end": 220
+                              },
+                              {
+                                "kind": "navigation_suffix",
+                                "start": 220,
+                                "end": 225,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 221,
+                                    "end": 225
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 225,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 225,
+                                "end": 231,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 226,
+                                    "end": 230,
+                                    "children": [
+                                      {
+                                        "kind": "real_literal",
+                                        "start": 226,
+                                        "end": 230
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 233,
+        "end": 247,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 233,
+            "end": 238
+          },
+          {
+            "kind": "call_suffix",
+            "start": 238,
+            "end": 247,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 238,
+                "end": 247,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 239,
+                    "end": 246,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 239,
+                        "end": 246,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 239,
+                            "end": 243
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 243,
+                            "end": 246,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 244,
+                                "end": 246
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/swift/python_math.swift.json
+++ b/tests/json-ast/x/swift/python_math.swift.json
@@ -1,0 +1,1921 @@
+{
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 946,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
+        "start": 71,
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 90,
+        "end": 104,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 97,
+            "end": 101
+          },
+          {
+            "kind": "class_body",
+            "start": 102,
+            "end": 104
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 105,
+        "end": 149,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 115,
+            "end": 119,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 115,
+                "end": 119
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 120,
+            "end": 149,
+            "children": [
+              {
+                "kind": "property_declaration",
+                "start": 122,
+                "end": 147,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 122,
+                    "end": 128,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 122,
+                        "end": 128
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 129,
+                    "end": 132
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 133,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 133,
+                        "end": 135
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "navigation_expression",
+                    "start": 138,
+                    "end": 147,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 138,
+                        "end": 144
+                      },
+                      {
+                        "kind": "navigation_suffix",
+                        "start": 144,
+                        "end": 147,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 145,
+                            "end": 147
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 150,
+        "end": 201,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 160,
+            "end": 164,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 160,
+                "end": 164
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 165,
+            "end": 201,
+            "children": [
+              {
+                "kind": "property_declaration",
+                "start": 167,
+                "end": 199,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 167,
+                    "end": 173,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 167,
+                        "end": 173
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 174,
+                    "end": 177
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 178,
+                    "end": 179,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 178,
+                        "end": 179
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "real_literal",
+                    "start": 182,
+                    "end": 199
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 202,
+        "end": 283,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 212,
+            "end": 216,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 212,
+                "end": 216
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 217,
+            "end": 283,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 219,
+                "end": 281,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 219,
+                    "end": 225,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 219,
+                        "end": 225
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 231,
+                    "end": 235
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 236,
+                    "end": 247,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 236,
+                        "end": 237
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 238,
+                        "end": 239
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 241,
+                        "end": 247,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 241,
+                            "end": 247
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 252,
+                    "end": 258,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 252,
+                        "end": 258
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 259,
+                    "end": 281,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 261,
+                        "end": 279,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 261,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 261,
+                                "end": 276,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 261,
+                                    "end": 271
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 271,
+                                    "end": 276,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 272,
+                                        "end": 276
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 276,
+                                "end": 279,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 276,
+                                    "end": 279,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 277,
+                                        "end": 278,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 277,
+                                            "end": 278
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 284,
+        "end": 379,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 294,
+            "end": 298,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 294,
+                "end": 298
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 299,
+            "end": 379,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 301,
+                "end": 377,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 301,
+                    "end": 307,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 301,
+                        "end": 307
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 313,
+                    "end": 316
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 317,
+                    "end": 328,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 317,
+                        "end": 318
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 319,
+                        "end": 320
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 322,
+                        "end": 328,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 322,
+                            "end": 328
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 330,
+                    "end": 341,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 330,
+                        "end": 331
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 332,
+                        "end": 333
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 335,
+                        "end": 341,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 335,
+                            "end": 341
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 346,
+                    "end": 352,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 346,
+                        "end": 352
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 353,
+                    "end": 377,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 355,
+                        "end": 375,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 355,
+                            "end": 375,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 355,
+                                "end": 369,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 355,
+                                    "end": 365
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 365,
+                                    "end": 369,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 366,
+                                        "end": 369
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 369,
+                                "end": 375,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 369,
+                                    "end": 375,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 370,
+                                        "end": 371,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 370,
+                                            "end": 371
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 373,
+                                        "end": 374,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 373,
+                                            "end": 374
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 380,
+        "end": 459,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 390,
+            "end": 394,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 390,
+                "end": 394
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 395,
+            "end": 459,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 397,
+                "end": 457,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 397,
+                    "end": 403,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 397,
+                        "end": 403
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 409,
+                    "end": 412
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 413,
+                    "end": 424,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 413,
+                        "end": 414
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 415,
+                        "end": 416
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 418,
+                        "end": 424,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 418,
+                            "end": 424
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 429,
+                    "end": 435,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 429,
+                        "end": 435
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 436,
+                    "end": 457,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 438,
+                        "end": 455,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 438,
+                            "end": 455,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 438,
+                                "end": 452,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 438,
+                                    "end": 448
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 448,
+                                    "end": 452,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 449,
+                                        "end": 452
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 452,
+                                "end": 455,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 452,
+                                    "end": 455,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 453,
+                                        "end": 454,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 453,
+                                            "end": 454
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "class_declaration",
+        "start": 460,
+        "end": 539,
+        "children": [
+          {
+            "kind": "user_type",
+            "start": 470,
+            "end": 474,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 470,
+                "end": 474
+              }
+            ]
+          },
+          {
+            "kind": "class_body",
+            "start": 475,
+            "end": 539,
+            "children": [
+              {
+                "kind": "function_declaration",
+                "start": 477,
+                "end": 537,
+                "children": [
+                  {
+                    "kind": "modifiers",
+                    "start": 477,
+                    "end": 483,
+                    "children": [
+                      {
+                        "kind": "property_modifier",
+                        "start": 477,
+                        "end": 483
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 489,
+                    "end": 492
+                  },
+                  {
+                    "kind": "parameter",
+                    "start": 493,
+                    "end": 504,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 493,
+                        "end": 494
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 495,
+                        "end": 496
+                      },
+                      {
+                        "kind": "user_type",
+                        "start": 498,
+                        "end": 504,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 498,
+                            "end": 504
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 509,
+                    "end": 515,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 509,
+                        "end": 515
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "function_body",
+                    "start": 516,
+                    "end": 537,
+                    "children": [
+                      {
+                        "kind": "statements",
+                        "start": 518,
+                        "end": 535,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 518,
+                            "end": 535,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 518,
+                                "end": 532,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 518,
+                                    "end": 528
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 528,
+                                    "end": 532,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 529,
+                                        "end": 532
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 532,
+                                "end": 535,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 532,
+                                    "end": 535,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 533,
+                                        "end": 534,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 533,
+                                            "end": 534
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 540,
+        "end": 551,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 540,
+            "end": 543
+          },
+          {
+            "kind": "pattern",
+            "start": 544,
+            "end": 545,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 544,
+                "end": 545
+              }
+            ]
+          },
+          {
+            "kind": "real_literal",
+            "start": 548,
+            "end": 551
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 552,
+        "end": 617,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 552,
+            "end": 555
+          },
+          {
+            "kind": "pattern",
+            "start": 556,
+            "end": 560,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 556,
+                "end": 560
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 563,
+            "end": 617,
+            "children": [
+              {
+                "kind": "multiplicative_expression",
+                "start": 564,
+                "end": 616,
+                "children": [
+                  {
+                    "kind": "navigation_expression",
+                    "start": 564,
+                    "end": 571,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 564,
+                        "end": 568
+                      },
+                      {
+                        "kind": "navigation_suffix",
+                        "start": 568,
+                        "end": 571,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 569,
+                            "end": 571
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "tuple_expression",
+                    "start": 574,
+                    "end": 616,
+                    "children": [
+                      {
+                        "kind": "as_expression",
+                        "start": 575,
+                        "end": 615,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 575,
+                            "end": 604,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 575,
+                                "end": 583,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 575,
+                                    "end": 579
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 579,
+                                    "end": 583,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 580,
+                                        "end": 583
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 583,
+                                "end": 604,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 583,
+                                    "end": 604,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 584,
+                                        "end": 598,
+                                        "children": [
+                                          {
+                                            "kind": "tuple_expression",
+                                            "start": 584,
+                                            "end": 598,
+                                            "children": [
+                                              {
+                                                "kind": "as_expression",
+                                                "start": 585,
+                                                "end": 597,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 585,
+                                                    "end": 586
+                                                  },
+                                                  {
+                                                    "kind": "as_operator",
+                                                    "start": 587,
+                                                    "end": 590
+                                                  },
+                                                  {
+                                                    "kind": "user_type",
+                                                    "start": 591,
+                                                    "end": 597,
+                                                    "children": [
+                                                      {
+                                                        "kind": "type_identifier",
+                                                        "start": 591,
+                                                        "end": 597
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 600,
+                                        "end": 603,
+                                        "children": [
+                                          {
+                                            "kind": "real_literal",
+                                            "start": 600,
+                                            "end": 603
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "as_operator",
+                            "start": 605,
+                            "end": 608
+                          },
+                          {
+                            "kind": "user_type",
+                            "start": 609,
+                            "end": 615,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 609,
+                                "end": 615
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 618,
+        "end": 657,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 618,
+            "end": 621
+          },
+          {
+            "kind": "pattern",
+            "start": 622,
+            "end": 626,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 622,
+                "end": 626
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 629,
+            "end": 657,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 630,
+                "end": 656,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 630,
+                    "end": 645,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 630,
+                        "end": 639,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 630,
+                            "end": 634
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 634,
+                            "end": 639,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 635,
+                                "end": 639
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 639,
+                        "end": 645,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 639,
+                            "end": 645,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 640,
+                                "end": 644,
+                                "children": [
+                                  {
+                                    "kind": "real_literal",
+                                    "start": 640,
+                                    "end": 644
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 646,
+                    "end": 649
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 650,
+                    "end": 656,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 650,
+                        "end": 656
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 658,
+        "end": 708,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 658,
+            "end": 661
+          },
+          {
+            "kind": "pattern",
+            "start": 662,
+            "end": 667,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 662,
+                "end": 667
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 670,
+            "end": 708,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 671,
+                "end": 707,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 671,
+                    "end": 696,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 671,
+                        "end": 679,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 671,
+                            "end": 675
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 675,
+                            "end": 679,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 676,
+                                "end": 679
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 679,
+                        "end": 696,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 679,
+                            "end": 696,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 680,
+                                "end": 695,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 680,
+                                    "end": 695,
+                                    "children": [
+                                      {
+                                        "kind": "multiplicative_expression",
+                                        "start": 681,
+                                        "end": 694,
+                                        "children": [
+                                          {
+                                            "kind": "navigation_expression",
+                                            "start": 681,
+                                            "end": 688,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 681,
+                                                "end": 685
+                                              },
+                                              {
+                                                "kind": "navigation_suffix",
+                                                "start": 685,
+                                                "end": 688,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 686,
+                                                    "end": 688
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "real_literal",
+                                            "start": 691,
+                                            "end": 694
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 697,
+                    "end": 700
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 701,
+                    "end": 707,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 701,
+                        "end": 707
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 709,
+        "end": 750,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 709,
+            "end": 712
+          },
+          {
+            "kind": "pattern",
+            "start": 713,
+            "end": 718,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 713,
+                "end": 718
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 721,
+            "end": 750,
+            "children": [
+              {
+                "kind": "as_expression",
+                "start": 722,
+                "end": 749,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 722,
+                    "end": 738,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 722,
+                        "end": 730,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 722,
+                            "end": 726
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 726,
+                            "end": 730,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 727,
+                                "end": 730
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 730,
+                        "end": 738,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 730,
+                            "end": 738,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 731,
+                                "end": 737,
+                                "children": [
+                                  {
+                                    "kind": "navigation_expression",
+                                    "start": 731,
+                                    "end": 737,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 731,
+                                        "end": 735
+                                      },
+                                      {
+                                        "kind": "navigation_suffix",
+                                        "start": 735,
+                                        "end": 737,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 736,
+                                            "end": 737
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "as_operator",
+                    "start": 739,
+                    "end": 742
+                  },
+                  {
+                    "kind": "user_type",
+                    "start": 743,
+                    "end": 749,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 743,
+                        "end": 749
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 751,
+        "end": 821,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 751,
+            "end": 756
+          },
+          {
+            "kind": "call_suffix",
+            "start": 756,
+            "end": 821,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 756,
+                "end": 821,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 757,
+                    "end": 779,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 757,
+                        "end": 779,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 758,
+                            "end": 778
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 781,
+                    "end": 795,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 781,
+                        "end": 795,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 782,
+                            "end": 794,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 782,
+                                "end": 783
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 784,
+                                "end": 787
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 788,
+                                "end": 794,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 788,
+                                    "end": 794
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 797,
+                    "end": 801,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 797,
+                        "end": 801,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 798,
+                            "end": 800
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 803,
+                    "end": 820,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 803,
+                        "end": 820,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 804,
+                            "end": 819,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 804,
+                                "end": 808
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 809,
+                                "end": 812
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 813,
+                                "end": 819,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 813,
+                                    "end": 819
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 822,
+        "end": 868,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 822,
+            "end": 827
+          },
+          {
+            "kind": "call_suffix",
+            "start": 827,
+            "end": 868,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 827,
+                "end": 868,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 828,
+                    "end": 848,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 828,
+                        "end": 848,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 829,
+                            "end": 847
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 850,
+                    "end": 867,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 850,
+                        "end": 867,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 851,
+                            "end": 866,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 851,
+                                "end": 855
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 856,
+                                "end": 859
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 860,
+                                "end": 866,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 860,
+                                    "end": 866
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 869,
+        "end": 908,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 869,
+            "end": 874
+          },
+          {
+            "kind": "call_suffix",
+            "start": 874,
+            "end": 908,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 874,
+                "end": 908,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 875,
+                    "end": 887,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 875,
+                        "end": 887,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 876,
+                            "end": 886
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 889,
+                    "end": 907,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 889,
+                        "end": 907,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 890,
+                            "end": 906,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 890,
+                                "end": 895
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 896,
+                                "end": 899
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 900,
+                                "end": 906,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 900,
+                                    "end": 906
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 909,
+        "end": 945,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 909,
+            "end": 914
+          },
+          {
+            "kind": "call_suffix",
+            "start": 914,
+            "end": 945,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 914,
+                "end": 945,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 915,
+                    "end": 924,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 915,
+                        "end": 924,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 916,
+                            "end": 923
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "value_argument",
+                    "start": 926,
+                    "end": 944,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 926,
+                        "end": 944,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 927,
+                            "end": 943,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 927,
+                                "end": 932
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 933,
+                                "end": 936
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 937,
+                                "end": 943,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 937,
+                                    "end": 943
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/swift/record_assign.swift.json
+++ b/tests/json-ast/x/swift/record_assign.swift.json
@@ -1,160 +1,429 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 225,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "struct_decl",
-      "name": {
-        "base_name": {
-          "name": "Counter"
-        }
-      },
-      "range": {
-        "start": 90,
-        "end": 122
-      },
-      "interface_type": "$s4main7CounterVmD",
-      "access": "internal",
-      "members": [
-        {
-          "_kind": "pattern_binding_decl",
-          "range": {
-            "start": 111,
-            "end": 118
-          }
-        },
-        {
-          "_kind": "var_decl",
-          "name": {
-            "base_name": {
-              "name": "n"
-            }
-          },
-          "range": {
-            "start": 115,
-            "end": 115
-          },
-          "interface_type": "$sSiD",
-          "access": "internal"
-        },
-        {
-          "_kind": "constructor_decl",
-          "name": {
-            "base_name": {
-              "name": ""
-            }
-          },
-          "params": {
-            "params": [
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
               {
-                "name": {
-                  "base_name": {
-                    "name": "n"
-                  }
-                },
-                "interface_type": "$sSiD"
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
               }
             ]
-          },
-          "range": {
-            "start": 97,
-            "end": 97
-          },
-          "interface_type": "$sy4main7CounterVSi_tcACmcD",
-          "access": "internal"
-        }
-      ]
-    },
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "inc"
-        }
-      },
-      "params": {
-        "params": [
-          {
-            "name": {
-              "base_name": {
-                "name": "c"
-              }
-            },
-            "interface_type": "$s4main7CounterVD"
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 147,
-          "end": 183
-        }
+      {
+        "kind": "class_declaration",
+        "start": 90,
+        "end": 123,
+        "children": [
+          {
+            "kind": "type_identifier",
+            "start": 97,
+            "end": 104
+          },
+          {
+            "kind": "class_body",
+            "start": 105,
+            "end": 123,
+            "children": [
+              {
+                "kind": "property_declaration",
+                "start": 111,
+                "end": 121,
+                "children": [
+                  {
+                    "kind": "value_binding_pattern",
+                    "start": 111,
+                    "end": 114
+                  },
+                  {
+                    "kind": "pattern",
+                    "start": 115,
+                    "end": 116,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 115,
+                        "end": 116
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "type_annotation",
+                    "start": 116,
+                    "end": 121,
+                    "children": [
+                      {
+                        "kind": "user_type",
+                        "start": 118,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "type_identifier",
+                            "start": 118,
+                            "end": 121
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "function_declaration",
         "start": 124,
-        "end": 183
+        "end": 184,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 129,
+            "end": 132
+          },
+          {
+            "kind": "parameter",
+            "start": 133,
+            "end": 145,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 133,
+                "end": 134
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 135,
+                "end": 136
+              },
+              {
+                "kind": "user_type",
+                "start": 138,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 138,
+                    "end": 145
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 147,
+            "end": 184,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 153,
+                "end": 183,
+                "children": [
+                  {
+                    "kind": "property_declaration",
+                    "start": 153,
+                    "end": 162,
+                    "children": [
+                      {
+                        "kind": "value_binding_pattern",
+                        "start": 153,
+                        "end": 156
+                      },
+                      {
+                        "kind": "pattern",
+                        "start": 157,
+                        "end": 158,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 157,
+                            "end": 158
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "simple_identifier",
+                        "start": 161,
+                        "end": 162
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "assignment",
+                    "start": 167,
+                    "end": 182,
+                    "children": [
+                      {
+                        "kind": "directly_assignable_expression",
+                        "start": 167,
+                        "end": 170,
+                        "children": [
+                          {
+                            "kind": "navigation_expression",
+                            "start": 167,
+                            "end": 170,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 167,
+                                "end": 168
+                              },
+                              {
+                                "kind": "navigation_suffix",
+                                "start": 168,
+                                "end": 170,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 169,
+                                    "end": 170
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "tuple_expression",
+                        "start": 173,
+                        "end": 182,
+                        "children": [
+                          {
+                            "kind": "additive_expression",
+                            "start": 174,
+                            "end": 181,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 174,
+                                "end": 177,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 174,
+                                    "end": 175
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 175,
+                                    "end": 177,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 176,
+                                        "end": 177
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 180,
+                                "end": 181
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "result": "$sytD",
-      "interface_type": "$syy4main7CounterVcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 185,
-          "end": 205
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 185,
-        "end": 205
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "c"
-        }
+        "end": 206,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 185,
+            "end": 188
+          },
+          {
+            "kind": "pattern",
+            "start": 189,
+            "end": 190,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 189,
+                "end": 190
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 193,
+            "end": 206,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 193,
+                "end": 200
+              },
+              {
+                "kind": "call_suffix",
+                "start": 200,
+                "end": 206,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 200,
+                    "end": 206,
+                    "children": [
+                      {
+                        "kind": "value_argument",
+                        "start": 201,
+                        "end": 205,
+                        "children": [
+                          {
+                            "kind": "value_argument_label",
+                            "start": 201,
+                            "end": 202,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 201,
+                                "end": 202
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer_literal",
+                            "start": 204,
+                            "end": 205
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 189,
-        "end": 189
-      },
-      "interface_type": "$s4main7CounterVD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 207,
-          "end": 212
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 207,
-        "end": 212
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 214,
-          "end": 223
-        }
+        "end": 213,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 207,
+            "end": 210
+          },
+          {
+            "kind": "call_suffix",
+            "start": 210,
+            "end": 213,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 210,
+                "end": 213,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 211,
+                    "end": 212,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 211,
+                        "end": 212
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 214,
-        "end": 223
+        "end": 224,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 214,
+            "end": 219
+          },
+          {
+            "kind": "call_suffix",
+            "start": 219,
+            "end": 224,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 219,
+                "end": 224,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 220,
+                    "end": 223,
+                    "children": [
+                      {
+                        "kind": "navigation_expression",
+                        "start": 220,
+                        "end": 223,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 220,
+                            "end": 221
+                          },
+                          {
+                            "kind": "navigation_suffix",
+                            "start": 221,
+                            "end": 223,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 222,
+                                "end": 223
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/short_circuit.swift.json
+++ b/tests/json-ast/x/swift/short_circuit.swift.json
@@ -1,71 +1,481 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "boom"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 246,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 146,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "a"
-              }
-            },
-            "interface_type": "$sSiD"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 80
           },
           {
-            "name": {
-              "base_name": {
-                "name": "b"
+            "kind": "parameter",
+            "start": 81,
+            "end": 89,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 81,
+                "end": 82
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "user_type",
+                "start": 86,
+                "end": 89,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 86,
+                    "end": 89
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "parameter",
+            "start": 91,
+            "end": 99,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 91,
+                "end": 92
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 93,
+                "end": 94
+              },
+              {
+                "kind": "user_type",
+                "start": 96,
+                "end": 99,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 96,
+                    "end": 99
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 104,
+            "end": 108,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 104,
+                "end": 108
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 109,
+            "end": 146,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 115,
+                "end": 145,
+                "children": [
+                  {
+                    "kind": "call_expression",
+                    "start": 115,
+                    "end": 128,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 115,
+                        "end": 120
+                      },
+                      {
+                        "kind": "call_suffix",
+                        "start": 120,
+                        "end": 128,
+                        "children": [
+                          {
+                            "kind": "value_arguments",
+                            "start": 120,
+                            "end": 128,
+                            "children": [
+                              {
+                                "kind": "value_argument",
+                                "start": 121,
+                                "end": 127,
+                                "children": [
+                                  {
+                                    "kind": "line_string_literal",
+                                    "start": 121,
+                                    "end": 127,
+                                    "children": [
+                                      {
+                                        "kind": "line_str_text",
+                                        "start": 122,
+                                        "end": 126
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 133,
+                    "end": 144,
+                    "children": [
+                      {
+                        "kind": "boolean_literal",
+                        "start": 140,
+                        "end": 144
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 109,
-          "end": 145
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 145
-      },
-      "result": "$sSbD",
-      "interface_type": "$sySbSi_SitcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 147,
-          "end": 195
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 147,
-        "end": 195
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 197,
-          "end": 244
-        }
+        "end": 196,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 147,
+            "end": 152
+          },
+          {
+            "kind": "call_suffix",
+            "start": 152,
+            "end": 196,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 152,
+                "end": 196,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 153,
+                    "end": 195,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 153,
+                        "end": 195,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 154,
+                            "end": 194,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 154,
+                                "end": 186,
+                                "children": [
+                                  {
+                                    "kind": "conjunction_expression",
+                                    "start": 155,
+                                    "end": 185,
+                                    "children": [
+                                      {
+                                        "kind": "boolean_literal",
+                                        "start": 155,
+                                        "end": 160
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 164,
+                                        "end": 185,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 165,
+                                            "end": 184,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 165,
+                                                "end": 175,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 165,
+                                                    "end": 169
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 169,
+                                                    "end": 175,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 169,
+                                                        "end": 175,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 170,
+                                                            "end": 171,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 170,
+                                                                "end": 171
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 173,
+                                                            "end": 174,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 173,
+                                                                "end": 174
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 176,
+                                                "end": 179
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 180,
+                                                "end": 184,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 180,
+                                                    "end": 184
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 189,
+                                "end": 190
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 193,
+                                "end": 194
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 197,
-        "end": 244
+        "end": 245,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 197,
+            "end": 202
+          },
+          {
+            "kind": "call_suffix",
+            "start": 202,
+            "end": 245,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 202,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 203,
+                    "end": 244,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 203,
+                        "end": 244,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 204,
+                            "end": 243,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 204,
+                                "end": 235,
+                                "children": [
+                                  {
+                                    "kind": "disjunction_expression",
+                                    "start": 205,
+                                    "end": 234,
+                                    "children": [
+                                      {
+                                        "kind": "boolean_literal",
+                                        "start": 205,
+                                        "end": 209
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 213,
+                                        "end": 234,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 214,
+                                            "end": 233,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 214,
+                                                "end": 224,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 214,
+                                                    "end": 218
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 218,
+                                                    "end": 224,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 218,
+                                                        "end": 224,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 219,
+                                                            "end": 220,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 219,
+                                                                "end": 220
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 222,
+                                                            "end": 223,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 222,
+                                                                "end": 223
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 225,
+                                                "end": 228
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 229,
+                                                "end": 233,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 229,
+                                                    "end": 233
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 238,
+                                "end": 239
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 242,
+                                "end": 243
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/str_builtin.swift.json
+++ b/tests/json-ast/x/swift/str_builtin.swift.json
@@ -1,17 +1,116 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 101
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 103,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 101
+        "end": 102,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 102,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 102,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 101,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 77,
+                        "end": 101,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 78,
+                            "end": 100,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 78,
+                                "end": 89,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 78,
+                                    "end": 84
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 84,
+                                    "end": 89,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 84,
+                                        "end": 89,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 85,
+                                            "end": 88,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 85,
+                                                "end": 88
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 90,
+                                "end": 93
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 94,
+                                "end": 100,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 94,
+                                    "end": 100
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_compare.swift.json
+++ b/tests/json-ast/x/swift/string_compare.swift.json
@@ -1,56 +1,166 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 78
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 107,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 80,
-          "end": 87
-        }
+        "end": 79,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 79,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 79,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 78,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 77,
+                        "end": 78
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 80,
-        "end": 87
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 89,
-          "end": 96
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 80,
+            "end": 85
+          },
+          {
+            "kind": "call_suffix",
+            "start": 85,
+            "end": 88,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 85,
+                "end": 88,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 86,
+                    "end": 87,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 86,
+                        "end": 87
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 89,
-        "end": 96
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 98,
-          "end": 105
-        }
+        "end": 97,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 89,
+            "end": 94
+          },
+          {
+            "kind": "call_suffix",
+            "start": 94,
+            "end": 97,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 94,
+                "end": 97,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 95,
+                    "end": 96,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 95,
+                        "end": 96
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 98,
-        "end": 105
+        "end": 106,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 98,
+            "end": 103
+          },
+          {
+            "kind": "call_suffix",
+            "start": 103,
+            "end": 106,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 103,
+                "end": 106,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 104,
+                    "end": 105,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 104,
+                        "end": 105
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_concat.swift.json
+++ b/tests/json-ast/x/swift/string_concat.swift.json
@@ -1,17 +1,59 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 90
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 92,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 90
+        "end": 91,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 91,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 91,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 90,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 77,
+                        "end": 90,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 78,
+                            "end": 89
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_contains.swift.json
+++ b/tests/json-ast/x/swift/string_contains.swift.json
@@ -1,57 +1,258 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 141,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s"
-        }
+        "end": 86,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 79,
+            "end": 86,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 80,
+                "end": 85
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 87,
-          "end": 112
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 87,
-        "end": 112
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 114,
-          "end": 139
-        }
+        "end": 113,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 87,
+            "end": 92
+          },
+          {
+            "kind": "call_suffix",
+            "start": 92,
+            "end": 113,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 92,
+                "end": 113,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 93,
+                    "end": 112,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 93,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 94,
+                            "end": 111,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 94,
+                                "end": 104,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 94,
+                                    "end": 95
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 95,
+                                    "end": 104,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 96,
+                                        "end": 104
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 104,
+                                "end": 111,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 104,
+                                    "end": 111,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 105,
+                                        "end": 110,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 105,
+                                            "end": 110,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 106,
+                                                "end": 109
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 114,
-        "end": 139
+        "end": 140,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 114,
+            "end": 119
+          },
+          {
+            "kind": "call_suffix",
+            "start": 119,
+            "end": 140,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 119,
+                "end": 140,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 120,
+                    "end": 139,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 120,
+                        "end": 139,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 121,
+                            "end": 138,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 121,
+                                "end": 131,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 121,
+                                    "end": 122
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 122,
+                                    "end": 131,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 123,
+                                        "end": 131
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 131,
+                                "end": 138,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 131,
+                                    "end": 138,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 132,
+                                        "end": 137,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 132,
+                                            "end": 137,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 133,
+                                                "end": 136
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_in_operator.swift.json
+++ b/tests/json-ast/x/swift/string_in_operator.swift.json
@@ -1,57 +1,320 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 167,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s"
-        }
+        "end": 86,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 79,
+            "end": 86,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 80,
+                "end": 85
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 87,
-          "end": 125
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 87,
-        "end": 125
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 127,
-          "end": 165
-        }
+        "end": 126,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 87,
+            "end": 92
+          },
+          {
+            "kind": "call_suffix",
+            "start": 92,
+            "end": 126,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 92,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 93,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 93,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 94,
+                            "end": 124,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 94,
+                                "end": 117,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 94,
+                                    "end": 108,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 95,
+                                        "end": 107,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 95,
+                                            "end": 96
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 97,
+                                            "end": 100
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 101,
+                                            "end": 107,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 101,
+                                                "end": 107
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 108,
+                                    "end": 117,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 109,
+                                        "end": 117
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 117,
+                                "end": 124,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 117,
+                                    "end": 124,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 118,
+                                        "end": 123,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 118,
+                                            "end": 123,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 119,
+                                                "end": 122
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 127,
-        "end": 165
+        "end": 166,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 127,
+            "end": 132
+          },
+          {
+            "kind": "call_suffix",
+            "start": 132,
+            "end": 166,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 132,
+                "end": 166,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 133,
+                    "end": 165,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 133,
+                        "end": 165,
+                        "children": [
+                          {
+                            "kind": "call_expression",
+                            "start": 134,
+                            "end": 164,
+                            "children": [
+                              {
+                                "kind": "navigation_expression",
+                                "start": 134,
+                                "end": 157,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 134,
+                                    "end": 148,
+                                    "children": [
+                                      {
+                                        "kind": "as_expression",
+                                        "start": 135,
+                                        "end": 147,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 135,
+                                            "end": 136
+                                          },
+                                          {
+                                            "kind": "as_operator",
+                                            "start": 137,
+                                            "end": 140
+                                          },
+                                          {
+                                            "kind": "user_type",
+                                            "start": 141,
+                                            "end": 147,
+                                            "children": [
+                                              {
+                                                "kind": "type_identifier",
+                                                "start": 141,
+                                                "end": 147
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "navigation_suffix",
+                                    "start": 148,
+                                    "end": 157,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 149,
+                                        "end": 157
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "call_suffix",
+                                "start": 157,
+                                "end": 164,
+                                "children": [
+                                  {
+                                    "kind": "value_arguments",
+                                    "start": 157,
+                                    "end": 164,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument",
+                                        "start": 158,
+                                        "end": 163,
+                                        "children": [
+                                          {
+                                            "kind": "line_string_literal",
+                                            "start": 158,
+                                            "end": 163,
+                                            "children": [
+                                              {
+                                                "kind": "line_str_text",
+                                                "start": 159,
+                                                "end": 162
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_index.swift.json
+++ b/tests/json-ast/x/swift/string_index.swift.json
@@ -1,44 +1,218 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 127,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s"
-        }
+        "end": 86,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 79,
+            "end": 86,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 80,
+                "end": 85
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 87,
-          "end": 125
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 87,
-        "end": 125
+        "end": 126,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 87,
+            "end": 92
+          },
+          {
+            "kind": "call_suffix",
+            "start": 92,
+            "end": 126,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 92,
+                "end": 126,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 93,
+                    "end": 125,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 93,
+                        "end": 125,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 94,
+                            "end": 124,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 94,
+                                "end": 113,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 94,
+                                    "end": 100
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 100,
+                                    "end": 113,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 100,
+                                        "end": 113,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 101,
+                                            "end": 112,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 101,
+                                                "end": 112,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 101,
+                                                    "end": 109,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 101,
+                                                        "end": 106
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 106,
+                                                        "end": 109,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 106,
+                                                            "end": 109,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 107,
+                                                                "end": 108,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 107,
+                                                                    "end": 108
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 109,
+                                                    "end": 112,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 109,
+                                                        "end": 112,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 110,
+                                                            "end": 111,
+                                                            "children": [
+                                                              {
+                                                                "kind": "integer_literal",
+                                                                "start": 110,
+                                                                "end": 111
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 114,
+                                "end": 117
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 118,
+                                "end": 124,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 118,
+                                    "end": 124
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/string_prefix_slice.swift.json
+++ b/tests/json-ast/x/swift/string_prefix_slice.swift.json
@@ -1,111 +1,820 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 84
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 363,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 84
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "prefix"
-        }
+        "end": 90,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 81,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 81
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 84,
+            "end": 90,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 85,
+                "end": 89
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 91,
-          "end": 100
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 91,
-        "end": 100
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s1"
-        }
+        "end": 108,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 91,
+            "end": 94
+          },
+          {
+            "kind": "pattern",
+            "start": 95,
+            "end": 97,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 95,
+                "end": 97
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 100,
+            "end": 108,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 101,
+                "end": 107
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 95,
-        "end": 95
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 109,
-          "end": 225
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 109,
-        "end": 225
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 227,
-          "end": 236
-        }
+        "end": 226,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 109,
+            "end": 114
+          },
+          {
+            "kind": "call_suffix",
+            "start": 114,
+            "end": 226,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 114,
+                "end": 226,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 115,
+                    "end": 225,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 115,
+                        "end": 225,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 116,
+                            "end": 224,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 116,
+                                "end": 216,
+                                "children": [
+                                  {
+                                    "kind": "equality_expression",
+                                    "start": 117,
+                                    "end": 215,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 117,
+                                        "end": 192,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 118,
+                                            "end": 191,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 118,
+                                                "end": 180,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 118,
+                                                    "end": 124
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 124,
+                                                    "end": 180,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 124,
+                                                        "end": 180,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 125,
+                                                            "end": 179,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 125,
+                                                                "end": 179,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 125,
+                                                                    "end": 134,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 125,
+                                                                        "end": 130
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 130,
+                                                                        "end": 134,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 130,
+                                                                            "end": 134,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 131,
+                                                                                "end": 133,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "simple_identifier",
+                                                                                    "start": 131,
+                                                                                    "end": 133
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 134,
+                                                                    "end": 179,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 134,
+                                                                        "end": 179,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 135,
+                                                                            "end": 178,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "range_expression",
+                                                                                "start": 135,
+                                                                                "end": 178,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "integer_literal",
+                                                                                    "start": 135,
+                                                                                    "end": 136
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "tuple_expression",
+                                                                                    "start": 139,
+                                                                                    "end": 178,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "as_expression",
+                                                                                        "start": 140,
+                                                                                        "end": 177,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "tuple_expression",
+                                                                                            "start": 140,
+                                                                                            "end": 169,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "navigation_expression",
+                                                                                                "start": 141,
+                                                                                                "end": 168,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "tuple_expression",
+                                                                                                    "start": 141,
+                                                                                                    "end": 162,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "tuple_expression",
+                                                                                                        "start": 142,
+                                                                                                        "end": 161,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "as_expression",
+                                                                                                            "start": 143,
+                                                                                                            "end": 160,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "simple_identifier",
+                                                                                                                "start": 143,
+                                                                                                                "end": 149
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "kind": "as_operator",
+                                                                                                                "start": 150,
+                                                                                                                "end": 153
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "kind": "user_type",
+                                                                                                                "start": 154,
+                                                                                                                "end": 160,
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "kind": "type_identifier",
+                                                                                                                    "start": 154,
+                                                                                                                    "end": 160
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "kind": "navigation_suffix",
+                                                                                                    "start": 162,
+                                                                                                    "end": 168,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "simple_identifier",
+                                                                                                        "start": 163,
+                                                                                                        "end": 168
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "as_operator",
+                                                                                            "start": 170,
+                                                                                            "end": 173
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "user_type",
+                                                                                            "start": 174,
+                                                                                            "end": 177,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "type_identifier",
+                                                                                                "start": 174,
+                                                                                                "end": 177
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 181,
+                                                "end": 184
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 185,
+                                                "end": 191,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 185,
+                                                    "end": 191
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 196,
+                                        "end": 215,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 197,
+                                            "end": 214,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 197,
+                                                "end": 203
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 204,
+                                                "end": 207
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 208,
+                                                "end": 214,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 208,
+                                                    "end": 214
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 219,
+                                "end": 220
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 223,
+                                "end": 224
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 227,
-        "end": 236
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "s2"
-        }
+        "end": 244,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 227,
+            "end": 230
+          },
+          {
+            "kind": "pattern",
+            "start": 231,
+            "end": 233,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 231,
+                "end": 233
+              }
+            ]
+          },
+          {
+            "kind": "line_string_literal",
+            "start": 236,
+            "end": 244,
+            "children": [
+              {
+                "kind": "line_str_text",
+                "start": 237,
+                "end": 243
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 231,
-        "end": 231
-      },
-      "interface_type": "$sSSD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 245,
-          "end": 361
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 245,
-        "end": 361
+        "end": 362,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 245,
+            "end": 250
+          },
+          {
+            "kind": "call_suffix",
+            "start": 250,
+            "end": 362,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 250,
+                "end": 362,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 251,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 251,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 252,
+                            "end": 360,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 252,
+                                "end": 352,
+                                "children": [
+                                  {
+                                    "kind": "equality_expression",
+                                    "start": 253,
+                                    "end": 351,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 253,
+                                        "end": 328,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 254,
+                                            "end": 327,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 254,
+                                                "end": 316,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 254,
+                                                    "end": 260
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 260,
+                                                    "end": 316,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 260,
+                                                        "end": 316,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 261,
+                                                            "end": 315,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 261,
+                                                                "end": 315,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "call_expression",
+                                                                    "start": 261,
+                                                                    "end": 270,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 261,
+                                                                        "end": 266
+                                                                      },
+                                                                      {
+                                                                        "kind": "call_suffix",
+                                                                        "start": 266,
+                                                                        "end": 270,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_arguments",
+                                                                            "start": 266,
+                                                                            "end": 270,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "value_argument",
+                                                                                "start": 267,
+                                                                                "end": 269,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "simple_identifier",
+                                                                                    "start": 267,
+                                                                                    "end": 269
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 270,
+                                                                    "end": 315,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 270,
+                                                                        "end": 315,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 271,
+                                                                            "end": 314,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "range_expression",
+                                                                                "start": 271,
+                                                                                "end": 314,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "kind": "integer_literal",
+                                                                                    "start": 271,
+                                                                                    "end": 272
+                                                                                  },
+                                                                                  {
+                                                                                    "kind": "tuple_expression",
+                                                                                    "start": 275,
+                                                                                    "end": 314,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "kind": "as_expression",
+                                                                                        "start": 276,
+                                                                                        "end": 313,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "kind": "tuple_expression",
+                                                                                            "start": 276,
+                                                                                            "end": 305,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "navigation_expression",
+                                                                                                "start": 277,
+                                                                                                "end": 304,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "kind": "tuple_expression",
+                                                                                                    "start": 277,
+                                                                                                    "end": 298,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "tuple_expression",
+                                                                                                        "start": 278,
+                                                                                                        "end": 297,
+                                                                                                        "children": [
+                                                                                                          {
+                                                                                                            "kind": "as_expression",
+                                                                                                            "start": 279,
+                                                                                                            "end": 296,
+                                                                                                            "children": [
+                                                                                                              {
+                                                                                                                "kind": "simple_identifier",
+                                                                                                                "start": 279,
+                                                                                                                "end": 285
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "kind": "as_operator",
+                                                                                                                "start": 286,
+                                                                                                                "end": 289
+                                                                                                              },
+                                                                                                              {
+                                                                                                                "kind": "user_type",
+                                                                                                                "start": 290,
+                                                                                                                "end": 296,
+                                                                                                                "children": [
+                                                                                                                  {
+                                                                                                                    "kind": "type_identifier",
+                                                                                                                    "start": 290,
+                                                                                                                    "end": 296
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "kind": "navigation_suffix",
+                                                                                                    "start": 298,
+                                                                                                    "end": 304,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "kind": "simple_identifier",
+                                                                                                        "start": 299,
+                                                                                                        "end": 304
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "as_operator",
+                                                                                            "start": 306,
+                                                                                            "end": 309
+                                                                                          },
+                                                                                          {
+                                                                                            "kind": "user_type",
+                                                                                            "start": 310,
+                                                                                            "end": 313,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "kind": "type_identifier",
+                                                                                                "start": 310,
+                                                                                                "end": 313
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 317,
+                                                "end": 320
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 321,
+                                                "end": 327,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 321,
+                                                    "end": 327
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 332,
+                                        "end": 351,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 333,
+                                            "end": 350,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 333,
+                                                "end": 339
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 340,
+                                                "end": 343
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 344,
+                                                "end": 350,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 344,
+                                                    "end": 350
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 355,
+                                "end": 356
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 359,
+                                "end": 360
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/substring_builtin.swift.json
+++ b/tests/json-ast/x/swift/substring_builtin.swift.json
@@ -1,17 +1,201 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 119
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 121,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 119
+        "end": 120,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 120,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 120,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 119,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 77,
+                        "end": 119,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 78,
+                            "end": 118,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 78,
+                                "end": 107,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 78,
+                                    "end": 84
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 84,
+                                    "end": 107,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 84,
+                                        "end": 107,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 85,
+                                            "end": 106,
+                                            "children": [
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 85,
+                                                "end": 106,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 85,
+                                                    "end": 99,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 85,
+                                                        "end": 90
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 90,
+                                                        "end": 99,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 90,
+                                                            "end": 99,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 91,
+                                                                "end": 98,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_string_literal",
+                                                                    "start": 91,
+                                                                    "end": 98,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_str_text",
+                                                                        "start": 92,
+                                                                        "end": 97
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 99,
+                                                    "end": 106,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 99,
+                                                        "end": 106,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 100,
+                                                            "end": 105,
+                                                            "children": [
+                                                              {
+                                                                "kind": "range_expression",
+                                                                "start": 100,
+                                                                "end": 105,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "integer_literal",
+                                                                    "start": 100,
+                                                                    "end": 101
+                                                                  },
+                                                                  {
+                                                                    "kind": "integer_literal",
+                                                                    "start": 104,
+                                                                    "end": 105
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 108,
+                                "end": 111
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 112,
+                                "end": 118,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 112,
+                                    "end": 118
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/sum_builtin.swift.json
+++ b/tests/json-ast/x/swift/sum_builtin.swift.json
@@ -1,17 +1,164 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 110
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 112,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 110
+        "end": 111,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 111,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 111,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 110,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 77,
+                        "end": 110,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 78,
+                            "end": 109,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 78,
+                                "end": 101,
+                                "children": [
+                                  {
+                                    "kind": "call_expression",
+                                    "start": 79,
+                                    "end": 100,
+                                    "children": [
+                                      {
+                                        "kind": "navigation_expression",
+                                        "start": 79,
+                                        "end": 95,
+                                        "children": [
+                                          {
+                                            "kind": "array_literal",
+                                            "start": 79,
+                                            "end": 88,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 80,
+                                                "end": 81
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 83,
+                                                "end": 84
+                                              },
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 86,
+                                                "end": 87
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "navigation_suffix",
+                                            "start": 88,
+                                            "end": 95,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 89,
+                                                "end": 95
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "call_suffix",
+                                        "start": 95,
+                                        "end": 100,
+                                        "children": [
+                                          {
+                                            "kind": "value_arguments",
+                                            "start": 95,
+                                            "end": 100,
+                                            "children": [
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 96,
+                                                "end": 97,
+                                                "children": [
+                                                  {
+                                                    "kind": "integer_literal",
+                                                    "start": 96,
+                                                    "end": 97
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "value_argument",
+                                                "start": 98,
+                                                "end": 99
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 102,
+                                "end": 105
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 106,
+                                "end": 109,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 106,
+                                    "end": 109
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/tail_recursion.swift.json
+++ b/tests/json-ast/x/swift/tail_recursion.swift.json
@@ -1,58 +1,431 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "sum_rec"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 251,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 218,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "n"
-              }
-            },
-            "interface_type": "$sSiD"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 83
           },
           {
-            "name": {
-              "base_name": {
-                "name": "acc"
+            "kind": "parameter",
+            "start": 84,
+            "end": 92,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 84,
+                "end": 85
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 86,
+                "end": 87
+              },
+              {
+                "kind": "user_type",
+                "start": 89,
+                "end": 92,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 89,
+                    "end": 92
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "parameter",
+            "start": 94,
+            "end": 104,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 95
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 96,
+                "end": 99
+              },
+              {
+                "kind": "user_type",
+                "start": 101,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 101,
+                    "end": 104
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 109,
+            "end": 112,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 109,
+                "end": 112
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 113,
+            "end": 218,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 119,
+                "end": 217,
+                "children": [
+                  {
+                    "kind": "if_statement",
+                    "start": 119,
+                    "end": 167,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 122,
+                        "end": 140,
+                        "children": [
+                          {
+                            "kind": "equality_expression",
+                            "start": 123,
+                            "end": 139,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 123,
+                                "end": 134,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 124,
+                                    "end": 133,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 124,
+                                        "end": 125
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 126,
+                                        "end": 129
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 130,
+                                        "end": 133,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 130,
+                                            "end": 133
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 138,
+                                "end": 139
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "statements",
+                        "start": 151,
+                        "end": 166,
+                        "children": [
+                          {
+                            "kind": "control_transfer_statement",
+                            "start": 151,
+                            "end": 161,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 158,
+                                "end": 161
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 172,
+                    "end": 216,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 179,
+                        "end": 216,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 180,
+                            "end": 215,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 180,
+                                "end": 207,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 180,
+                                    "end": 187
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 187,
+                                    "end": 207,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 187,
+                                        "end": 207,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 188,
+                                            "end": 195,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 188,
+                                                "end": 195,
+                                                "children": [
+                                                  {
+                                                    "kind": "additive_expression",
+                                                    "start": 189,
+                                                    "end": 194,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 189,
+                                                        "end": 190
+                                                      },
+                                                      {
+                                                        "kind": "integer_literal",
+                                                        "start": 193,
+                                                        "end": 194
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 197,
+                                            "end": 206,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 197,
+                                                "end": 206,
+                                                "children": [
+                                                  {
+                                                    "kind": "additive_expression",
+                                                    "start": 198,
+                                                    "end": 205,
+                                                    "children": [
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 198,
+                                                        "end": 201
+                                                      },
+                                                      {
+                                                        "kind": "simple_identifier",
+                                                        "start": 204,
+                                                        "end": 205
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 208,
+                                "end": 211
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 212,
+                                "end": 215,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 212,
+                                    "end": 215
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 113,
-          "end": 217
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 217
-      },
-      "result": "$sSiD",
-      "interface_type": "$syS2i_SitcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 219,
-          "end": 249
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 219,
-        "end": 249
+        "end": 250,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 219,
+            "end": 224
+          },
+          {
+            "kind": "call_suffix",
+            "start": 224,
+            "end": 250,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 224,
+                "end": 250,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 225,
+                    "end": 249,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 225,
+                        "end": 249,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 226,
+                            "end": 248,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 226,
+                                "end": 240,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 226,
+                                    "end": 233
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 233,
+                                    "end": 240,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 233,
+                                        "end": 240,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 234,
+                                            "end": 236,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 234,
+                                                "end": 236
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 238,
+                                            "end": 239,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 238,
+                                                "end": 239
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 241,
+                                "end": 244
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 245,
+                                "end": 248,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 245,
+                                    "end": 248
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/test_block.swift.json
+++ b/tests/json-ast/x/swift/test_block.swift.json
@@ -1,64 +1,214 @@
 {
-  "items": [
-    {
-      "_kind": "import_decl",
-      "range": {
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 145,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
         "start": 71,
-        "end": 78
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 90,
-          "end": 104
-        }
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 90,
-        "end": 104
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 105,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 95,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 95
+              }
+            ]
+          },
+          {
+            "kind": "tuple_expression",
+            "start": 98,
+            "end": 105,
+            "children": [
+              {
+                "kind": "additive_expression",
+                "start": 99,
+                "end": 104,
+                "children": [
+                  {
+                    "kind": "integer_literal",
+                    "start": 99,
+                    "end": 100
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 103,
+                    "end": 104
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 94,
-        "end": 94
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 106,
-          "end": 131
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 106,
-        "end": 131
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 133,
-          "end": 143
-        }
+        "end": 132,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 106,
+            "end": 112
+          },
+          {
+            "kind": "call_suffix",
+            "start": 112,
+            "end": 132,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 112,
+                "end": 132,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 113,
+                    "end": 131,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 113,
+                        "end": 131,
+                        "children": [
+                          {
+                            "kind": "equality_expression",
+                            "start": 114,
+                            "end": 130,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 114,
+                                "end": 125,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 115,
+                                    "end": 124,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 115,
+                                        "end": 116
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 117,
+                                        "end": 120
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 121,
+                                        "end": 124,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 121,
+                                            "end": 124
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 129,
+                                "end": 130
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 133,
-        "end": 143
+        "end": 144,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 133,
+            "end": 138
+          },
+          {
+            "kind": "call_suffix",
+            "start": 138,
+            "end": 144,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 138,
+                "end": 144,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 139,
+                    "end": 143,
+                    "children": [
+                      {
+                        "kind": "line_string_literal",
+                        "start": 139,
+                        "end": 143,
+                        "children": [
+                          {
+                            "kind": "line_str_text",
+                            "start": 140,
+                            "end": 142
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/tree_sum.swift.json
+++ b/tests/json-ast/x/swift/tree_sum.swift.json
@@ -1,0 +1,684 @@
+{
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 392,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
+        "start": 71,
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "function_declaration",
+        "start": 90,
+        "end": 275,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 95,
+            "end": 103
+          },
+          {
+            "kind": "parameter",
+            "start": 104,
+            "end": 112,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 104,
+                "end": 105
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 106,
+                "end": 107
+              },
+              {
+                "kind": "user_type",
+                "start": 109,
+                "end": 112,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 109,
+                    "end": 112
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "user_type",
+            "start": 117,
+            "end": 120,
+            "children": [
+              {
+                "kind": "type_identifier",
+                "start": 117,
+                "end": 120
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 121,
+            "end": 275,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 127,
+                "end": 274,
+                "children": [
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 127,
+                    "end": 273,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 134,
+                        "end": 273,
+                        "children": [
+                          {
+                            "kind": "ternary_expression",
+                            "start": 135,
+                            "end": 272,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 135,
+                                "end": 146,
+                                "children": [
+                                  {
+                                    "kind": "equality_expression",
+                                    "start": 136,
+                                    "end": 145,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 136,
+                                        "end": 137
+                                      },
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 141,
+                                        "end": 145
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 149,
+                                "end": 150
+                              },
+                              {
+                                "kind": "tuple_expression",
+                                "start": 153,
+                                "end": 272,
+                                "children": [
+                                  {
+                                    "kind": "ternary_expression",
+                                    "start": 154,
+                                    "end": 271,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 154,
+                                        "end": 185,
+                                        "children": [
+                                          {
+                                            "kind": "equality_expression",
+                                            "start": 155,
+                                            "end": 184,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 155,
+                                                "end": 156
+                                              },
+                                              {
+                                                "kind": "call_expression",
+                                                "start": 160,
+                                                "end": 184,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 160,
+                                                    "end": 164
+                                                  },
+                                                  {
+                                                    "kind": "call_suffix",
+                                                    "start": 164,
+                                                    "end": 184,
+                                                    "children": [
+                                                      {
+                                                        "kind": "value_arguments",
+                                                        "start": 164,
+                                                        "end": 184,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 165,
+                                                            "end": 169,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 165,
+                                                                "end": 169
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 171,
+                                                            "end": 176,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 171,
+                                                                "end": 176
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "value_argument",
+                                                            "start": 178,
+                                                            "end": 183,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 178,
+                                                                "end": 183
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 188,
+                                        "end": 265,
+                                        "children": [
+                                          {
+                                            "kind": "additive_expression",
+                                            "start": 189,
+                                            "end": 264,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 189,
+                                                "end": 236,
+                                                "children": [
+                                                  {
+                                                    "kind": "additive_expression",
+                                                    "start": 190,
+                                                    "end": 235,
+                                                    "children": [
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 190,
+                                                        "end": 214,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 191,
+                                                            "end": 213,
+                                                            "children": [
+                                                              {
+                                                                "kind": "call_expression",
+                                                                "start": 191,
+                                                                "end": 205,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 191,
+                                                                    "end": 199
+                                                                  },
+                                                                  {
+                                                                    "kind": "call_suffix",
+                                                                    "start": 199,
+                                                                    "end": 205,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_arguments",
+                                                                        "start": 199,
+                                                                        "end": 205,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "value_argument",
+                                                                            "start": 200,
+                                                                            "end": 204,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "simple_identifier",
+                                                                                "start": 200,
+                                                                                "end": 204
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 206,
+                                                                "end": 209
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 210,
+                                                                "end": 213,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 210,
+                                                                    "end": 213
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "tuple_expression",
+                                                        "start": 217,
+                                                        "end": 235,
+                                                        "children": [
+                                                          {
+                                                            "kind": "as_expression",
+                                                            "start": 218,
+                                                            "end": 234,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 218,
+                                                                "end": 223
+                                                              },
+                                                              {
+                                                                "kind": "as_operator",
+                                                                "start": 224,
+                                                                "end": 227
+                                                              },
+                                                              {
+                                                                "kind": "user_type",
+                                                                "start": 228,
+                                                                "end": 234,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "type_identifier",
+                                                                    "start": 228,
+                                                                    "end": 234
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 239,
+                                                "end": 264,
+                                                "children": [
+                                                  {
+                                                    "kind": "as_expression",
+                                                    "start": 240,
+                                                    "end": 263,
+                                                    "children": [
+                                                      {
+                                                        "kind": "call_expression",
+                                                        "start": 240,
+                                                        "end": 255,
+                                                        "children": [
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 240,
+                                                            "end": 248
+                                                          },
+                                                          {
+                                                            "kind": "call_suffix",
+                                                            "start": 248,
+                                                            "end": 255,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_arguments",
+                                                                "start": 248,
+                                                                "end": 255,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_argument",
+                                                                    "start": 249,
+                                                                    "end": 254,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "simple_identifier",
+                                                                        "start": 249,
+                                                                        "end": 254
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "as_operator",
+                                                        "start": 256,
+                                                        "end": 259
+                                                      },
+                                                      {
+                                                        "kind": "user_type",
+                                                        "start": 260,
+                                                        "end": 263,
+                                                        "children": [
+                                                          {
+                                                            "kind": "type_identifier",
+                                                            "start": 260,
+                                                            "end": 263
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 276,
+        "end": 362,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 276,
+            "end": 279
+          },
+          {
+            "kind": "pattern",
+            "start": 280,
+            "end": 281,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 280,
+                "end": 281
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 284,
+            "end": 362,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 285,
+                "end": 291,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 286,
+                    "end": 290
+                  }
+                ]
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 293,
+                "end": 297
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 299,
+                "end": 306,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 300,
+                    "end": 305
+                  }
+                ]
+              },
+              {
+                "kind": "integer_literal",
+                "start": 308,
+                "end": 309
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 311,
+                "end": 318,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 312,
+                    "end": 317
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 320,
+                "end": 361,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 321,
+                    "end": 327,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 322,
+                        "end": 326
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 329,
+                    "end": 333
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 335,
+                    "end": 342,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 336,
+                        "end": 341
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 344,
+                    "end": 345
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 347,
+                    "end": 354,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 348,
+                        "end": 353
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "simple_identifier",
+                    "start": 356,
+                    "end": 360
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 363,
+        "end": 391,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 363,
+            "end": 368
+          },
+          {
+            "kind": "call_suffix",
+            "start": 368,
+            "end": 391,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 368,
+                "end": 391,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 369,
+                    "end": 390,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 369,
+                        "end": 390,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 370,
+                            "end": 389,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 370,
+                                "end": 381,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 370,
+                                    "end": 378
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 378,
+                                    "end": 381,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 378,
+                                        "end": 381,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 379,
+                                            "end": 380,
+                                            "children": [
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 379,
+                                                "end": 380
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 382,
+                                "end": 385
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 386,
+                                "end": 389,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 386,
+                                    "end": 389
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/swift/two-sum.swift.json
+++ b/tests/json-ast/x/swift/two-sum.swift.json
@@ -1,98 +1,807 @@
 {
-  "items": [
-    {
-      "_kind": "func_decl",
-      "name": {
-        "base_name": {
-          "name": "twoSum"
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 437,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "params": {
-        "params": [
+      {
+        "kind": "function_declaration",
+        "start": 71,
+        "end": 343,
+        "children": [
           {
-            "name": {
-              "base_name": {
-                "name": "nums"
-              }
-            },
-            "interface_type": "$sSiXSaD"
+            "kind": "simple_identifier",
+            "start": 76,
+            "end": 82
           },
           {
-            "name": {
-              "base_name": {
-                "name": "target"
+            "kind": "parameter",
+            "start": 83,
+            "end": 96,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 83,
+                "end": 84
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 85,
+                "end": 89
+              },
+              {
+                "kind": "array_type",
+                "start": 91,
+                "end": 96,
+                "children": [
+                  {
+                    "kind": "user_type",
+                    "start": 92,
+                    "end": 95,
+                    "children": [
+                      {
+                        "kind": "type_identifier",
+                        "start": 92,
+                        "end": 95
+                      }
+                    ]
+                  }
+                ]
               }
-            },
-            "interface_type": "$sSiD"
+            ]
+          },
+          {
+            "kind": "parameter",
+            "start": 98,
+            "end": 111,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 98,
+                "end": 99
+              },
+              {
+                "kind": "simple_identifier",
+                "start": 100,
+                "end": 106
+              },
+              {
+                "kind": "user_type",
+                "start": 108,
+                "end": 111,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 108,
+                    "end": 111
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "array_type",
+            "start": 116,
+            "end": 121,
+            "children": [
+              {
+                "kind": "user_type",
+                "start": 117,
+                "end": 120,
+                "children": [
+                  {
+                    "kind": "type_identifier",
+                    "start": 117,
+                    "end": 120
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "function_body",
+            "start": 122,
+            "end": 343,
+            "children": [
+              {
+                "kind": "statements",
+                "start": 128,
+                "end": 342,
+                "children": [
+                  {
+                    "kind": "property_declaration",
+                    "start": 128,
+                    "end": 160,
+                    "children": [
+                      {
+                        "kind": "value_binding_pattern",
+                        "start": 128,
+                        "end": 131
+                      },
+                      {
+                        "kind": "pattern",
+                        "start": 132,
+                        "end": 133,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 132,
+                            "end": 133
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "tuple_expression",
+                        "start": 136,
+                        "end": 160,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 137,
+                            "end": 159,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 137,
+                                "end": 151,
+                                "children": [
+                                  {
+                                    "kind": "navigation_expression",
+                                    "start": 138,
+                                    "end": 150,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 138,
+                                        "end": 144,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 139,
+                                            "end": 143
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "navigation_suffix",
+                                        "start": 144,
+                                        "end": 150,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 145,
+                                            "end": 150
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 152,
+                                "end": 155
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 156,
+                                "end": 159,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 156,
+                                    "end": 159
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_statement",
+                    "start": 165,
+                    "end": 321,
+                    "children": [
+                      {
+                        "kind": "pattern",
+                        "start": 169,
+                        "end": 170,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 169,
+                            "end": 170
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "range_expression",
+                        "start": 174,
+                        "end": 179,
+                        "children": [
+                          {
+                            "kind": "integer_literal",
+                            "start": 174,
+                            "end": 175
+                          },
+                          {
+                            "kind": "simple_identifier",
+                            "start": 178,
+                            "end": 179
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "statements",
+                        "start": 190,
+                        "end": 320,
+                        "children": [
+                          {
+                            "kind": "for_statement",
+                            "start": 190,
+                            "end": 315,
+                            "children": [
+                              {
+                                "kind": "pattern",
+                                "start": 194,
+                                "end": 195,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 194,
+                                    "end": 195
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "range_expression",
+                                "start": 199,
+                                "end": 210,
+                                "children": [
+                                  {
+                                    "kind": "tuple_expression",
+                                    "start": 199,
+                                    "end": 206,
+                                    "children": [
+                                      {
+                                        "kind": "additive_expression",
+                                        "start": 200,
+                                        "end": 205,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 200,
+                                            "end": 201
+                                          },
+                                          {
+                                            "kind": "integer_literal",
+                                            "start": 204,
+                                            "end": 205
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 209,
+                                    "end": 210
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "statements",
+                                "start": 225,
+                                "end": 314,
+                                "children": [
+                                  {
+                                    "kind": "if_statement",
+                                    "start": 225,
+                                    "end": 305,
+                                    "children": [
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 228,
+                                        "end": 259,
+                                        "children": [
+                                          {
+                                            "kind": "equality_expression",
+                                            "start": 229,
+                                            "end": 258,
+                                            "children": [
+                                              {
+                                                "kind": "tuple_expression",
+                                                "start": 229,
+                                                "end": 248,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 230,
+                                                    "end": 247,
+                                                    "children": [
+                                                      {
+                                                        "kind": "additive_expression",
+                                                        "start": 230,
+                                                        "end": 244,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 230,
+                                                            "end": 237,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 230,
+                                                                "end": 234
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 234,
+                                                                "end": 237,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 234,
+                                                                    "end": 237,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 235,
+                                                                        "end": 236,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "simple_identifier",
+                                                                            "start": 235,
+                                                                            "end": 236
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "simple_identifier",
+                                                            "start": 240,
+                                                            "end": 244
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 244,
+                                                        "end": 247,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 244,
+                                                            "end": 247,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 245,
+                                                                "end": 246,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "simple_identifier",
+                                                                    "start": 245,
+                                                                    "end": 246
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "simple_identifier",
+                                                "start": 252,
+                                                "end": 258
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "statements",
+                                        "start": 278,
+                                        "end": 304,
+                                        "children": [
+                                          {
+                                            "kind": "control_transfer_statement",
+                                            "start": 278,
+                                            "end": 291,
+                                            "children": [
+                                              {
+                                                "kind": "array_literal",
+                                                "start": 285,
+                                                "end": 291,
+                                                "children": [
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 286,
+                                                    "end": 287
+                                                  },
+                                                  {
+                                                    "kind": "simple_identifier",
+                                                    "start": 289,
+                                                    "end": 290
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "control_transfer_statement",
+                    "start": 326,
+                    "end": 341,
+                    "children": [
+                      {
+                        "kind": "array_literal",
+                        "start": 333,
+                        "end": 341,
+                        "children": [
+                          {
+                            "kind": "prefix_expression",
+                            "start": 334,
+                            "end": 336,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 335,
+                                "end": 336
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "prefix_expression",
+                            "start": 338,
+                            "end": 340,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 339,
+                                "end": 340
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
-      "body": {
-        "range": {
-          "start": 122,
-          "end": 342
-        }
-      },
-      "range": {
-        "start": 71,
-        "end": 342
-      },
-      "result": "$sSiXSaD",
-      "interface_type": "$sySiXSaSiXSa_SitcD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 344,
-          "end": 381
-        }
-      },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 344,
-        "end": 381
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "result"
-        }
+        "end": 382,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 344,
+            "end": 347
+          },
+          {
+            "kind": "pattern",
+            "start": 348,
+            "end": 354,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 348,
+                "end": 354
+              }
+            ]
+          },
+          {
+            "kind": "call_expression",
+            "start": 357,
+            "end": 382,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 357,
+                "end": 363
+              },
+              {
+                "kind": "call_suffix",
+                "start": 363,
+                "end": 382,
+                "children": [
+                  {
+                    "kind": "value_arguments",
+                    "start": 363,
+                    "end": 382,
+                    "children": [
+                      {
+                        "kind": "value_argument",
+                        "start": 364,
+                        "end": 378,
+                        "children": [
+                          {
+                            "kind": "array_literal",
+                            "start": 364,
+                            "end": 378,
+                            "children": [
+                              {
+                                "kind": "integer_literal",
+                                "start": 365,
+                                "end": 366
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 368,
+                                "end": 369
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 371,
+                                "end": 373
+                              },
+                              {
+                                "kind": "integer_literal",
+                                "start": 375,
+                                "end": 377
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "value_argument",
+                        "start": 380,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "integer_literal",
+                            "start": 380,
+                            "end": 381
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
-        "start": 348,
-        "end": 348
-      },
-      "interface_type": "$sSiXSaD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 383,
-          "end": 408
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 383,
-        "end": 408
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 410,
-          "end": 435
-        }
+        "end": 409,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 383,
+            "end": 388
+          },
+          {
+            "kind": "call_suffix",
+            "start": 388,
+            "end": 409,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 388,
+                "end": 409,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 389,
+                    "end": 408,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 389,
+                        "end": 408,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 390,
+                            "end": 407,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 390,
+                                "end": 399,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 390,
+                                    "end": 396
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 396,
+                                    "end": 399,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 396,
+                                        "end": 399,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 397,
+                                            "end": 398,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 397,
+                                                "end": 398
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 400,
+                                "end": 403
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 404,
+                                "end": 407,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 404,
+                                    "end": 407
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 410,
-        "end": 435
+        "end": 436,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 410,
+            "end": 415
+          },
+          {
+            "kind": "call_suffix",
+            "start": 415,
+            "end": 436,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 415,
+                "end": 436,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 416,
+                    "end": 435,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 416,
+                        "end": 435,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 417,
+                            "end": 434,
+                            "children": [
+                              {
+                                "kind": "call_expression",
+                                "start": 417,
+                                "end": 426,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 417,
+                                    "end": 423
+                                  },
+                                  {
+                                    "kind": "call_suffix",
+                                    "start": 423,
+                                    "end": 426,
+                                    "children": [
+                                      {
+                                        "kind": "value_arguments",
+                                        "start": 423,
+                                        "end": 426,
+                                        "children": [
+                                          {
+                                            "kind": "value_argument",
+                                            "start": 424,
+                                            "end": 425,
+                                            "children": [
+                                              {
+                                                "kind": "integer_literal",
+                                                "start": 424,
+                                                "end": 425
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 427,
+                                "end": 430
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 431,
+                                "end": 434,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 431,
+                                    "end": 434
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/typed_let.swift.json
+++ b/tests/json-ast/x/swift/typed_let.swift.json
@@ -1,44 +1,112 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 100,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "y"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 98
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 81,
-        "end": 98
+        "end": 99,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 81,
+            "end": 86
+          },
+          {
+            "kind": "call_suffix",
+            "start": 86,
+            "end": 99,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 86,
+                "end": 99,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 87,
+                    "end": 98,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 87,
+                        "end": 98,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 88,
+                            "end": 97,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 88,
+                                "end": 89
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 90,
+                                "end": 93
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 94,
+                                "end": 97,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 94,
+                                    "end": 97
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/typed_var.swift.json
+++ b/tests/json-ast/x/swift/typed_var.swift.json
@@ -1,44 +1,112 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 100,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 98
-        }
-      },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 81,
-        "end": 98
+        "end": 99,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 81,
+            "end": 86
+          },
+          {
+            "kind": "call_suffix",
+            "start": 86,
+            "end": 99,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 86,
+                "end": 99,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 87,
+                    "end": 98,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 87,
+                        "end": 98,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 88,
+                            "end": 97,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 88,
+                                "end": 89
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 90,
+                                "end": 93
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 94,
+                                "end": 97,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 94,
+                                    "end": 97
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/unary_neg.swift.json
+++ b/tests/json-ast/x/swift/unary_neg.swift.json
@@ -1,30 +1,97 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 90,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 88
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 71,
+            "end": 76
+          },
+          {
+            "kind": "call_suffix",
+            "start": 76,
+            "end": 80,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 76,
+                "end": 80,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 77,
+                    "end": 79,
+                    "children": [
+                      {
+                        "kind": "prefix_expression",
+                        "start": 77,
+                        "end": 79,
+                        "children": [
+                          {
+                            "kind": "integer_literal",
+                            "start": 78,
+                            "end": 79
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 81,
-        "end": 88
+        "end": 89,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 81,
+            "end": 86
+          },
+          {
+            "kind": "call_suffix",
+            "start": 86,
+            "end": 89,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 86,
+                "end": 89,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 87,
+                    "end": 88,
+                    "children": [
+                      {
+                        "kind": "integer_literal",
+                        "start": 87,
+                        "end": 88
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/user_type_literal.swift.json
+++ b/tests/json-ast/x/swift/user_type_literal.swift.json
@@ -1,0 +1,366 @@
+{
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 220,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
+      },
+      {
+        "kind": "import_declaration",
+        "start": 71,
+        "end": 88,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 78,
+            "end": 88,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 78,
+                "end": 88
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "property_declaration",
+        "start": 90,
+        "end": 154,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 90,
+            "end": 93
+          },
+          {
+            "kind": "pattern",
+            "start": 94,
+            "end": 98,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 94,
+                "end": 98
+              }
+            ]
+          },
+          {
+            "kind": "dictionary_literal",
+            "start": 101,
+            "end": 154,
+            "children": [
+              {
+                "kind": "line_string_literal",
+                "start": 102,
+                "end": 109,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 103,
+                    "end": 108
+                  }
+                ]
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 111,
+                "end": 115,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 112,
+                    "end": 114
+                  }
+                ]
+              },
+              {
+                "kind": "line_string_literal",
+                "start": 117,
+                "end": 125,
+                "children": [
+                  {
+                    "kind": "line_str_text",
+                    "start": 118,
+                    "end": 124
+                  }
+                ]
+              },
+              {
+                "kind": "dictionary_literal",
+                "start": 127,
+                "end": 153,
+                "children": [
+                  {
+                    "kind": "line_string_literal",
+                    "start": 128,
+                    "end": 134,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 129,
+                        "end": 133
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 136,
+                    "end": 141,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 137,
+                        "end": 140
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "line_string_literal",
+                    "start": 143,
+                    "end": 148,
+                    "children": [
+                      {
+                        "kind": "line_str_text",
+                        "start": 144,
+                        "end": 147
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 150,
+                    "end": 152
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "call_expression",
+        "start": 155,
+        "end": 219,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 155,
+            "end": 160
+          },
+          {
+            "kind": "call_suffix",
+            "start": 160,
+            "end": 219,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 160,
+                "end": 219,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 161,
+                    "end": 218,
+                    "children": [
+                      {
+                        "kind": "call_expression",
+                        "start": 161,
+                        "end": 218,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 161,
+                            "end": 167
+                          },
+                          {
+                            "kind": "call_suffix",
+                            "start": 167,
+                            "end": 218,
+                            "children": [
+                              {
+                                "kind": "value_arguments",
+                                "start": 167,
+                                "end": 218,
+                                "children": [
+                                  {
+                                    "kind": "value_argument",
+                                    "start": 168,
+                                    "end": 217,
+                                    "children": [
+                                      {
+                                        "kind": "value_argument_label",
+                                        "start": 168,
+                                        "end": 178,
+                                        "children": [
+                                          {
+                                            "kind": "simple_identifier",
+                                            "start": 168,
+                                            "end": 178
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "tuple_expression",
+                                        "start": 180,
+                                        "end": 217,
+                                        "children": [
+                                          {
+                                            "kind": "as_expression",
+                                            "start": 181,
+                                            "end": 216,
+                                            "children": [
+                                              {
+                                                "kind": "postfix_expression",
+                                                "start": 181,
+                                                "end": 205,
+                                                "children": [
+                                                  {
+                                                    "kind": "call_expression",
+                                                    "start": 181,
+                                                    "end": 204,
+                                                    "children": [
+                                                      {
+                                                        "kind": "postfix_expression",
+                                                        "start": 181,
+                                                        "end": 196,
+                                                        "children": [
+                                                          {
+                                                            "kind": "call_expression",
+                                                            "start": 181,
+                                                            "end": 195,
+                                                            "children": [
+                                                              {
+                                                                "kind": "simple_identifier",
+                                                                "start": 181,
+                                                                "end": 185
+                                                              },
+                                                              {
+                                                                "kind": "call_suffix",
+                                                                "start": 185,
+                                                                "end": 195,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "value_arguments",
+                                                                    "start": 185,
+                                                                    "end": 195,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "value_argument",
+                                                                        "start": 186,
+                                                                        "end": 194,
+                                                                        "children": [
+                                                                          {
+                                                                            "kind": "line_string_literal",
+                                                                            "start": 186,
+                                                                            "end": 194,
+                                                                            "children": [
+                                                                              {
+                                                                                "kind": "line_str_text",
+                                                                                "start": 187,
+                                                                                "end": 193
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "kind": "bang",
+                                                            "start": 195,
+                                                            "end": 196
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "kind": "call_suffix",
+                                                        "start": 196,
+                                                        "end": 204,
+                                                        "children": [
+                                                          {
+                                                            "kind": "value_arguments",
+                                                            "start": 196,
+                                                            "end": 204,
+                                                            "children": [
+                                                              {
+                                                                "kind": "value_argument",
+                                                                "start": 197,
+                                                                "end": 203,
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "line_string_literal",
+                                                                    "start": 197,
+                                                                    "end": 203,
+                                                                    "children": [
+                                                                      {
+                                                                        "kind": "line_str_text",
+                                                                        "start": 198,
+                                                                        "end": 202
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "kind": "bang",
+                                                    "start": 204,
+                                                    "end": 205
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "kind": "as_operator",
+                                                "start": 206,
+                                                "end": 209
+                                              },
+                                              {
+                                                "kind": "user_type",
+                                                "start": 210,
+                                                "end": 216,
+                                                "children": [
+                                                  {
+                                                    "kind": "type_identifier",
+                                                    "start": 210,
+                                                    "end": 216
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/swift/var_assignment.swift.json
+++ b/tests/json-ast/x/swift/var_assignment.swift.json
@@ -1,57 +1,136 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 106,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "x"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 85
-        }
-      },
-      "range": {
+      {
+        "kind": "assignment",
         "start": 81,
-        "end": 85
-      }
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 87,
-          "end": 104
-        }
+        "end": 86,
+        "children": [
+          {
+            "kind": "directly_assignable_expression",
+            "start": 81,
+            "end": 82,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 81,
+                "end": 82
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 85,
+            "end": 86
+          }
+        ]
       },
-      "range": {
+      {
+        "kind": "call_expression",
         "start": 87,
-        "end": 104
+        "end": 105,
+        "children": [
+          {
+            "kind": "simple_identifier",
+            "start": 87,
+            "end": 92
+          },
+          {
+            "kind": "call_suffix",
+            "start": 92,
+            "end": 105,
+            "children": [
+              {
+                "kind": "value_arguments",
+                "start": 92,
+                "end": 105,
+                "children": [
+                  {
+                    "kind": "value_argument",
+                    "start": 93,
+                    "end": 104,
+                    "children": [
+                      {
+                        "kind": "tuple_expression",
+                        "start": 93,
+                        "end": 104,
+                        "children": [
+                          {
+                            "kind": "as_expression",
+                            "start": 94,
+                            "end": 103,
+                            "children": [
+                              {
+                                "kind": "simple_identifier",
+                                "start": 94,
+                                "end": 95
+                              },
+                              {
+                                "kind": "as_operator",
+                                "start": 96,
+                                "end": 99
+                              },
+                              {
+                                "kind": "user_type",
+                                "start": 100,
+                                "end": 103,
+                                "children": [
+                                  {
+                                    "kind": "type_identifier",
+                                    "start": 100,
+                                    "end": 103
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tests/json-ast/x/swift/while_loop.swift.json
+++ b/tests/json-ast/x/swift/while_loop.swift.json
@@ -1,44 +1,255 @@
 {
-  "items": [
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 71,
-          "end": 79
-        }
+  "file": {
+    "kind": "source_file",
+    "start": 0,
+    "end": 158,
+    "children": [
+      {
+        "kind": "comment",
+        "start": 0,
+        "end": 70
       },
-      "range": {
+      {
+        "kind": "property_declaration",
         "start": 71,
-        "end": 79
-      }
-    },
-    {
-      "_kind": "var_decl",
-      "name": {
-        "base_name": {
-          "name": "i"
-        }
+        "end": 80,
+        "children": [
+          {
+            "kind": "value_binding_pattern",
+            "start": 71,
+            "end": 74
+          },
+          {
+            "kind": "pattern",
+            "start": 75,
+            "end": 76,
+            "children": [
+              {
+                "kind": "simple_identifier",
+                "start": 75,
+                "end": 76
+              }
+            ]
+          },
+          {
+            "kind": "integer_literal",
+            "start": 79,
+            "end": 80
+          }
+        ]
       },
-      "range": {
-        "start": 75,
-        "end": 75
-      },
-      "interface_type": "$sSiD",
-      "access": "internal"
-    },
-    {
-      "_kind": "top_level_code_decl",
-      "body": {
-        "range": {
-          "start": 81,
-          "end": 156
-        }
-      },
-      "range": {
+      {
+        "kind": "while_statement",
         "start": 81,
-        "end": 156
+        "end": 157,
+        "children": [
+          {
+            "kind": "tuple_expression",
+            "start": 87,
+            "end": 104,
+            "children": [
+              {
+                "kind": "comparison_expression",
+                "start": 88,
+                "end": 103,
+                "children": [
+                  {
+                    "kind": "tuple_expression",
+                    "start": 88,
+                    "end": 99,
+                    "children": [
+                      {
+                        "kind": "as_expression",
+                        "start": 89,
+                        "end": 98,
+                        "children": [
+                          {
+                            "kind": "simple_identifier",
+                            "start": 89,
+                            "end": 90
+                          },
+                          {
+                            "kind": "as_operator",
+                            "start": 91,
+                            "end": 94
+                          },
+                          {
+                            "kind": "user_type",
+                            "start": 95,
+                            "end": 98,
+                            "children": [
+                              {
+                                "kind": "type_identifier",
+                                "start": 95,
+                                "end": 98
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "integer_literal",
+                    "start": 102,
+                    "end": 103
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "statements",
+            "start": 111,
+            "end": 156,
+            "children": [
+              {
+                "kind": "call_expression",
+                "start": 111,
+                "end": 129,
+                "children": [
+                  {
+                    "kind": "simple_identifier",
+                    "start": 111,
+                    "end": 116
+                  },
+                  {
+                    "kind": "call_suffix",
+                    "start": 116,
+                    "end": 129,
+                    "children": [
+                      {
+                        "kind": "value_arguments",
+                        "start": 116,
+                        "end": 129,
+                        "children": [
+                          {
+                            "kind": "value_argument",
+                            "start": 117,
+                            "end": 128,
+                            "children": [
+                              {
+                                "kind": "tuple_expression",
+                                "start": 117,
+                                "end": 128,
+                                "children": [
+                                  {
+                                    "kind": "as_expression",
+                                    "start": 118,
+                                    "end": 127,
+                                    "children": [
+                                      {
+                                        "kind": "simple_identifier",
+                                        "start": 118,
+                                        "end": 119
+                                      },
+                                      {
+                                        "kind": "as_operator",
+                                        "start": 120,
+                                        "end": 123
+                                      },
+                                      {
+                                        "kind": "user_type",
+                                        "start": 124,
+                                        "end": 127,
+                                        "children": [
+                                          {
+                                            "kind": "type_identifier",
+                                            "start": 124,
+                                            "end": 127
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "assignment",
+                "start": 134,
+                "end": 155,
+                "children": [
+                  {
+                    "kind": "directly_assignable_expression",
+                    "start": 134,
+                    "end": 135,
+                    "children": [
+                      {
+                        "kind": "simple_identifier",
+                        "start": 134,
+                        "end": 135
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "tuple_expression",
+                    "start": 138,
+                    "end": 155,
+                    "children": [
+                      {
+                        "kind": "additive_expression",
+                        "start": 139,
+                        "end": 154,
+                        "children": [
+                          {
+                            "kind": "tuple_expression",
+                            "start": 139,
+                            "end": 150,
+                            "children": [
+                              {
+                                "kind": "as_expression",
+                                "start": 140,
+                                "end": 149,
+                                "children": [
+                                  {
+                                    "kind": "simple_identifier",
+                                    "start": 140,
+                                    "end": 141
+                                  },
+                                  {
+                                    "kind": "as_operator",
+                                    "start": 142,
+                                    "end": 145
+                                  },
+                                  {
+                                    "kind": "user_type",
+                                    "start": 146,
+                                    "end": 149,
+                                    "children": [
+                                      {
+                                        "kind": "type_identifier",
+                                        "start": 146,
+                                        "end": 149
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "integer_literal",
+                            "start": 153,
+                            "end": 154
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
-    }
-  ]
+    ]
+  }
 }

--- a/tools/json-ast/x/swift/inspect.go
+++ b/tools/json-ast/x/swift/inspect.go
@@ -1,174 +1,48 @@
 package swift
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"time"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	ts "github.com/smacker/go-tree-sitter/swift"
 )
 
-// Program represents a parsed Swift source file as produced by
-// `swiftc -dump-ast -dump-ast-format json`.
-// Program represents a parsed Swift source file including its full AST.
+// Node represents a node in the Swift syntax tree.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// Program represents a parsed Swift source file.
 type Program struct {
 	File *Node `json:"file"`
 }
 
-// Node represents a single Swift AST node.
-// Only a subset of common fields are captured explicitly and all
-// child nodes are recursively stored in Children.
-type Node struct {
-	Kind     string       `json:"kind"`
-	Name     string       `json:"name,omitempty"`
-	Type     string       `json:"type,omitempty"`
-	Range    *offsetRange `json:"range,omitempty"`
-	Children []*Node      `json:"children,omitempty"`
-}
-
-type declName struct {
-	BaseName baseName `json:"base_name"`
-}
-
-type baseName struct {
-	Name string `json:"name"`
-}
-
-type offsetRange struct {
-	Start int `json:"start"`
-	End   int `json:"end"`
-}
-
-// Inspect parses Swift source code using the Swift compiler and
-// returns its AST as a Program.
+// Inspect parses the given Swift source code using tree-sitter and returns
+// a Program describing its syntax tree.
 func Inspect(src string) (*Program, error) {
-	tmp, err := os.CreateTemp("", "swift-src-*.swift")
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.WriteString(src); err != nil {
-		tmp.Close()
-		return nil, err
-	}
-	tmp.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "swiftc", "-dump-ast", "-dump-ast-format", "json", tmp.Name())
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("swiftc: %v: %s", err, out.String())
-	}
-	data := filterOutput(out.Bytes())
-	var raw json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, err
-	}
-	node, err := parseNode(raw)
-	if err != nil {
-		return nil, err
-	}
-	return &Program{File: node}, nil
+	p := sitter.NewParser()
+	p.SetLanguage(ts.GetLanguage())
+	tree := p.Parse(nil, []byte(src))
+	return &Program{File: toNode(tree.RootNode())}, nil
 }
 
-func filterOutput(data []byte) []byte {
-	var filtered [][]byte
-	for _, line := range bytes.Split(data, []byte("\n")) {
-		trim := bytes.TrimSpace(line)
-		if len(trim) == 0 {
-			continue
-		}
-		if trim[0] >= '0' && trim[0] <= '9' && bytes.Contains(trim, []byte("|")) {
-			continue
-		}
-		if bytes.HasPrefix(trim, []byte("tests/")) && bytes.Contains(trim, []byte("warning")) {
-			continue
-		}
-		filtered = append(filtered, trim)
+func toNode(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
 	}
-	data = bytes.Join(filtered, []byte("\n"))
-	start := bytes.Index(data, []byte("{\"_kind\""))
-	if start >= 0 {
-		data = data[start:]
-		depth := 0
-		inStr := false
-		for i, b := range data {
-			switch b {
-			case '"':
-				if i == 0 || data[i-1] != '\\' {
-					inStr = !inStr
-				}
-			case '{':
-				if !inStr {
-					depth++
-				}
-			case '}':
-				if !inStr {
-					depth--
-					if depth == 0 {
-						data = data[:i+1]
-						break
-					}
-				}
-			}
-		}
+	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, toNode(child))
 	}
-	return data
+	return out
 }
 
-func parseNode(data json.RawMessage) (*Node, error) {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, err
-	}
-	kindVal, ok := m["_kind"]
-	if !ok {
-		return nil, fmt.Errorf("missing _kind")
-	}
-	var n Node
-	if err := json.Unmarshal(kindVal, &n.Kind); err != nil {
-		return nil, err
-	}
-	delete(m, "_kind")
-	for k, v := range m {
-		switch k {
-		case "name":
-			var dn declName
-			if err := json.Unmarshal(v, &dn); err == nil {
-				n.Name = dn.BaseName.Name
-			}
-		case "type":
-			_ = json.Unmarshal(v, &n.Type)
-		case "range":
-			var r offsetRange
-			if err := json.Unmarshal(v, &r); err == nil {
-				n.Range = &r
-			}
-		default:
-			trimmed := bytes.TrimSpace(v)
-			if len(trimmed) == 0 {
-				continue
-			}
-			if trimmed[0] == '{' {
-				if child, err := parseNode(v); err == nil {
-					n.Children = append(n.Children, child)
-				}
-			} else if trimmed[0] == '[' {
-				var arr []json.RawMessage
-				if err := json.Unmarshal(v, &arr); err == nil {
-					for _, a := range arr {
-						if child, err := parseNode(a); err == nil {
-							n.Children = append(n.Children, child)
-						}
-					}
-				}
-			}
-		}
-	}
-	return &n, nil
+// MarshalJSON implements json.Marshaler for Program to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }

--- a/tools/json-ast/x/swift/inspect_test.go
+++ b/tools/json-ast/x/swift/inspect_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -36,24 +35,7 @@ func repoRoot(t *testing.T) string {
 	return ""
 }
 
-func ensureSwift(t *testing.T) string {
-	if env := os.Getenv("SWIFT"); env != "" {
-		if p, err := exec.LookPath(env); err == nil {
-			return p
-		}
-	}
-	if p, err := exec.LookPath("swiftc"); err == nil {
-		return p
-	}
-	if p, err := exec.LookPath("swift"); err == nil {
-		return p
-	}
-	t.Skip("swift not found")
-	return ""
-}
-
 func TestInspect_Golden(t *testing.T) {
-	_ = ensureSwift(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "swift")
 	outDir := filepath.Join(root, "tests", "json-ast", "x", "swift")


### PR DESCRIPTION
## Summary
- refactor `tools/json-ast/x/swift` to use `go-tree-sitter`
- drop dependency on `swiftc`
- regenerate Swift AST golden files

## Testing
- `go test ./tools/json-ast/x/swift -tags slow -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_6889aa72476483208b95be28b5d5995e