### PR TITLE
Refactor Java json-ast package

### DIFF
--- a/tools/json-ast/x/java/ast.go
+++ b/tools/json-ast/x/java/ast.go
@@ -1,0 +1,32 @@
+package java
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node models a tree-sitter node for Java source.
+type Node struct {
+	Kind     string `json:"kind"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Text     string `json:"text,omitempty"`
+	Children []Node `json:"children,omitempty"`
+}
+
+// convert creates a Node from a tree-sitter node.
+func convert(n *sitter.Node, src []byte) Node {
+	node := Node{
+		Kind:  n.Type(),
+		Start: int(n.StartByte()),
+		End:   int(n.EndByte()),
+	}
+	if n.ChildCount() == 0 {
+		node.Text = n.Content(src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		node.Children = append(node.Children, convert(child, src))
+	}
+	return node
+}

--- a/tools/json-ast/x/java/inspect.go
+++ b/tools/json-ast/x/java/inspect.go
@@ -10,15 +10,6 @@ import (
 	javats "github.com/smacker/go-tree-sitter/java"
 )
 
-// Node represents a tree-sitter node in a generic form.
-type Node struct {
-	Kind     string `json:"kind"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Text     string `json:"text,omitempty"`
-	Children []Node `json:"children,omitempty"`
-}
-
 // Program represents a parsed Java source file.
 type Program struct {
 	Root Node `json:"root"`
@@ -33,21 +24,6 @@ func Inspect(src string) (*Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
-	root := convertNode(tree.RootNode(), []byte(src))
+	root := convert(tree.RootNode(), []byte(src))
 	return &Program{Root: root}, nil
-}
-
-func convertNode(n *sitter.Node, src []byte) Node {
-	node := Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
-	if n.ChildCount() == 0 {
-		node.Text = n.Content(src)
-	}
-	for i := 0; i < int(n.ChildCount()); i++ {
-		child := n.Child(i)
-		if child == nil {
-			continue
-		}
-		node.Children = append(node.Children, convertNode(child, src))
-	}
-	return node
 }


### PR DESCRIPTION
## Summary
- add new `ast.go` with Node structure for Java
- refactor Java inspector to use the new AST utilities

## Testing
- `go test -tags slow ./tools/json-ast/x/java -run TestInspect_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_6889c16c7b4c8320825862ebf65e5380