### PR TITLE
Add AST struct for C# json-ast

### DIFF
--- a/tools/json-ast/x/cs/ast.go
+++ b/tools/json-ast/x/cs/ast.go
@@ -1,0 +1,33 @@
+package cs
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node models a portion of the C# syntax tree as returned by tree-sitter.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// Program represents a parsed C# file.
+type Program struct {
+	File *Node `json:"file"`
+}
+
+// convert builds a Node tree starting from the given tree-sitter node.
+func convert(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
+	}
+	node := &Node{
+		Kind:  n.Type(),
+		Start: int(n.StartByte()),
+		End:   int(n.EndByte()),
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		c := n.NamedChild(i)
+		node.Children = append(node.Children, convert(c))
+	}
+	return node
+}

--- a/tools/json-ast/x/cs/inspect.go
+++ b/tools/json-ast/x/cs/inspect.go
@@ -7,18 +7,7 @@ import (
 	csharp "github.com/smacker/go-tree-sitter/csharp"
 )
 
-// Node represents a tree-sitter node in a generic form.
-type Node struct {
-	Kind     string  `json:"kind"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Children []*Node `json:"children,omitempty"`
-}
-
-// Program represents a parsed C# source file.
-type Program struct {
-	File *Node `json:"file"`
-}
+// Program is defined in ast.go and composes Node values.
 
 // Inspect parses the given C# source code using tree-sitter and returns
 // a Program describing its syntax tree.
@@ -26,19 +15,7 @@ func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(csharp.GetLanguage())
 	tree := p.Parse(nil, []byte(src))
-	return &Program{File: toNode(tree.RootNode())}, nil
-}
-
-func toNode(n *sitter.Node) *Node {
-	if n == nil {
-		return nil
-	}
-	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
-		out.Children = append(out.Children, toNode(child))
-	}
-	return out
+	return &Program{File: convert(tree.RootNode())}, nil
 }
 
 // MarshalJSON implements json.Marshaler for Program to ensure stable output.


### PR DESCRIPTION
## Summary
- extract AST node types for C# json-ast package
- use `convert` helper when building programs
- regenerate cross_join.cs.json

## Testing
- `go test -tags slow -run TestInspect_Golden/cross_join$`

------
https://chatgpt.com/codex/tasks/task_e_6889c128a0c88320b12d890798a0ffc0