### PR TITLE
Add Kotlin AST helper

### DIFF
--- a/tools/json-ast/x/kotlin/ast.go
+++ b/tools/json-ast/x/kotlin/ast.go
@@ -1,0 +1,30 @@
+package kotlin
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Node represents a tree-sitter node in a simplified AST form.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// toNode converts a tree-sitter Node into our AST Node structure.
+func toNode(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
+	}
+	node := &Node{
+		Kind:  n.Type(),
+		Start: int(n.StartByte()),
+		End:   int(n.EndByte()),
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		node.Children = append(node.Children, toNode(child))
+	}
+	return node
+}

--- a/tools/json-ast/x/kotlin/inspect.go
+++ b/tools/json-ast/x/kotlin/inspect.go
@@ -7,14 +7,6 @@ import (
 	ts "github.com/smacker/go-tree-sitter/kotlin"
 )
 
-// Node represents a tree-sitter node.
-type Node struct {
-	Kind     string  `json:"kind"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Children []*Node `json:"children,omitempty"`
-}
-
 // Program represents a parsed Kotlin source file.
 type Program struct {
 	File *Node `json:"file"`
@@ -26,22 +18,6 @@ func Inspect(src string) (*Program, error) {
 	p.SetLanguage(ts.GetLanguage())
 	tree := p.Parse(nil, []byte(src))
 	return &Program{File: toNode(tree.RootNode())}, nil
-}
-
-func toNode(n *sitter.Node) *Node {
-	if n == nil {
-		return nil
-	}
-	node := &Node{
-		Kind:  n.Type(),
-		Start: int(n.StartByte()),
-		End:   int(n.EndByte()),
-	}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
-		node.Children = append(node.Children, toNode(child))
-	}
-	return node
 }
 
 // MarshalJSON ensures stable output for Program.


### PR DESCRIPTION
## Summary
- add `ast.go` for Kotlin with simple AST node struct
- use new AST helpers from `inspect.go`
- regenerate Kotlin JSON AST golden files

## Testing
- `go test -tags slow ./tools/json-ast/x/kotlin -run TestInspect_Golden -update`
- `go test ./...` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6889c17763b48320a0a49b6dd71039c0