### PR TITLE
Switch python json-ast to tree-sitter

### DIFF
--- a/tests/json-ast/x/python/cross_join.python.json
+++ b/tests/json-ast/x/python/cross_join.python.json
@@ -1,1011 +1,1197 @@
 {
-  "module": {
-    "_type": "Module",
-    "body": [
+  "file": {
+    "kind": "module",
+    "start": 0,
+    "end": 897,
+    "children": [
       {
-        "_type": "ImportFrom",
-        "lineno": 3,
-        "end_lineno": 3,
-        "end_col_offset": 34
+        "kind": "comment",
+        "start": 0,
+        "end": 37
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 4,
-        "end_lineno": 4,
-        "end_col_offset": 33
+        "kind": "comment",
+        "start": 38,
+        "end": 92
       },
       {
-        "_type": "ImportFrom",
-        "lineno": 5,
-        "end_lineno": 5,
-        "end_col_offset": 29
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Customer",
-        "body": [
+        "kind": "future_import_statement",
+        "start": 93,
+        "end": 127,
+        "children": [
           {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 9,
-              "end_lineno": 9,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 9,
-            "end_lineno": 9,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 10,
-              "end_col_offset": 13
-            },
-            "target": {
-              "_type": "Name",
-              "id": "name",
-              "lineno": 10,
-              "end_lineno": 10,
-              "col_offset": 4,
-              "end_col_offset": 8
-            },
-            "lineno": 10,
-            "end_lineno": 10,
-            "col_offset": 4,
-            "end_col_offset": 13
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 7,
-            "end_lineno": 7,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 8,
-        "end_lineno": 10,
-        "end_col_offset": 13
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "customers",
-            "lineno": 12,
-            "end_lineno": 12,
-            "end_col_offset": 9
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 13,
-                "end_col_offset": 21
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 22,
-                  "end_col_offset": 23
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Alice",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 25,
-                  "end_col_offset": 32
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 13,
-              "end_col_offset": 33
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 35,
-                "end_col_offset": 43
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 44,
-                  "end_col_offset": 45
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Bob",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 47,
-                  "end_col_offset": 52
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 35,
-              "end_col_offset": 53
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Customer",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 12,
-                "end_lineno": 12,
-                "col_offset": 55,
-                "end_col_offset": 63
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 3,
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 64,
-                  "end_col_offset": 65
-                },
-                {
-                  "_type": "Constant",
-                  "value": "Charlie",
-                  "kind": null,
-                  "lineno": 12,
-                  "end_lineno": 12,
-                  "col_offset": 67,
-                  "end_col_offset": 76
-                }
-              ],
-              "keywords": [],
-              "lineno": 12,
-              "end_lineno": 12,
-              "col_offset": 55,
-              "end_col_offset": 77
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 12,
-          "end_lineno": 12,
-          "col_offset": 12,
-          "end_col_offset": 78
-        },
-        "lineno": 12,
-        "end_lineno": 12,
-        "end_col_offset": 78
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Order",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 8,
-              "end_col_offset": 11
-            },
-            "target": {
-              "_type": "Name",
-              "id": "id",
-              "lineno": 15,
-              "end_lineno": 15,
-              "col_offset": 4,
-              "end_col_offset": 6
-            },
-            "lineno": 15,
-            "end_lineno": 15,
-            "col_offset": 4,
-            "end_col_offset": 11
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "customerId",
-              "lineno": 16,
-              "end_lineno": 16,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 16,
-            "end_lineno": 16,
-            "col_offset": 4,
-            "end_col_offset": 19
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 11,
-              "end_col_offset": 14
-            },
-            "target": {
-              "_type": "Name",
-              "id": "total",
-              "lineno": 17,
-              "end_lineno": 17,
-              "col_offset": 4,
-              "end_col_offset": 9
-            },
-            "lineno": 17,
-            "end_lineno": 17,
-            "col_offset": 4,
-            "end_col_offset": 14
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 13,
-            "end_lineno": 13,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 14,
-        "end_lineno": 17,
-        "end_col_offset": 14
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "orders",
-            "lineno": 19,
-            "end_lineno": 19,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "List",
-          "elts": [
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 10,
-                "end_col_offset": 15
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 100,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 16,
-                  "end_col_offset": 19
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 21,
-                  "end_col_offset": 22
-                },
-                {
-                  "_type": "Constant",
-                  "value": 250,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 24,
-                  "end_col_offset": 27
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 10,
-              "end_col_offset": 28
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 30,
-                "end_col_offset": 35
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 101,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 36,
-                  "end_col_offset": 39
-                },
-                {
-                  "_type": "Constant",
-                  "value": 2,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 41,
-                  "end_col_offset": 42
-                },
-                {
-                  "_type": "Constant",
-                  "value": 125,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 44,
-                  "end_col_offset": 47
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 30,
-              "end_col_offset": 48
-            },
-            {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "Order",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 19,
-                "end_lineno": 19,
-                "col_offset": 50,
-                "end_col_offset": 55
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": 102,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 56,
-                  "end_col_offset": 59
-                },
-                {
-                  "_type": "Constant",
-                  "value": 1,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 61,
-                  "end_col_offset": 62
-                },
-                {
-                  "_type": "Constant",
-                  "value": 300,
-                  "kind": null,
-                  "lineno": 19,
-                  "end_lineno": 19,
-                  "col_offset": 64,
-                  "end_col_offset": 67
-                }
-              ],
-              "keywords": [],
-              "lineno": 19,
-              "end_lineno": 19,
-              "col_offset": 50,
-              "end_col_offset": 68
-            }
-          ],
-          "ctx": {
-            "_type": "Load"
-          },
-          "lineno": 19,
-          "end_lineno": 19,
-          "col_offset": 9,
-          "end_col_offset": 69
-        },
-        "lineno": 19,
-        "end_lineno": 19,
-        "end_col_offset": 69
-      },
-      {
-        "_type": "ClassDef",
-        "name": "Result",
-        "body": [
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 13,
-              "end_col_offset": 16
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderId",
-              "lineno": 22,
-              "end_lineno": 22,
-              "col_offset": 4,
-              "end_col_offset": 11
-            },
-            "lineno": 22,
-            "end_lineno": 22,
-            "col_offset": 4,
-            "end_col_offset": 16
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 21,
-              "end_col_offset": 24
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderCustomerId",
-              "lineno": 23,
-              "end_lineno": 23,
-              "col_offset": 4,
-              "end_col_offset": 19
-            },
-            "lineno": 23,
-            "end_lineno": 23,
-            "col_offset": 4,
-            "end_col_offset": 24
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "str",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 24,
-              "end_col_offset": 27
-            },
-            "target": {
-              "_type": "Name",
-              "id": "pairedCustomerName",
-              "lineno": 24,
-              "end_lineno": 24,
-              "col_offset": 4,
-              "end_col_offset": 22
-            },
-            "lineno": 24,
-            "end_lineno": 24,
-            "col_offset": 4,
-            "end_col_offset": 27
-          },
-          {
-            "_type": "AnnAssign",
-            "value": null,
-            "annotation": {
-              "_type": "Name",
-              "id": "int",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 16,
-              "end_col_offset": 19
-            },
-            "target": {
-              "_type": "Name",
-              "id": "orderTotal",
-              "lineno": 25,
-              "end_lineno": 25,
-              "col_offset": 4,
-              "end_col_offset": 14
-            },
-            "lineno": 25,
-            "end_lineno": 25,
-            "col_offset": 4,
-            "end_col_offset": 19
-          }
-        ],
-        "decorator_list": [
-          {
-            "_type": "Name",
-            "id": "dataclass",
-            "lineno": 20,
-            "end_lineno": 20,
-            "col_offset": 1,
-            "end_col_offset": 10
-          }
-        ],
-        "lineno": 21,
-        "end_lineno": 25,
-        "end_col_offset": 19
-      },
-      {
-        "_type": "Assign",
-        "targets": [
-          {
-            "_type": "Name",
-            "id": "result",
-            "lineno": 27,
-            "end_lineno": 27,
-            "end_col_offset": 6
-          }
-        ],
-        "value": {
-          "_type": "ListComp",
-          "elt": {
-            "_type": "Call",
-            "func": {
-              "_type": "Name",
-              "id": "Result",
-              "ctx": {
-                "_type": "Load"
-              },
-              "lineno": 27,
-              "end_lineno": 27,
-              "col_offset": 10,
-              "end_col_offset": 16
-            },
-            "args": [
+            "kind": "dotted_name",
+            "start": 116,
+            "end": 127,
+            "children": [
               {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 17,
-                  "end_col_offset": 18
-                },
-                "attr": "id",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 17,
-                "end_col_offset": 21
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 23,
-                  "end_col_offset": 24
-                },
-                "attr": "customerId",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 23,
-                "end_col_offset": 35
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "c",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 37,
-                  "end_col_offset": 38
-                },
-                "attr": "name",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 37,
-                "end_col_offset": 43
-              },
-              {
-                "_type": "Attribute",
-                "value": {
-                  "_type": "Name",
-                  "id": "o",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 27,
-                  "end_lineno": 27,
-                  "col_offset": 45,
-                  "end_col_offset": 46
-                },
-                "attr": "total",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 45,
-                "end_col_offset": 52
+                "kind": "identifier",
+                "start": 116,
+                "end": 127
               }
-            ],
-            "keywords": [],
-            "lineno": 27,
-            "end_lineno": 27,
-            "col_offset": 10,
-            "end_col_offset": 53
-          },
-          "generators": [
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "o",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 58,
-                "end_col_offset": 59
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "orders",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 63,
-                "end_col_offset": 69
-              },
-              "ifs": [],
-              "is_async": 0
-            },
-            {
-              "_type": "comprehension",
-              "target": {
-                "_type": "Name",
-                "id": "c",
-                "ctx": {
-                  "_type": "Store"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 74,
-                "end_col_offset": 75
-              },
-              "iter": {
-                "_type": "Name",
-                "id": "customers",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 27,
-                "end_lineno": 27,
-                "col_offset": 79,
-                "end_col_offset": 88
-              },
-              "ifs": [],
-              "is_async": 0
-            }
-          ],
-          "lineno": 27,
-          "end_lineno": 27,
-          "col_offset": 9,
-          "end_col_offset": 89
-        },
-        "lineno": 27,
-        "end_lineno": 27,
-        "end_col_offset": 89
-      },
-      {
-        "_type": "Expr",
-        "value": {
-          "_type": "Call",
-          "func": {
-            "_type": "Name",
-            "id": "print",
-            "ctx": {
-              "_type": "Load"
-            },
-            "lineno": 28,
-            "end_lineno": 28,
-            "col_offset": 0,
-            "end_col_offset": 5
-          },
-          "args": [
-            {
-              "_type": "Constant",
-              "value": "--- Cross Join: All order-customer pairs ---",
-              "kind": null,
-              "lineno": 28,
-              "end_lineno": 28,
-              "col_offset": 6,
-              "end_col_offset": 52
-            }
-          ],
-          "keywords": [],
-          "lineno": 28,
-          "end_lineno": 28,
-          "col_offset": 0,
-          "end_col_offset": 53
-        },
-        "lineno": 28,
-        "end_lineno": 28,
-        "end_col_offset": 53
-      },
-      {
-        "_type": "For",
-        "body": [
-          {
-            "_type": "Expr",
-            "value": {
-              "_type": "Call",
-              "func": {
-                "_type": "Name",
-                "id": "print",
-                "ctx": {
-                  "_type": "Load"
-                },
-                "lineno": 30,
-                "end_lineno": 30,
-                "col_offset": 4,
-                "end_col_offset": 9
-              },
-              "args": [
-                {
-                  "_type": "Constant",
-                  "value": "Order",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 10,
-                  "end_col_offset": 17
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 19,
-                    "end_col_offset": 24
-                  },
-                  "attr": "orderId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 19,
-                  "end_col_offset": 32
-                },
-                {
-                  "_type": "Constant",
-                  "value": "(customerId:",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 34,
-                  "end_col_offset": 48
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 50,
-                    "end_col_offset": 55
-                  },
-                  "attr": "orderCustomerId",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 50,
-                  "end_col_offset": 71
-                },
-                {
-                  "_type": "Constant",
-                  "value": ", total: $",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 73,
-                  "end_col_offset": 85
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 87,
-                    "end_col_offset": 92
-                  },
-                  "attr": "orderTotal",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 87,
-                  "end_col_offset": 103
-                },
-                {
-                  "_type": "Constant",
-                  "value": ") paired with",
-                  "kind": null,
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 105,
-                  "end_col_offset": 120
-                },
-                {
-                  "_type": "Attribute",
-                  "value": {
-                    "_type": "Name",
-                    "id": "entry",
-                    "ctx": {
-                      "_type": "Load"
-                    },
-                    "lineno": 30,
-                    "end_lineno": 30,
-                    "col_offset": 122,
-                    "end_col_offset": 127
-                  },
-                  "attr": "pairedCustomerName",
-                  "ctx": {
-                    "_type": "Load"
-                  },
-                  "lineno": 30,
-                  "end_lineno": 30,
-                  "col_offset": 122,
-                  "end_col_offset": 146
-                }
-              ],
-              "keywords": [],
-              "lineno": 30,
-              "end_lineno": 30,
-              "col_offset": 4,
-              "end_col_offset": 147
-            },
-            "lineno": 30,
-            "end_lineno": 30,
-            "col_offset": 4,
-            "end_col_offset": 147
+            ]
           }
-        ],
-        "target": {
-          "_type": "Name",
-          "id": "entry",
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 4,
-          "end_col_offset": 9
-        },
-        "iter": {
-          "_type": "Name",
-          "id": "result",
-          "lineno": 29,
-          "end_lineno": 29,
-          "col_offset": 13,
-          "end_col_offset": 19
-        },
-        "lineno": 29,
-        "end_lineno": 30,
-        "end_col_offset": 147
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 128,
+        "end": 161,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 133,
+            "end": 144,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 133,
+                "end": 144
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 152,
+            "end": 161,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 152,
+                "end": 161
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "import_from_statement",
+        "start": 162,
+        "end": 191,
+        "children": [
+          {
+            "kind": "dotted_name",
+            "start": 167,
+            "end": 173,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 167,
+                "end": 173
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 181,
+            "end": 185,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 181,
+                "end": 185
+              }
+            ]
+          },
+          {
+            "kind": "dotted_name",
+            "start": 187,
+            "end": 191,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 187,
+                "end": 191
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 193,
+        "end": 245,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 193,
+            "end": 203,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 194,
+                "end": 203
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 204,
+            "end": 245,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 210,
+                "end": 218
+              },
+              {
+                "kind": "block",
+                "start": 224,
+                "end": 245,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 224,
+                    "end": 231,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 224,
+                        "end": 231,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 224,
+                            "end": 226
+                          },
+                          {
+                            "kind": "type",
+                            "start": 228,
+                            "end": 231,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 228,
+                                "end": 231
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 236,
+                    "end": 245,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 236,
+                        "end": 245,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 236,
+                            "end": 240
+                          },
+                          {
+                            "kind": "type",
+                            "start": 242,
+                            "end": 245,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 242,
+                                "end": 245
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 247,
+        "end": 325,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 247,
+            "end": 325,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 247,
+                "end": 256
+              },
+              {
+                "kind": "list",
+                "start": 259,
+                "end": 325,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 260,
+                    "end": 280,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 260,
+                        "end": 268
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 268,
+                        "end": 280,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 269,
+                            "end": 270
+                          },
+                          {
+                            "kind": "string",
+                            "start": 272,
+                            "end": 279,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 272,
+                                "end": 273
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 273,
+                                "end": 278
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 278,
+                                "end": 279
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 282,
+                    "end": 300,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 282,
+                        "end": 290
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 290,
+                        "end": 300,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 291,
+                            "end": 292
+                          },
+                          {
+                            "kind": "string",
+                            "start": 294,
+                            "end": 299,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 294,
+                                "end": 295
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 295,
+                                "end": 298
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 298,
+                                "end": 299
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 302,
+                    "end": 324,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 302,
+                        "end": 310
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 310,
+                        "end": 324,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 311,
+                            "end": 312
+                          },
+                          {
+                            "kind": "string",
+                            "start": 314,
+                            "end": 323,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 314,
+                                "end": 315
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 315,
+                                "end": 322
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 322,
+                                "end": 323
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 326,
+        "end": 396,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 326,
+            "end": 336,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 327,
+                "end": 336
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 337,
+            "end": 396,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 343,
+                "end": 348
+              },
+              {
+                "kind": "block",
+                "start": 354,
+                "end": 396,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 354,
+                    "end": 361,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 354,
+                        "end": 361,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 354,
+                            "end": 356
+                          },
+                          {
+                            "kind": "type",
+                            "start": 358,
+                            "end": 361,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 358,
+                                "end": 361
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 366,
+                    "end": 381,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 366,
+                        "end": 381,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 366,
+                            "end": 376
+                          },
+                          {
+                            "kind": "type",
+                            "start": 378,
+                            "end": 381,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 378,
+                                "end": 381
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 386,
+                    "end": 396,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 386,
+                        "end": 396,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 386,
+                            "end": 391
+                          },
+                          {
+                            "kind": "type",
+                            "start": 393,
+                            "end": 396,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 393,
+                                "end": 396
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 398,
+        "end": 467,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 398,
+            "end": 467,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 398,
+                "end": 404
+              },
+              {
+                "kind": "list",
+                "start": 407,
+                "end": 467,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 408,
+                    "end": 426,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 408,
+                        "end": 413
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 413,
+                        "end": 426,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 414,
+                            "end": 417
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 419,
+                            "end": 420
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 422,
+                            "end": 425
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 428,
+                    "end": 446,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 428,
+                        "end": 433
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 433,
+                        "end": 446,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 434,
+                            "end": 437
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 439,
+                            "end": 440
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 442,
+                            "end": 445
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "call",
+                    "start": 448,
+                    "end": 466,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 448,
+                        "end": 453
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 453,
+                        "end": 466,
+                        "children": [
+                          {
+                            "kind": "integer",
+                            "start": 454,
+                            "end": 457
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 459,
+                            "end": 460
+                          },
+                          {
+                            "kind": "integer",
+                            "start": 462,
+                            "end": 465
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "decorated_definition",
+        "start": 468,
+        "end": 582,
+        "children": [
+          {
+            "kind": "decorator",
+            "start": 468,
+            "end": 478,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 469,
+                "end": 478
+              }
+            ]
+          },
+          {
+            "kind": "class_definition",
+            "start": 479,
+            "end": 582,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 485,
+                "end": 491
+              },
+              {
+                "kind": "block",
+                "start": 497,
+                "end": 582,
+                "children": [
+                  {
+                    "kind": "expression_statement",
+                    "start": 497,
+                    "end": 509,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 497,
+                        "end": 509,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 497,
+                            "end": 504
+                          },
+                          {
+                            "kind": "type",
+                            "start": 506,
+                            "end": 509,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 506,
+                                "end": 509
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 514,
+                    "end": 534,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 514,
+                        "end": 534,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 514,
+                            "end": 529
+                          },
+                          {
+                            "kind": "type",
+                            "start": 531,
+                            "end": 534,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 531,
+                                "end": 534
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 539,
+                    "end": 562,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 539,
+                        "end": 562,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 539,
+                            "end": 557
+                          },
+                          {
+                            "kind": "type",
+                            "start": 559,
+                            "end": 562,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 559,
+                                "end": 562
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "expression_statement",
+                    "start": 567,
+                    "end": 582,
+                    "children": [
+                      {
+                        "kind": "assignment",
+                        "start": 567,
+                        "end": 582,
+                        "children": [
+                          {
+                            "kind": "identifier",
+                            "start": 567,
+                            "end": 577
+                          },
+                          {
+                            "kind": "type",
+                            "start": 579,
+                            "end": 582,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 579,
+                                "end": 582
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 584,
+        "end": 673,
+        "children": [
+          {
+            "kind": "assignment",
+            "start": 584,
+            "end": 673,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 584,
+                "end": 590
+              },
+              {
+                "kind": "list_comprehension",
+                "start": 593,
+                "end": 673,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 594,
+                    "end": 637,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 594,
+                        "end": 600
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 600,
+                        "end": 637,
+                        "children": [
+                          {
+                            "kind": "attribute",
+                            "start": 601,
+                            "end": 605,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 601,
+                                "end": 602
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 603,
+                                "end": 605
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 607,
+                            "end": 619,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 607,
+                                "end": 608
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 609,
+                                "end": 619
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 621,
+                            "end": 627,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 621,
+                                "end": 622
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 623,
+                                "end": 627
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 629,
+                            "end": 636,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 629,
+                                "end": 630
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 631,
+                                "end": 636
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 638,
+                    "end": 653,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 642,
+                        "end": 643
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 647,
+                        "end": 653
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "for_in_clause",
+                    "start": 654,
+                    "end": 672,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 658,
+                        "end": 659
+                      },
+                      {
+                        "kind": "identifier",
+                        "start": 663,
+                        "end": 672
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "expression_statement",
+        "start": 674,
+        "end": 727,
+        "children": [
+          {
+            "kind": "call",
+            "start": 674,
+            "end": 727,
+            "children": [
+              {
+                "kind": "identifier",
+                "start": 674,
+                "end": 679
+              },
+              {
+                "kind": "argument_list",
+                "start": 679,
+                "end": 727,
+                "children": [
+                  {
+                    "kind": "string",
+                    "start": 680,
+                    "end": 726,
+                    "children": [
+                      {
+                        "kind": "string_start",
+                        "start": 680,
+                        "end": 681
+                      },
+                      {
+                        "kind": "string_content",
+                        "start": 681,
+                        "end": 725
+                      },
+                      {
+                        "kind": "string_end",
+                        "start": 725,
+                        "end": 726
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "for_statement",
+        "start": 728,
+        "end": 896,
+        "children": [
+          {
+            "kind": "identifier",
+            "start": 732,
+            "end": 737
+          },
+          {
+            "kind": "identifier",
+            "start": 741,
+            "end": 747
+          },
+          {
+            "kind": "block",
+            "start": 753,
+            "end": 896,
+            "children": [
+              {
+                "kind": "expression_statement",
+                "start": 753,
+                "end": 896,
+                "children": [
+                  {
+                    "kind": "call",
+                    "start": 753,
+                    "end": 896,
+                    "children": [
+                      {
+                        "kind": "identifier",
+                        "start": 753,
+                        "end": 758
+                      },
+                      {
+                        "kind": "argument_list",
+                        "start": 758,
+                        "end": 896,
+                        "children": [
+                          {
+                            "kind": "string",
+                            "start": 759,
+                            "end": 766,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 759,
+                                "end": 760
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 760,
+                                "end": 765
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 765,
+                                "end": 766
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 768,
+                            "end": 781,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 768,
+                                "end": 773
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 774,
+                                "end": 781
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 783,
+                            "end": 797,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 783,
+                                "end": 784
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 784,
+                                "end": 796
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 796,
+                                "end": 797
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 799,
+                            "end": 820,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 799,
+                                "end": 804
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 805,
+                                "end": 820
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 822,
+                            "end": 834,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 822,
+                                "end": 823
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 823,
+                                "end": 833
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 833,
+                                "end": 834
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 836,
+                            "end": 852,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 836,
+                                "end": 841
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 842,
+                                "end": 852
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "string",
+                            "start": 854,
+                            "end": 869,
+                            "children": [
+                              {
+                                "kind": "string_start",
+                                "start": 854,
+                                "end": 855
+                              },
+                              {
+                                "kind": "string_content",
+                                "start": 855,
+                                "end": 868
+                              },
+                              {
+                                "kind": "string_end",
+                                "start": 868,
+                                "end": 869
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "attribute",
+                            "start": 871,
+                            "end": 895,
+                            "children": [
+                              {
+                                "kind": "identifier",
+                                "start": 871,
+                                "end": 876
+                              },
+                              {
+                                "kind": "identifier",
+                                "start": 877,
+                                "end": 895
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tools/json-ast/x/python/ast.go
+++ b/tools/json-ast/x/python/ast.go
@@ -1,0 +1,24 @@
+package python
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node represents a tree-sitter node in a generic form.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// toNode converts a tree-sitter node to a Node.
+func toNode(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
+	}
+	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, toNode(child))
+	}
+	return out
+}

--- a/tools/json-ast/x/python/inspect.go
+++ b/tools/json-ast/x/python/inspect.go
@@ -1,105 +1,28 @@
 package python
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
-	"os/exec"
-	"strings"
-	"time"
-)
 
-// ASTNode mirrors Python's ast.AST structure as produced by the helper script.
-type ASTNode struct {
-	Type          string          `json:"_type"`
-	Name          string          `json:"name,omitempty"`
-	ID            string          `json:"id,omitempty"`
-	Arg           string          `json:"arg,omitempty"`
-	Body          []*ASTNode      `json:"body,omitempty"`
-	Targets       []*ASTNode      `json:"targets,omitempty"`
-	Value         json.RawMessage `json:"value,omitempty"`
-	Func          *ASTNode        `json:"func,omitempty"`
-	Args          json.RawMessage `json:"args,omitempty"`
-	Keywords      []*ASTNode      `json:"keywords,omitempty"`
-	Annotation    *ASTNode        `json:"annotation,omitempty"`
-	Returns       *ASTNode        `json:"returns,omitempty"`
-	Test          *ASTNode        `json:"test,omitempty"`
-	Target        *ASTNode        `json:"target,omitempty"`
-	Iter          *ASTNode        `json:"iter,omitempty"`
-	Operand       *ASTNode        `json:"operand,omitempty"`
-	Orelse        []*ASTNode      `json:"orelse,omitempty"`
-	Op            *ASTNode        `json:"op,omitempty"`
-	Left          *ASTNode        `json:"left,omitempty"`
-	Right         *ASTNode        `json:"right,omitempty"`
-	Attr          string          `json:"attr,omitempty"`
-	Elts          []*ASTNode      `json:"elts,omitempty"`
-	Keys          []*ASTNode      `json:"keys,omitempty"`
-	Values        []*ASTNode      `json:"values,omitempty"`
-	Slice         *ASTNode        `json:"slice,omitempty"`
-	Lower         *ASTNode        `json:"lower,omitempty"`
-	Upper         *ASTNode        `json:"upper,omitempty"`
-	Step          *ASTNode        `json:"step,omitempty"`
-	Ops           []*ASTNode      `json:"ops,omitempty"`
-	Comparators   []*ASTNode      `json:"comparators,omitempty"`
-	DecoratorList []*ASTNode      `json:"decorator_list,omitempty"`
-	Bases         []*ASTNode      `json:"bases,omitempty"`
-	Generators    []*ASTNode      `json:"generators,omitempty"`
-	Ifs           []*ASTNode      `json:"ifs,omitempty"`
-	Elt           *ASTNode        `json:"elt,omitempty"`
-	Line          int             `json:"lineno,omitempty"`
-	EndLine       int             `json:"end_lineno,omitempty"`
-	Col           int             `json:"col_offset,omitempty"`
-	EndCol        int             `json:"end_col_offset,omitempty"`
-}
+	sitter "github.com/smacker/go-tree-sitter"
+	tspython "github.com/smacker/go-tree-sitter/python"
+)
 
 // Program represents a parsed Python source file.
 type Program struct {
-	Module *ASTNode `json:"module"`
+	File *Node `json:"file"`
 }
 
-const astScript = `import ast, json, sys
-
-def node_to_dict(node):
-    if isinstance(node, ast.AST):
-        fields = {}
-        for k, v in ast.iter_fields(node):
-            fields[k] = node_to_dict(v)
-        for attr in ("lineno", "end_lineno", "col_offset", "end_col_offset"):
-            if hasattr(node, attr):
-                fields[attr] = getattr(node, attr)
-        return {'_type': node.__class__.__name__, **fields}
-    elif isinstance(node, list):
-        return [node_to_dict(x) for x in node]
-    else:
-        return node
-
-tree = ast.parse(sys.stdin.read())
-json.dump(node_to_dict(tree), sys.stdout)
-`
-
-var pythonCmd = "python3"
-
-// Inspect parses the given Python source code and returns a Program describing
-// its AST.
+// Inspect parses the given Python source code using tree-sitter and returns
+// a Program describing its syntax tree.
 func Inspect(src string) (*Program, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, pythonCmd, "-c", astScript)
-	cmd.Stdin = strings.NewReader(src)
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(errBuf.String())
-		if msg != "" {
-			return nil, fmt.Errorf("%v: %s", err, msg)
-		}
-		return nil, err
-	}
-	var root ASTNode
-	if err := json.Unmarshal(out.Bytes(), &root); err != nil {
-		return nil, err
-	}
-	return &Program{Module: &root}, nil
+	p := sitter.NewParser()
+	p.SetLanguage(tspython.GetLanguage())
+	tree := p.Parse(nil, []byte(src))
+	return &Program{File: toNode(tree.RootNode())}, nil
+}
+
+// MarshalJSON implements json.Marshaler for Program to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }

--- a/tools/json-ast/x/python/inspect_test.go
+++ b/tools/json-ast/x/python/inspect_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -36,14 +35,7 @@ func repoRoot(t *testing.T) string {
 	return ""
 }
 
-func ensurePython(t *testing.T) {
-	if _, err := exec.LookPath("python3"); err != nil {
-		t.Skip("python3 not installed")
-	}
-}
-
 func TestInspect_Golden(t *testing.T) {
-	ensurePython(t)
 	root := repoRoot(t)
 	srcDir := filepath.Join(root, "tests", "transpiler", "x", "python")
 	outDir := filepath.Join(root, "tests", "json-ast", "x", "python")


### PR DESCRIPTION
## Summary
- add `Node` struct for the python json-ast
- use tree-sitter to inspect python code
- update python inspector test
- regenerate `cross_join.python.json`

## Testing
- `go test ./tools/json-ast/x/python -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6889c0dde5e88320bb75b84c9652e876