### PR TITLE
Use tree-sitter for php json-ast

### DIFF
--- a/tests/json-ast/x/php/cross_join.php.json
+++ b/tests/json-ast/x/php/cross_join.php.json
@@ -1,1076 +1,3780 @@
 {
   "root": {
-    "kind": "AST_STMT_LIST",
-    "flags": 0,
-    "lineno": 1,
+    "type": "program",
+    "start": 0,
+    "end": 1143,
     "children": [
       {
-        "kind": "AST_ASSIGN",
-        "flags": 0,
-        "lineno": 2,
-        "children": {
-          "var": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 2,
-            "children": {
-              "name": "customers"
-            }
-          },
-          "expr": {
-            "kind": "AST_ARRAY",
-            "flags": 3,
-            "lineno": 2,
-            "children": [
-              {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 2,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 2,
-                    "children": [
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": 1,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": "Alice",
-                          "key": "name"
-                        }
-                      }
-                    ]
-                  },
-                  "key": null
-                }
-              },
-              {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 2,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 2,
-                    "children": [
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": 2,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": "Bob",
-                          "key": "name"
-                        }
-                      }
-                    ]
-                  },
-                  "key": null
-                }
-              },
-              {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 2,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 2,
-                    "children": [
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": 3,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 2,
-                        "children": {
-                          "value": "Charlie",
-                          "key": "name"
-                        }
-                      }
-                    ]
-                  },
-                  "key": null
-                }
-              }
-            ]
-          }
-        }
+        "type": "php_tag",
+        "start": 0,
+        "end": 5,
+        "text": "\u003c?php"
       },
       {
-        "kind": "AST_ASSIGN",
-        "flags": 0,
-        "lineno": 3,
-        "children": {
-          "var": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 3,
-            "children": {
-              "name": "orders"
-            }
-          },
-          "expr": {
-            "kind": "AST_ARRAY",
-            "flags": 3,
-            "lineno": 3,
+        "type": "expression_statement",
+        "start": 6,
+        "end": 116,
+        "children": [
+          {
+            "type": "assignment_expression",
+            "start": 6,
+            "end": 115,
             "children": [
               {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 3,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 3,
-                    "children": [
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 100,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 1,
-                          "key": "customerId"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 250,
-                          "key": "total"
-                        }
-                      }
-                    ]
+                "type": "variable_name",
+                "start": 6,
+                "end": 16,
+                "children": [
+                  {
+                    "type": "$",
+                    "start": 6,
+                    "end": 7,
+                    "text": "$"
                   },
-                  "key": null
-                }
+                  {
+                    "type": "name",
+                    "start": 7,
+                    "end": 16,
+                    "text": "customers"
+                  }
+                ]
               },
               {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 3,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 3,
-                    "children": [
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 101,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 2,
-                          "key": "customerId"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 125,
-                          "key": "total"
-                        }
-                      }
-                    ]
-                  },
-                  "key": null
-                }
+                "type": "=",
+                "start": 17,
+                "end": 18,
+                "text": "="
               },
               {
-                "kind": "AST_ARRAY_ELEM",
-                "flags": 0,
-                "lineno": 3,
-                "children": {
-                  "value": {
-                    "kind": "AST_ARRAY",
-                    "flags": 3,
-                    "lineno": 3,
+                "type": "array_creation_expression",
+                "start": 19,
+                "end": 115,
+                "children": [
+                  {
+                    "type": "[",
+                    "start": 19,
+                    "end": 20,
+                    "text": "["
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 20,
+                    "end": 50,
                     "children": [
                       {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 102,
-                          "key": "id"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 1,
-                          "key": "customerId"
-                        }
-                      },
-                      {
-                        "kind": "AST_ARRAY_ELEM",
-                        "flags": 0,
-                        "lineno": 3,
-                        "children": {
-                          "value": 300,
-                          "key": "total"
-                        }
-                      }
-                    ]
-                  },
-                  "key": null
-                }
-              }
-            ]
-          }
-        }
-      },
-      {
-        "kind": "AST_ASSIGN",
-        "flags": 0,
-        "lineno": 4,
-        "children": {
-          "var": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 4,
-            "children": {
-              "name": "result"
-            }
-          },
-          "expr": {
-            "kind": "AST_ARRAY",
-            "flags": 3,
-            "lineno": 4
-          }
-        }
-      },
-      {
-        "kind": "AST_FOREACH",
-        "flags": 0,
-        "lineno": 5,
-        "children": {
-          "expr": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 5,
-            "children": {
-              "name": "orders"
-            }
-          },
-          "value": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 5,
-            "children": {
-              "name": "o"
-            }
-          },
-          "key": null,
-          "stmts": {
-            "kind": "AST_STMT_LIST",
-            "flags": 0,
-            "lineno": 5,
-            "children": [
-              {
-                "kind": "AST_FOREACH",
-                "flags": 0,
-                "lineno": 6,
-                "children": {
-                  "expr": {
-                    "kind": "AST_VAR",
-                    "flags": 0,
-                    "lineno": 6,
-                    "children": {
-                      "name": "customers"
-                    }
-                  },
-                  "value": {
-                    "kind": "AST_VAR",
-                    "flags": 0,
-                    "lineno": 6,
-                    "children": {
-                      "name": "c"
-                    }
-                  },
-                  "key": null,
-                  "stmts": {
-                    "kind": "AST_STMT_LIST",
-                    "flags": 0,
-                    "lineno": 6,
-                    "children": [
-                      {
-                        "kind": "AST_ASSIGN",
-                        "flags": 0,
-                        "lineno": 7,
-                        "children": {
-                          "var": {
-                            "kind": "AST_DIM",
-                            "flags": 0,
-                            "lineno": 7,
-                            "children": {
-                              "expr": {
-                                "kind": "AST_VAR",
-                                "flags": 0,
-                                "lineno": 7,
-                                "children": {
-                                  "name": "result"
-                                }
-                              },
-                              "dim": null
-                            }
+                        "type": "array_creation_expression",
+                        "start": 20,
+                        "end": 50,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 20,
+                            "end": 21,
+                            "text": "["
                           },
-                          "expr": {
-                            "kind": "AST_ARRAY",
-                            "flags": 3,
-                            "lineno": 7,
+                          {
+                            "type": "array_element_initializer",
+                            "start": 21,
+                            "end": 30,
                             "children": [
                               {
-                                "kind": "AST_ARRAY_ELEM",
-                                "flags": 0,
-                                "lineno": 7,
-                                "children": {
-                                  "value": {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 7,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 7,
-                                        "children": {
-                                          "name": "o"
-                                        }
-                                      },
-                                      "dim": "id"
-                                    }
-                                  },
-                                  "key": "orderId"
-                                }
-                              },
-                              {
-                                "kind": "AST_ARRAY_ELEM",
-                                "flags": 0,
-                                "lineno": 7,
-                                "children": {
-                                  "value": {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 7,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 7,
-                                        "children": {
-                                          "name": "o"
-                                        }
-                                      },
-                                      "dim": "customerId"
-                                    }
-                                  },
-                                  "key": "orderCustomerId"
-                                }
-                              },
-                              {
-                                "kind": "AST_ARRAY_ELEM",
-                                "flags": 0,
-                                "lineno": 7,
-                                "children": {
-                                  "value": {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 7,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 7,
-                                        "children": {
-                                          "name": "c"
-                                        }
-                                      },
-                                      "dim": "name"
-                                    }
-                                  },
-                                  "key": "pairedCustomerName"
-                                }
-                              },
-                              {
-                                "kind": "AST_ARRAY_ELEM",
-                                "flags": 0,
-                                "lineno": 7,
-                                "children": {
-                                  "value": {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 7,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 7,
-                                        "children": {
-                                          "name": "o"
-                                        }
-                                      },
-                                      "dim": "total"
-                                    }
-                                  },
-                                  "key": "orderTotal"
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        }
-      },
-      {
-        "kind": "AST_ECHO",
-        "flags": 0,
-        "lineno": 11,
-        "children": {
-          "expr": "--- Cross Join: All order-customer pairs ---"
-        }
-      },
-      {
-        "kind": "AST_ECHO",
-        "flags": 0,
-        "lineno": 11,
-        "children": {
-          "expr": {
-            "kind": "AST_CONST",
-            "flags": 0,
-            "lineno": 11,
-            "children": {
-              "name": {
-                "kind": "AST_NAME",
-                "flags": 1,
-                "lineno": 11,
-                "children": {
-                  "name": "PHP_EOL"
-                }
-              }
-            }
-          }
-        }
-      },
-      {
-        "kind": "AST_FOREACH",
-        "flags": 0,
-        "lineno": 12,
-        "children": {
-          "expr": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 12,
-            "children": {
-              "name": "result"
-            }
-          },
-          "value": {
-            "kind": "AST_VAR",
-            "flags": 0,
-            "lineno": 12,
-            "children": {
-              "name": "entry"
-            }
-          },
-          "key": null,
-          "stmts": {
-            "kind": "AST_STMT_LIST",
-            "flags": 0,
-            "lineno": 12,
-            "children": [
-              {
-                "kind": "AST_ECHO",
-                "flags": 0,
-                "lineno": 13,
-                "children": {
-                  "expr": {
-                    "kind": "AST_BINARY_OP",
-                    "flags": 8,
-                    "lineno": 13,
-                    "children": {
-                      "left": {
-                        "kind": "AST_BINARY_OP",
-                        "flags": 8,
-                        "lineno": 13,
-                        "children": {
-                          "left": {
-                            "kind": "AST_BINARY_OP",
-                            "flags": 8,
-                            "lineno": 13,
-                            "children": {
-                              "left": {
-                                "kind": "AST_BINARY_OP",
-                                "flags": 8,
-                                "lineno": 13,
-                                "children": {
-                                  "left": {
-                                    "kind": "AST_BINARY_OP",
-                                    "flags": 8,
-                                    "lineno": 13,
-                                    "children": {
-                                      "left": {
-                                        "kind": "AST_BINARY_OP",
-                                        "flags": 8,
-                                        "lineno": 13,
-                                        "children": {
-                                          "left": {
-                                            "kind": "AST_BINARY_OP",
-                                            "flags": 8,
-                                            "lineno": 13,
-                                            "children": {
-                                              "left": {
-                                                "kind": "AST_BINARY_OP",
-                                                "flags": 8,
-                                                "lineno": 13,
-                                                "children": {
-                                                  "left": {
-                                                    "kind": "AST_BINARY_OP",
-                                                    "flags": 8,
-                                                    "lineno": 13,
-                                                    "children": {
-                                                      "left": {
-                                                        "kind": "AST_BINARY_OP",
-                                                        "flags": 8,
-                                                        "lineno": 13,
-                                                        "children": {
-                                                          "left": {
-                                                            "kind": "AST_BINARY_OP",
-                                                            "flags": 8,
-                                                            "lineno": 13,
-                                                            "children": {
-                                                              "left": {
-                                                                "kind": "AST_BINARY_OP",
-                                                                "flags": 8,
-                                                                "lineno": 13,
-                                                                "children": {
-                                                                  "left": {
-                                                                    "kind": "AST_BINARY_OP",
-                                                                    "flags": 8,
-                                                                    "lineno": 13,
-                                                                    "children": {
-                                                                      "left": "Order ",
-                                                                      "right": {
-                                                                        "kind": "AST_CONDITIONAL",
-                                                                        "flags": 1,
-                                                                        "lineno": 13,
-                                                                        "children": {
-                                                                          "cond": {
-                                                                            "kind": "AST_CALL",
-                                                                            "flags": 0,
-                                                                            "lineno": 13,
-                                                                            "children": {
-                                                                              "expr": {
-                                                                                "kind": "AST_NAME",
-                                                                                "flags": 1,
-                                                                                "lineno": 13,
-                                                                                "children": {
-                                                                                  "name": "is_float"
-                                                                                }
-                                                                              },
-                                                                              "args": {
-                                                                                "kind": "AST_ARG_LIST",
-                                                                                "flags": 0,
-                                                                                "lineno": 13,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "AST_DIM",
-                                                                                    "flags": 0,
-                                                                                    "lineno": 13,
-                                                                                    "children": {
-                                                                                      "expr": {
-                                                                                        "kind": "AST_VAR",
-                                                                                        "flags": 0,
-                                                                                        "lineno": 13,
-                                                                                        "children": {
-                                                                                          "name": "entry"
-                                                                                        }
-                                                                                      },
-                                                                                      "dim": "orderId"
-                                                                                    }
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            }
-                                                                          },
-                                                                          "true": {
-                                                                            "kind": "AST_CALL",
-                                                                            "flags": 0,
-                                                                            "lineno": 13,
-                                                                            "children": {
-                                                                              "expr": {
-                                                                                "kind": "AST_NAME",
-                                                                                "flags": 1,
-                                                                                "lineno": 13,
-                                                                                "children": {
-                                                                                  "name": "json_encode"
-                                                                                }
-                                                                              },
-                                                                              "args": {
-                                                                                "kind": "AST_ARG_LIST",
-                                                                                "flags": 0,
-                                                                                "lineno": 13,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "kind": "AST_DIM",
-                                                                                    "flags": 0,
-                                                                                    "lineno": 13,
-                                                                                    "children": {
-                                                                                      "expr": {
-                                                                                        "kind": "AST_VAR",
-                                                                                        "flags": 0,
-                                                                                        "lineno": 13,
-                                                                                        "children": {
-                                                                                          "name": "entry"
-                                                                                        }
-                                                                                      },
-                                                                                      "dim": "orderId"
-                                                                                    }
-                                                                                  },
-                                                                                  1344
-                                                                                ]
-                                                                              }
-                                                                            }
-                                                                          },
-                                                                          "false": {
-                                                                            "kind": "AST_DIM",
-                                                                            "flags": 0,
-                                                                            "lineno": 13,
-                                                                            "children": {
-                                                                              "expr": {
-                                                                                "kind": "AST_VAR",
-                                                                                "flags": 0,
-                                                                                "lineno": 13,
-                                                                                "children": {
-                                                                                  "name": "entry"
-                                                                                }
-                                                                              },
-                                                                              "dim": "orderId"
-                                                                            }
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  },
-                                                                  "right": " "
-                                                                }
-                                                              },
-                                                              "right": "(customerId:"
-                                                            }
-                                                          },
-                                                          "right": " "
-                                                        }
-                                                      },
-                                                      "right": {
-                                                        "kind": "AST_CONDITIONAL",
-                                                        "flags": 1,
-                                                        "lineno": 13,
-                                                        "children": {
-                                                          "cond": {
-                                                            "kind": "AST_CALL",
-                                                            "flags": 0,
-                                                            "lineno": 13,
-                                                            "children": {
-                                                              "expr": {
-                                                                "kind": "AST_NAME",
-                                                                "flags": 1,
-                                                                "lineno": 13,
-                                                                "children": {
-                                                                  "name": "is_float"
-                                                                }
-                                                              },
-                                                              "args": {
-                                                                "kind": "AST_ARG_LIST",
-                                                                "flags": 0,
-                                                                "lineno": 13,
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "AST_DIM",
-                                                                    "flags": 0,
-                                                                    "lineno": 13,
-                                                                    "children": {
-                                                                      "expr": {
-                                                                        "kind": "AST_VAR",
-                                                                        "flags": 0,
-                                                                        "lineno": 13,
-                                                                        "children": {
-                                                                          "name": "entry"
-                                                                        }
-                                                                      },
-                                                                      "dim": "orderCustomerId"
-                                                                    }
-                                                                  }
-                                                                ]
-                                                              }
-                                                            }
-                                                          },
-                                                          "true": {
-                                                            "kind": "AST_CALL",
-                                                            "flags": 0,
-                                                            "lineno": 13,
-                                                            "children": {
-                                                              "expr": {
-                                                                "kind": "AST_NAME",
-                                                                "flags": 1,
-                                                                "lineno": 13,
-                                                                "children": {
-                                                                  "name": "json_encode"
-                                                                }
-                                                              },
-                                                              "args": {
-                                                                "kind": "AST_ARG_LIST",
-                                                                "flags": 0,
-                                                                "lineno": 13,
-                                                                "children": [
-                                                                  {
-                                                                    "kind": "AST_DIM",
-                                                                    "flags": 0,
-                                                                    "lineno": 13,
-                                                                    "children": {
-                                                                      "expr": {
-                                                                        "kind": "AST_VAR",
-                                                                        "flags": 0,
-                                                                        "lineno": 13,
-                                                                        "children": {
-                                                                          "name": "entry"
-                                                                        }
-                                                                      },
-                                                                      "dim": "orderCustomerId"
-                                                                    }
-                                                                  },
-                                                                  1344
-                                                                ]
-                                                              }
-                                                            }
-                                                          },
-                                                          "false": {
-                                                            "kind": "AST_DIM",
-                                                            "flags": 0,
-                                                            "lineno": 13,
-                                                            "children": {
-                                                              "expr": {
-                                                                "kind": "AST_VAR",
-                                                                "flags": 0,
-                                                                "lineno": 13,
-                                                                "children": {
-                                                                  "name": "entry"
-                                                                }
-                                                              },
-                                                              "dim": "orderCustomerId"
-                                                            }
-                                                          }
-                                                        }
-                                                      }
-                                                    }
-                                                  },
-                                                  "right": " "
-                                                }
-                                              },
-                                              "right": ", total: $"
-                                            }
-                                          },
-                                          "right": " "
-                                        }
-                                      },
-                                      "right": {
-                                        "kind": "AST_CONDITIONAL",
-                                        "flags": 1,
-                                        "lineno": 13,
-                                        "children": {
-                                          "cond": {
-                                            "kind": "AST_CALL",
-                                            "flags": 0,
-                                            "lineno": 13,
-                                            "children": {
-                                              "expr": {
-                                                "kind": "AST_NAME",
-                                                "flags": 1,
-                                                "lineno": 13,
-                                                "children": {
-                                                  "name": "is_float"
-                                                }
-                                              },
-                                              "args": {
-                                                "kind": "AST_ARG_LIST",
-                                                "flags": 0,
-                                                "lineno": 13,
-                                                "children": [
-                                                  {
-                                                    "kind": "AST_DIM",
-                                                    "flags": 0,
-                                                    "lineno": 13,
-                                                    "children": {
-                                                      "expr": {
-                                                        "kind": "AST_VAR",
-                                                        "flags": 0,
-                                                        "lineno": 13,
-                                                        "children": {
-                                                          "name": "entry"
-                                                        }
-                                                      },
-                                                      "dim": "orderTotal"
-                                                    }
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          "true": {
-                                            "kind": "AST_CALL",
-                                            "flags": 0,
-                                            "lineno": 13,
-                                            "children": {
-                                              "expr": {
-                                                "kind": "AST_NAME",
-                                                "flags": 1,
-                                                "lineno": 13,
-                                                "children": {
-                                                  "name": "json_encode"
-                                                }
-                                              },
-                                              "args": {
-                                                "kind": "AST_ARG_LIST",
-                                                "flags": 0,
-                                                "lineno": 13,
-                                                "children": [
-                                                  {
-                                                    "kind": "AST_DIM",
-                                                    "flags": 0,
-                                                    "lineno": 13,
-                                                    "children": {
-                                                      "expr": {
-                                                        "kind": "AST_VAR",
-                                                        "flags": 0,
-                                                        "lineno": 13,
-                                                        "children": {
-                                                          "name": "entry"
-                                                        }
-                                                      },
-                                                      "dim": "orderTotal"
-                                                    }
-                                                  },
-                                                  1344
-                                                ]
-                                              }
-                                            }
-                                          },
-                                          "false": {
-                                            "kind": "AST_DIM",
-                                            "flags": 0,
-                                            "lineno": 13,
-                                            "children": {
-                                              "expr": {
-                                                "kind": "AST_VAR",
-                                                "flags": 0,
-                                                "lineno": 13,
-                                                "children": {
-                                                  "name": "entry"
-                                                }
-                                              },
-                                              "dim": "orderTotal"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "right": " "
-                                }
-                              },
-                              "right": ") paired with"
-                            }
-                          },
-                          "right": " "
-                        }
-                      },
-                      "right": {
-                        "kind": "AST_CONDITIONAL",
-                        "flags": 1,
-                        "lineno": 13,
-                        "children": {
-                          "cond": {
-                            "kind": "AST_CALL",
-                            "flags": 0,
-                            "lineno": 13,
-                            "children": {
-                              "expr": {
-                                "kind": "AST_NAME",
-                                "flags": 1,
-                                "lineno": 13,
-                                "children": {
-                                  "name": "is_float"
-                                }
-                              },
-                              "args": {
-                                "kind": "AST_ARG_LIST",
-                                "flags": 0,
-                                "lineno": 13,
+                                "type": "encapsed_string",
+                                "start": 21,
+                                "end": 25,
                                 "children": [
                                   {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 13,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 13,
-                                        "children": {
-                                          "name": "entry"
-                                        }
-                                      },
-                                      "dim": "pairedCustomerName"
-                                    }
+                                    "type": "\"",
+                                    "start": 21,
+                                    "end": 22,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 22,
+                                    "end": 24,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 24,
+                                    "end": 25,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 26,
+                                "end": 28,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 29,
+                                "end": 30,
+                                "text": "1"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 30,
+                            "end": 31,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 32,
+                            "end": 49,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 32,
+                                "end": 38,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 32,
+                                    "end": 33,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 33,
+                                    "end": 37,
+                                    "text": "name"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 37,
+                                    "end": 38,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 39,
+                                "end": 41,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "encapsed_string",
+                                "start": 42,
+                                "end": 49,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 42,
+                                    "end": 43,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 43,
+                                    "end": 48,
+                                    "text": "Alice"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 48,
+                                    "end": 49,
+                                    "text": "\""
                                   }
                                 ]
                               }
-                            }
+                            ]
                           },
-                          "true": {
-                            "kind": "AST_CALL",
-                            "flags": 0,
-                            "lineno": 13,
-                            "children": {
-                              "expr": {
-                                "kind": "AST_NAME",
-                                "flags": 1,
-                                "lineno": 13,
-                                "children": {
-                                  "name": "json_encode"
-                                }
-                              },
-                              "args": {
-                                "kind": "AST_ARG_LIST",
-                                "flags": 0,
-                                "lineno": 13,
+                          {
+                            "type": "]",
+                            "start": 49,
+                            "end": 50,
+                            "text": "]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": ",",
+                    "start": 50,
+                    "end": 51,
+                    "text": ","
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 52,
+                    "end": 80,
+                    "children": [
+                      {
+                        "type": "array_creation_expression",
+                        "start": 52,
+                        "end": 80,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 52,
+                            "end": 53,
+                            "text": "["
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 53,
+                            "end": 62,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 53,
+                                "end": 57,
                                 "children": [
                                   {
-                                    "kind": "AST_DIM",
-                                    "flags": 0,
-                                    "lineno": 13,
-                                    "children": {
-                                      "expr": {
-                                        "kind": "AST_VAR",
-                                        "flags": 0,
-                                        "lineno": 13,
-                                        "children": {
-                                          "name": "entry"
-                                        }
-                                      },
-                                      "dim": "pairedCustomerName"
-                                    }
+                                    "type": "\"",
+                                    "start": 53,
+                                    "end": 54,
+                                    "text": "\""
                                   },
-                                  1344
+                                  {
+                                    "type": "string_content",
+                                    "start": 54,
+                                    "end": 56,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 56,
+                                    "end": 57,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 58,
+                                "end": 60,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 61,
+                                "end": 62,
+                                "text": "2"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 62,
+                            "end": 63,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 64,
+                            "end": 79,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 64,
+                                "end": 70,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 64,
+                                    "end": 65,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 65,
+                                    "end": 69,
+                                    "text": "name"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 69,
+                                    "end": 70,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 71,
+                                "end": 73,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "encapsed_string",
+                                "start": 74,
+                                "end": 79,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 74,
+                                    "end": 75,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 75,
+                                    "end": 78,
+                                    "text": "Bob"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 78,
+                                    "end": 79,
+                                    "text": "\""
+                                  }
                                 ]
                               }
-                            }
+                            ]
                           },
-                          "false": {
-                            "kind": "AST_DIM",
-                            "flags": 0,
-                            "lineno": 13,
-                            "children": {
-                              "expr": {
-                                "kind": "AST_VAR",
-                                "flags": 0,
-                                "lineno": 13,
-                                "children": {
-                                  "name": "entry"
-                                }
-                              },
-                              "dim": "pairedCustomerName"
-                            }
+                          {
+                            "type": "]",
+                            "start": 79,
+                            "end": 80,
+                            "text": "]"
                           }
-                        }
+                        ]
                       }
-                    }
+                    ]
+                  },
+                  {
+                    "type": ",",
+                    "start": 80,
+                    "end": 81,
+                    "text": ","
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 82,
+                    "end": 114,
+                    "children": [
+                      {
+                        "type": "array_creation_expression",
+                        "start": 82,
+                        "end": 114,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 82,
+                            "end": 83,
+                            "text": "["
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 83,
+                            "end": 92,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 83,
+                                "end": 87,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 83,
+                                    "end": 84,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 84,
+                                    "end": 86,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 86,
+                                    "end": 87,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 88,
+                                "end": 90,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 91,
+                                "end": 92,
+                                "text": "3"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 92,
+                            "end": 93,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 94,
+                            "end": 113,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 94,
+                                "end": 100,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 94,
+                                    "end": 95,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 95,
+                                    "end": 99,
+                                    "text": "name"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 99,
+                                    "end": 100,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 101,
+                                "end": 103,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "encapsed_string",
+                                "start": 104,
+                                "end": 113,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 104,
+                                    "end": 105,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 105,
+                                    "end": 112,
+                                    "text": "Charlie"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 112,
+                                    "end": 113,
+                                    "text": "\""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": "]",
+                            "start": 113,
+                            "end": 114,
+                            "text": "]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "]",
+                    "start": 114,
+                    "end": 115,
+                    "text": "]"
                   }
-                }
+                ]
+              }
+            ]
+          },
+          {
+            "type": ";",
+            "start": 115,
+            "end": 116,
+            "text": ";"
+          }
+        ]
+      },
+      {
+        "type": "expression_statement",
+        "start": 117,
+        "end": 278,
+        "children": [
+          {
+            "type": "assignment_expression",
+            "start": 117,
+            "end": 277,
+            "children": [
+              {
+                "type": "variable_name",
+                "start": 117,
+                "end": 124,
+                "children": [
+                  {
+                    "type": "$",
+                    "start": 117,
+                    "end": 118,
+                    "text": "$"
+                  },
+                  {
+                    "type": "name",
+                    "start": 118,
+                    "end": 124,
+                    "text": "orders"
+                  }
+                ]
               },
               {
-                "kind": "AST_ECHO",
-                "flags": 0,
-                "lineno": 13,
-                "children": {
-                  "expr": {
-                    "kind": "AST_CONST",
-                    "flags": 0,
-                    "lineno": 13,
-                    "children": {
-                      "name": {
-                        "kind": "AST_NAME",
-                        "flags": 1,
-                        "lineno": 13,
-                        "children": {
-                          "name": "PHP_EOL"
-                        }
+                "type": "=",
+                "start": 125,
+                "end": 126,
+                "text": "="
+              },
+              {
+                "type": "array_creation_expression",
+                "start": 127,
+                "end": 277,
+                "children": [
+                  {
+                    "type": "[",
+                    "start": 127,
+                    "end": 128,
+                    "text": "["
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 128,
+                    "end": 176,
+                    "children": [
+                      {
+                        "type": "array_creation_expression",
+                        "start": 128,
+                        "end": 176,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 128,
+                            "end": 129,
+                            "text": "["
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 129,
+                            "end": 140,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 129,
+                                "end": 133,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 129,
+                                    "end": 130,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 130,
+                                    "end": 132,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 132,
+                                    "end": 133,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 134,
+                                "end": 136,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 137,
+                                "end": 140,
+                                "text": "100"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 140,
+                            "end": 141,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 142,
+                            "end": 159,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 142,
+                                "end": 154,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 142,
+                                    "end": 143,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 143,
+                                    "end": 153,
+                                    "text": "customerId"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 153,
+                                    "end": 154,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 155,
+                                "end": 157,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 158,
+                                "end": 159,
+                                "text": "1"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 159,
+                            "end": 160,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 161,
+                            "end": 175,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 161,
+                                "end": 168,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 161,
+                                    "end": 162,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 162,
+                                    "end": 167,
+                                    "text": "total"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 167,
+                                    "end": 168,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 169,
+                                "end": 171,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 172,
+                                "end": 175,
+                                "text": "250"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "]",
+                            "start": 175,
+                            "end": 176,
+                            "text": "]"
+                          }
+                        ]
                       }
-                    }
+                    ]
+                  },
+                  {
+                    "type": ",",
+                    "start": 176,
+                    "end": 177,
+                    "text": ","
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 178,
+                    "end": 226,
+                    "children": [
+                      {
+                        "type": "array_creation_expression",
+                        "start": 178,
+                        "end": 226,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 178,
+                            "end": 179,
+                            "text": "["
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 179,
+                            "end": 190,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 179,
+                                "end": 183,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 179,
+                                    "end": 180,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 180,
+                                    "end": 182,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 182,
+                                    "end": 183,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 184,
+                                "end": 186,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 187,
+                                "end": 190,
+                                "text": "101"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 190,
+                            "end": 191,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 192,
+                            "end": 209,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 192,
+                                "end": 204,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 192,
+                                    "end": 193,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 193,
+                                    "end": 203,
+                                    "text": "customerId"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 203,
+                                    "end": 204,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 205,
+                                "end": 207,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 208,
+                                "end": 209,
+                                "text": "2"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 209,
+                            "end": 210,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 211,
+                            "end": 225,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 211,
+                                "end": 218,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 211,
+                                    "end": 212,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 212,
+                                    "end": 217,
+                                    "text": "total"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 217,
+                                    "end": 218,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 219,
+                                "end": 221,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 222,
+                                "end": 225,
+                                "text": "125"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "]",
+                            "start": 225,
+                            "end": 226,
+                            "text": "]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": ",",
+                    "start": 226,
+                    "end": 227,
+                    "text": ","
+                  },
+                  {
+                    "type": "array_element_initializer",
+                    "start": 228,
+                    "end": 276,
+                    "children": [
+                      {
+                        "type": "array_creation_expression",
+                        "start": 228,
+                        "end": 276,
+                        "children": [
+                          {
+                            "type": "[",
+                            "start": 228,
+                            "end": 229,
+                            "text": "["
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 229,
+                            "end": 240,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 229,
+                                "end": 233,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 229,
+                                    "end": 230,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 230,
+                                    "end": 232,
+                                    "text": "id"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 232,
+                                    "end": 233,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 234,
+                                "end": 236,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 237,
+                                "end": 240,
+                                "text": "102"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 240,
+                            "end": 241,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 242,
+                            "end": 259,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 242,
+                                "end": 254,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 242,
+                                    "end": 243,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 243,
+                                    "end": 253,
+                                    "text": "customerId"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 253,
+                                    "end": 254,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 255,
+                                "end": 257,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 258,
+                                "end": 259,
+                                "text": "1"
+                              }
+                            ]
+                          },
+                          {
+                            "type": ",",
+                            "start": 259,
+                            "end": 260,
+                            "text": ","
+                          },
+                          {
+                            "type": "array_element_initializer",
+                            "start": 261,
+                            "end": 275,
+                            "children": [
+                              {
+                                "type": "encapsed_string",
+                                "start": 261,
+                                "end": 268,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 261,
+                                    "end": 262,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 262,
+                                    "end": 267,
+                                    "text": "total"
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 267,
+                                    "end": 268,
+                                    "text": "\""
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=\u003e",
+                                "start": 269,
+                                "end": 271,
+                                "text": "=\u003e"
+                              },
+                              {
+                                "type": "integer",
+                                "start": 272,
+                                "end": 275,
+                                "text": "300"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "]",
+                            "start": 275,
+                            "end": 276,
+                            "text": "]"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "]",
+                    "start": 276,
+                    "end": 277,
+                    "text": "]"
                   }
-                }
+                ]
+              }
+            ]
+          },
+          {
+            "type": ";",
+            "start": 277,
+            "end": 278,
+            "text": ";"
+          }
+        ]
+      },
+      {
+        "type": "expression_statement",
+        "start": 279,
+        "end": 292,
+        "children": [
+          {
+            "type": "assignment_expression",
+            "start": 279,
+            "end": 291,
+            "children": [
+              {
+                "type": "variable_name",
+                "start": 279,
+                "end": 286,
+                "children": [
+                  {
+                    "type": "$",
+                    "start": 279,
+                    "end": 280,
+                    "text": "$"
+                  },
+                  {
+                    "type": "name",
+                    "start": 280,
+                    "end": 286,
+                    "text": "result"
+                  }
+                ]
+              },
+              {
+                "type": "=",
+                "start": 287,
+                "end": 288,
+                "text": "="
+              },
+              {
+                "type": "array_creation_expression",
+                "start": 289,
+                "end": 291,
+                "children": [
+                  {
+                    "type": "[",
+                    "start": 289,
+                    "end": 290,
+                    "text": "["
+                  },
+                  {
+                    "type": "]",
+                    "start": 290,
+                    "end": 291,
+                    "text": "]"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": ";",
+            "start": 291,
+            "end": 292,
+            "text": ";"
+          }
+        ]
+      },
+      {
+        "type": "foreach_statement",
+        "start": 293,
+        "end": 500,
+        "children": [
+          {
+            "type": "foreach",
+            "start": 293,
+            "end": 300,
+            "text": "foreach"
+          },
+          {
+            "type": "(",
+            "start": 301,
+            "end": 302,
+            "text": "("
+          },
+          {
+            "type": "variable_name",
+            "start": 302,
+            "end": 309,
+            "children": [
+              {
+                "type": "$",
+                "start": 302,
+                "end": 303,
+                "text": "$"
+              },
+              {
+                "type": "name",
+                "start": 303,
+                "end": 309,
+                "text": "orders"
+              }
+            ]
+          },
+          {
+            "type": "as",
+            "start": 310,
+            "end": 312,
+            "text": "as"
+          },
+          {
+            "type": "variable_name",
+            "start": 313,
+            "end": 315,
+            "children": [
+              {
+                "type": "$",
+                "start": 313,
+                "end": 314,
+                "text": "$"
+              },
+              {
+                "type": "name",
+                "start": 314,
+                "end": 315,
+                "text": "o"
+              }
+            ]
+          },
+          {
+            "type": ")",
+            "start": 315,
+            "end": 316,
+            "text": ")"
+          },
+          {
+            "type": "compound_statement",
+            "start": 317,
+            "end": 500,
+            "children": [
+              {
+                "type": "{",
+                "start": 317,
+                "end": 318,
+                "text": "{"
+              },
+              {
+                "type": "foreach_statement",
+                "start": 321,
+                "end": 498,
+                "children": [
+                  {
+                    "type": "foreach",
+                    "start": 321,
+                    "end": 328,
+                    "text": "foreach"
+                  },
+                  {
+                    "type": "(",
+                    "start": 329,
+                    "end": 330,
+                    "text": "("
+                  },
+                  {
+                    "type": "variable_name",
+                    "start": 330,
+                    "end": 340,
+                    "children": [
+                      {
+                        "type": "$",
+                        "start": 330,
+                        "end": 331,
+                        "text": "$"
+                      },
+                      {
+                        "type": "name",
+                        "start": 331,
+                        "end": 340,
+                        "text": "customers"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "as",
+                    "start": 341,
+                    "end": 343,
+                    "text": "as"
+                  },
+                  {
+                    "type": "variable_name",
+                    "start": 344,
+                    "end": 346,
+                    "children": [
+                      {
+                        "type": "$",
+                        "start": 344,
+                        "end": 345,
+                        "text": "$"
+                      },
+                      {
+                        "type": "name",
+                        "start": 345,
+                        "end": 346,
+                        "text": "c"
+                      }
+                    ]
+                  },
+                  {
+                    "type": ")",
+                    "start": 346,
+                    "end": 347,
+                    "text": ")"
+                  },
+                  {
+                    "type": "compound_statement",
+                    "start": 348,
+                    "end": 498,
+                    "children": [
+                      {
+                        "type": "{",
+                        "start": 348,
+                        "end": 349,
+                        "text": "{"
+                      },
+                      {
+                        "type": "expression_statement",
+                        "start": 354,
+                        "end": 494,
+                        "children": [
+                          {
+                            "type": "assignment_expression",
+                            "start": 354,
+                            "end": 493,
+                            "children": [
+                              {
+                                "type": "subscript_expression",
+                                "start": 354,
+                                "end": 363,
+                                "children": [
+                                  {
+                                    "type": "variable_name",
+                                    "start": 354,
+                                    "end": 361,
+                                    "children": [
+                                      {
+                                        "type": "$",
+                                        "start": 354,
+                                        "end": 355,
+                                        "text": "$"
+                                      },
+                                      {
+                                        "type": "name",
+                                        "start": 355,
+                                        "end": 361,
+                                        "text": "result"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "[",
+                                    "start": 361,
+                                    "end": 362,
+                                    "text": "["
+                                  },
+                                  {
+                                    "type": "]",
+                                    "start": 362,
+                                    "end": 363,
+                                    "text": "]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "=",
+                                "start": 364,
+                                "end": 365,
+                                "text": "="
+                              },
+                              {
+                                "type": "array_creation_expression",
+                                "start": 366,
+                                "end": 493,
+                                "children": [
+                                  {
+                                    "type": "[",
+                                    "start": 366,
+                                    "end": 367,
+                                    "text": "["
+                                  },
+                                  {
+                                    "type": "array_element_initializer",
+                                    "start": 367,
+                                    "end": 388,
+                                    "children": [
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 367,
+                                        "end": 376,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 367,
+                                            "end": 368,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 368,
+                                            "end": 375,
+                                            "text": "orderId"
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 375,
+                                            "end": 376,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "=\u003e",
+                                        "start": 377,
+                                        "end": 379,
+                                        "text": "=\u003e"
+                                      },
+                                      {
+                                        "type": "subscript_expression",
+                                        "start": 380,
+                                        "end": 388,
+                                        "children": [
+                                          {
+                                            "type": "variable_name",
+                                            "start": 380,
+                                            "end": 382,
+                                            "children": [
+                                              {
+                                                "type": "$",
+                                                "start": 380,
+                                                "end": 381,
+                                                "text": "$"
+                                              },
+                                              {
+                                                "type": "name",
+                                                "start": 381,
+                                                "end": 382,
+                                                "text": "o"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "[",
+                                            "start": 382,
+                                            "end": 383,
+                                            "text": "["
+                                          },
+                                          {
+                                            "type": "encapsed_string",
+                                            "start": 383,
+                                            "end": 387,
+                                            "children": [
+                                              {
+                                                "type": "\"",
+                                                "start": 383,
+                                                "end": 384,
+                                                "text": "\""
+                                              },
+                                              {
+                                                "type": "string_content",
+                                                "start": 384,
+                                                "end": 386,
+                                                "text": "id"
+                                              },
+                                              {
+                                                "type": "\"",
+                                                "start": 386,
+                                                "end": 387,
+                                                "text": "\""
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "]",
+                                            "start": 387,
+                                            "end": 388,
+                                            "text": "]"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": ",",
+                                    "start": 388,
+                                    "end": 389,
+                                    "text": ","
+                                  },
+                                  {
+                                    "type": "array_element_initializer",
+                                    "start": 390,
+                                    "end": 427,
+                                    "children": [
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 390,
+                                        "end": 407,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 390,
+                                            "end": 391,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 391,
+                                            "end": 406,
+                                            "text": "orderCustomerId"
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 406,
+                                            "end": 407,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "=\u003e",
+                                        "start": 408,
+                                        "end": 410,
+                                        "text": "=\u003e"
+                                      },
+                                      {
+                                        "type": "subscript_expression",
+                                        "start": 411,
+                                        "end": 427,
+                                        "children": [
+                                          {
+                                            "type": "variable_name",
+                                            "start": 411,
+                                            "end": 413,
+                                            "children": [
+                                              {
+                                                "type": "$",
+                                                "start": 411,
+                                                "end": 412,
+                                                "text": "$"
+                                              },
+                                              {
+                                                "type": "name",
+                                                "start": 412,
+                                                "end": 413,
+                                                "text": "o"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "[",
+                                            "start": 413,
+                                            "end": 414,
+                                            "text": "["
+                                          },
+                                          {
+                                            "type": "encapsed_string",
+                                            "start": 414,
+                                            "end": 426,
+                                            "children": [
+                                              {
+                                                "type": "\"",
+                                                "start": 414,
+                                                "end": 415,
+                                                "text": "\""
+                                              },
+                                              {
+                                                "type": "string_content",
+                                                "start": 415,
+                                                "end": 425,
+                                                "text": "customerId"
+                                              },
+                                              {
+                                                "type": "\"",
+                                                "start": 425,
+                                                "end": 426,
+                                                "text": "\""
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "]",
+                                            "start": 426,
+                                            "end": 427,
+                                            "text": "]"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": ",",
+                                    "start": 427,
+                                    "end": 428,
+                                    "text": ","
+                                  },
+                                  {
+                                    "type": "array_element_initializer",
+                                    "start": 429,
+                                    "end": 463,
+                                    "children": [
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 429,
+                                        "end": 449,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 429,
+                                            "end": 430,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 430,
+                                            "end": 448,
+                                            "text": "pairedCustomerName"
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 448,
+                                            "end": 449,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "=\u003e",
+                                        "start": 450,
+                                        "end": 452,
+                                        "text": "=\u003e"
+                                      },
+                                      {
+                                        "type": "subscript_expression",
+                                        "start": 453,
+                                        "end": 463,
+                                        "children": [
+                                          {
+                                            "type": "variable_name",
+                                            "start": 453,
+                                            "end": 455,
+                                            "children": [
+                                              {
+                                                "type": "$",
+                                                "start": 453,
+                                                "end": 454,
+                                                "text": "$"
+                                              },
+                                              {
+                                                "type": "name",
+                                                "start": 454,
+                                                "end": 455,
+                                                "text": "c"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "[",
+                                            "start": 455,
+                                            "end": 456,
+                                            "text": "["
+                                          },
+                                          {
+                                            "type": "encapsed_string",
+                                            "start": 456,
+                                            "end": 462,
+                                            "children": [
+                                              {
+                                                "type": "\"",
+                                                "start": 456,
+                                                "end": 457,
+                                                "text": "\""
+                                              },
+                                              {
+                                                "type": "string_content",
+                                                "start": 457,
+                                                "end": 461,
+                                                "text": "name"
+                                              },
+                                              {
+                                                "type": "\"",
+                                                "start": 461,
+                                                "end": 462,
+                                                "text": "\""
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "]",
+                                            "start": 462,
+                                            "end": 463,
+                                            "text": "]"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": ",",
+                                    "start": 463,
+                                    "end": 464,
+                                    "text": ","
+                                  },
+                                  {
+                                    "type": "array_element_initializer",
+                                    "start": 465,
+                                    "end": 492,
+                                    "children": [
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 465,
+                                        "end": 477,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 465,
+                                            "end": 466,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 466,
+                                            "end": 476,
+                                            "text": "orderTotal"
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 476,
+                                            "end": 477,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "=\u003e",
+                                        "start": 478,
+                                        "end": 480,
+                                        "text": "=\u003e"
+                                      },
+                                      {
+                                        "type": "subscript_expression",
+                                        "start": 481,
+                                        "end": 492,
+                                        "children": [
+                                          {
+                                            "type": "variable_name",
+                                            "start": 481,
+                                            "end": 483,
+                                            "children": [
+                                              {
+                                                "type": "$",
+                                                "start": 481,
+                                                "end": 482,
+                                                "text": "$"
+                                              },
+                                              {
+                                                "type": "name",
+                                                "start": 482,
+                                                "end": 483,
+                                                "text": "o"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "[",
+                                            "start": 483,
+                                            "end": 484,
+                                            "text": "["
+                                          },
+                                          {
+                                            "type": "encapsed_string",
+                                            "start": 484,
+                                            "end": 491,
+                                            "children": [
+                                              {
+                                                "type": "\"",
+                                                "start": 484,
+                                                "end": 485,
+                                                "text": "\""
+                                              },
+                                              {
+                                                "type": "string_content",
+                                                "start": 485,
+                                                "end": 490,
+                                                "text": "total"
+                                              },
+                                              {
+                                                "type": "\"",
+                                                "start": 490,
+                                                "end": 491,
+                                                "text": "\""
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "]",
+                                            "start": 491,
+                                            "end": 492,
+                                            "text": "]"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "]",
+                                    "start": 492,
+                                    "end": 493,
+                                    "text": "]"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": ";",
+                            "start": 493,
+                            "end": 494,
+                            "text": ";"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "}",
+                        "start": 497,
+                        "end": 498,
+                        "text": "}"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "}",
+                "start": 499,
+                "end": 500,
+                "text": "}"
               }
             ]
           }
-        }
+        ]
+      },
+      {
+        "type": "echo_statement",
+        "start": 502,
+        "end": 563,
+        "children": [
+          {
+            "type": "echo",
+            "start": 502,
+            "end": 506,
+            "text": "echo"
+          },
+          {
+            "type": "sequence_expression",
+            "start": 507,
+            "end": 562,
+            "children": [
+              {
+                "type": "encapsed_string",
+                "start": 507,
+                "end": 553,
+                "children": [
+                  {
+                    "type": "\"",
+                    "start": 507,
+                    "end": 508,
+                    "text": "\""
+                  },
+                  {
+                    "type": "string_content",
+                    "start": 508,
+                    "end": 552,
+                    "text": "--- Cross Join: All order-customer pairs ---"
+                  },
+                  {
+                    "type": "\"",
+                    "start": 552,
+                    "end": 553,
+                    "text": "\""
+                  }
+                ]
+              },
+              {
+                "type": ",",
+                "start": 553,
+                "end": 554,
+                "text": ","
+              },
+              {
+                "type": "name",
+                "start": 555,
+                "end": 562,
+                "text": "PHP_EOL"
+              }
+            ]
+          },
+          {
+            "type": ";",
+            "start": 562,
+            "end": 563,
+            "text": ";"
+          }
+        ]
+      },
+      {
+        "type": "foreach_statement",
+        "start": 564,
+        "end": 1142,
+        "children": [
+          {
+            "type": "foreach",
+            "start": 564,
+            "end": 571,
+            "text": "foreach"
+          },
+          {
+            "type": "(",
+            "start": 572,
+            "end": 573,
+            "text": "("
+          },
+          {
+            "type": "variable_name",
+            "start": 573,
+            "end": 580,
+            "children": [
+              {
+                "type": "$",
+                "start": 573,
+                "end": 574,
+                "text": "$"
+              },
+              {
+                "type": "name",
+                "start": 574,
+                "end": 580,
+                "text": "result"
+              }
+            ]
+          },
+          {
+            "type": "as",
+            "start": 581,
+            "end": 583,
+            "text": "as"
+          },
+          {
+            "type": "variable_name",
+            "start": 584,
+            "end": 590,
+            "children": [
+              {
+                "type": "$",
+                "start": 584,
+                "end": 585,
+                "text": "$"
+              },
+              {
+                "type": "name",
+                "start": 585,
+                "end": 590,
+                "text": "entry"
+              }
+            ]
+          },
+          {
+            "type": ")",
+            "start": 590,
+            "end": 591,
+            "text": ")"
+          },
+          {
+            "type": "compound_statement",
+            "start": 592,
+            "end": 1142,
+            "children": [
+              {
+                "type": "{",
+                "start": 592,
+                "end": 593,
+                "text": "{"
+              },
+              {
+                "type": "echo_statement",
+                "start": 596,
+                "end": 1140,
+                "children": [
+                  {
+                    "type": "echo",
+                    "start": 596,
+                    "end": 600,
+                    "text": "echo"
+                  },
+                  {
+                    "type": "sequence_expression",
+                    "start": 601,
+                    "end": 1139,
+                    "children": [
+                      {
+                        "type": "binary_expression",
+                        "start": 601,
+                        "end": 1130,
+                        "children": [
+                          {
+                            "type": "binary_expression",
+                            "start": 601,
+                            "end": 1006,
+                            "children": [
+                              {
+                                "type": "binary_expression",
+                                "start": 601,
+                                "end": 1000,
+                                "children": [
+                                  {
+                                    "type": "binary_expression",
+                                    "start": 601,
+                                    "end": 982,
+                                    "children": [
+                                      {
+                                        "type": "binary_expression",
+                                        "start": 601,
+                                        "end": 976,
+                                        "children": [
+                                          {
+                                            "type": "binary_expression",
+                                            "start": 601,
+                                            "end": 876,
+                                            "children": [
+                                              {
+                                                "type": "binary_expression",
+                                                "start": 601,
+                                                "end": 870,
+                                                "children": [
+                                                  {
+                                                    "type": "binary_expression",
+                                                    "start": 601,
+                                                    "end": 855,
+                                                    "children": [
+                                                      {
+                                                        "type": "binary_expression",
+                                                        "start": 601,
+                                                        "end": 849,
+                                                        "children": [
+                                                          {
+                                                            "type": "binary_expression",
+                                                            "start": 601,
+                                                            "end": 734,
+                                                            "children": [
+                                                              {
+                                                                "type": "binary_expression",
+                                                                "start": 601,
+                                                                "end": 728,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "binary_expression",
+                                                                    "start": 601,
+                                                                    "end": 711,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "binary_expression",
+                                                                        "start": 601,
+                                                                        "end": 705,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "binary_expression",
+                                                                            "start": 601,
+                                                                            "end": 614,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "encapsed_string",
+                                                                                "start": 601,
+                                                                                "end": 608,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "\"",
+                                                                                    "start": 601,
+                                                                                    "end": 602,
+                                                                                    "text": "\""
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "string_content",
+                                                                                    "start": 602,
+                                                                                    "end": 607,
+                                                                                    "text": "Order"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "\"",
+                                                                                    "start": 607,
+                                                                                    "end": 608,
+                                                                                    "text": "\""
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "type": ".",
+                                                                                "start": 609,
+                                                                                "end": 610,
+                                                                                "text": "."
+                                                                              },
+                                                                              {
+                                                                                "type": "encapsed_string",
+                                                                                "start": 611,
+                                                                                "end": 614,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "\"",
+                                                                                    "start": 611,
+                                                                                    "end": 612,
+                                                                                    "text": "\""
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "string_content",
+                                                                                    "start": 612,
+                                                                                    "end": 613,
+                                                                                    "text": " "
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "\"",
+                                                                                    "start": 613,
+                                                                                    "end": 614,
+                                                                                    "text": "\""
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "type": ".",
+                                                                            "start": 615,
+                                                                            "end": 616,
+                                                                            "text": "."
+                                                                          },
+                                                                          {
+                                                                            "type": "parenthesized_expression",
+                                                                            "start": 617,
+                                                                            "end": 705,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "(",
+                                                                                "start": 617,
+                                                                                "end": 618,
+                                                                                "text": "("
+                                                                              },
+                                                                              {
+                                                                                "type": "conditional_expression",
+                                                                                "start": 618,
+                                                                                "end": 704,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "function_call_expression",
+                                                                                    "start": 618,
+                                                                                    "end": 645,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "name",
+                                                                                        "start": 618,
+                                                                                        "end": 626,
+                                                                                        "text": "is_float"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "arguments",
+                                                                                        "start": 626,
+                                                                                        "end": 645,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "(",
+                                                                                            "start": 626,
+                                                                                            "end": 627,
+                                                                                            "text": "("
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "argument",
+                                                                                            "start": 627,
+                                                                                            "end": 644,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "subscript_expression",
+                                                                                                "start": 627,
+                                                                                                "end": 644,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "variable_name",
+                                                                                                    "start": 627,
+                                                                                                    "end": 633,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "$",
+                                                                                                        "start": 627,
+                                                                                                        "end": 628,
+                                                                                                        "text": "$"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "name",
+                                                                                                        "start": 628,
+                                                                                                        "end": 633,
+                                                                                                        "text": "entry"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "[",
+                                                                                                    "start": 633,
+                                                                                                    "end": 634,
+                                                                                                    "text": "["
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "encapsed_string",
+                                                                                                    "start": 634,
+                                                                                                    "end": 643,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "\"",
+                                                                                                        "start": 634,
+                                                                                                        "end": 635,
+                                                                                                        "text": "\""
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "string_content",
+                                                                                                        "start": 635,
+                                                                                                        "end": 642,
+                                                                                                        "text": "orderId"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "\"",
+                                                                                                        "start": 642,
+                                                                                                        "end": 643,
+                                                                                                        "text": "\""
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "]",
+                                                                                                    "start": 643,
+                                                                                                    "end": 644,
+                                                                                                    "text": "]"
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "type": ")",
+                                                                                            "start": 644,
+                                                                                            "end": 645,
+                                                                                            "text": ")"
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "?",
+                                                                                    "start": 646,
+                                                                                    "end": 647,
+                                                                                    "text": "?"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "function_call_expression",
+                                                                                    "start": 648,
+                                                                                    "end": 684,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "name",
+                                                                                        "start": 648,
+                                                                                        "end": 659,
+                                                                                        "text": "json_encode"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "arguments",
+                                                                                        "start": 659,
+                                                                                        "end": 684,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "(",
+                                                                                            "start": 659,
+                                                                                            "end": 660,
+                                                                                            "text": "("
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "argument",
+                                                                                            "start": 660,
+                                                                                            "end": 677,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "subscript_expression",
+                                                                                                "start": 660,
+                                                                                                "end": 677,
+                                                                                                "children": [
+                                                                                                  {
+                                                                                                    "type": "variable_name",
+                                                                                                    "start": 660,
+                                                                                                    "end": 666,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "$",
+                                                                                                        "start": 660,
+                                                                                                        "end": 661,
+                                                                                                        "text": "$"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "name",
+                                                                                                        "start": 661,
+                                                                                                        "end": 666,
+                                                                                                        "text": "entry"
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "[",
+                                                                                                    "start": 666,
+                                                                                                    "end": 667,
+                                                                                                    "text": "["
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "encapsed_string",
+                                                                                                    "start": 667,
+                                                                                                    "end": 676,
+                                                                                                    "children": [
+                                                                                                      {
+                                                                                                        "type": "\"",
+                                                                                                        "start": 667,
+                                                                                                        "end": 668,
+                                                                                                        "text": "\""
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "string_content",
+                                                                                                        "start": 668,
+                                                                                                        "end": 675,
+                                                                                                        "text": "orderId"
+                                                                                                      },
+                                                                                                      {
+                                                                                                        "type": "\"",
+                                                                                                        "start": 675,
+                                                                                                        "end": 676,
+                                                                                                        "text": "\""
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  },
+                                                                                                  {
+                                                                                                    "type": "]",
+                                                                                                    "start": 676,
+                                                                                                    "end": 677,
+                                                                                                    "text": "]"
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "type": ",",
+                                                                                            "start": 677,
+                                                                                            "end": 678,
+                                                                                            "text": ","
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "argument",
+                                                                                            "start": 679,
+                                                                                            "end": 683,
+                                                                                            "children": [
+                                                                                              {
+                                                                                                "type": "integer",
+                                                                                                "start": 679,
+                                                                                                "end": 683,
+                                                                                                "text": "1344"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          {
+                                                                                            "type": ")",
+                                                                                            "start": 683,
+                                                                                            "end": 684,
+                                                                                            "text": ")"
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": ":",
+                                                                                    "start": 685,
+                                                                                    "end": 686,
+                                                                                    "text": ":"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "subscript_expression",
+                                                                                    "start": 687,
+                                                                                    "end": 704,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "variable_name",
+                                                                                        "start": 687,
+                                                                                        "end": 693,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "$",
+                                                                                            "start": 687,
+                                                                                            "end": 688,
+                                                                                            "text": "$"
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "name",
+                                                                                            "start": 688,
+                                                                                            "end": 693,
+                                                                                            "text": "entry"
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "[",
+                                                                                        "start": 693,
+                                                                                        "end": 694,
+                                                                                        "text": "["
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "encapsed_string",
+                                                                                        "start": 694,
+                                                                                        "end": 703,
+                                                                                        "children": [
+                                                                                          {
+                                                                                            "type": "\"",
+                                                                                            "start": 694,
+                                                                                            "end": 695,
+                                                                                            "text": "\""
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "string_content",
+                                                                                            "start": 695,
+                                                                                            "end": 702,
+                                                                                            "text": "orderId"
+                                                                                          },
+                                                                                          {
+                                                                                            "type": "\"",
+                                                                                            "start": 702,
+                                                                                            "end": 703,
+                                                                                            "text": "\""
+                                                                                          }
+                                                                                        ]
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "]",
+                                                                                        "start": 703,
+                                                                                        "end": 704,
+                                                                                        "text": "]"
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              {
+                                                                                "type": ")",
+                                                                                "start": 704,
+                                                                                "end": 705,
+                                                                                "text": ")"
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "type": ".",
+                                                                        "start": 706,
+                                                                        "end": 707,
+                                                                        "text": "."
+                                                                      },
+                                                                      {
+                                                                        "type": "encapsed_string",
+                                                                        "start": 708,
+                                                                        "end": 711,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "\"",
+                                                                            "start": 708,
+                                                                            "end": 709,
+                                                                            "text": "\""
+                                                                          },
+                                                                          {
+                                                                            "type": "string_content",
+                                                                            "start": 709,
+                                                                            "end": 710,
+                                                                            "text": " "
+                                                                          },
+                                                                          {
+                                                                            "type": "\"",
+                                                                            "start": 710,
+                                                                            "end": 711,
+                                                                            "text": "\""
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": ".",
+                                                                    "start": 712,
+                                                                    "end": 713,
+                                                                    "text": "."
+                                                                  },
+                                                                  {
+                                                                    "type": "encapsed_string",
+                                                                    "start": 714,
+                                                                    "end": 728,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 714,
+                                                                        "end": 715,
+                                                                        "text": "\""
+                                                                      },
+                                                                      {
+                                                                        "type": "string_content",
+                                                                        "start": 715,
+                                                                        "end": 727,
+                                                                        "text": "(customerId:"
+                                                                      },
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 727,
+                                                                        "end": 728,
+                                                                        "text": "\""
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": ".",
+                                                                "start": 729,
+                                                                "end": 730,
+                                                                "text": "."
+                                                              },
+                                                              {
+                                                                "type": "encapsed_string",
+                                                                "start": 731,
+                                                                "end": 734,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "\"",
+                                                                    "start": 731,
+                                                                    "end": 732,
+                                                                    "text": "\""
+                                                                  },
+                                                                  {
+                                                                    "type": "string_content",
+                                                                    "start": 732,
+                                                                    "end": 733,
+                                                                    "text": " "
+                                                                  },
+                                                                  {
+                                                                    "type": "\"",
+                                                                    "start": 733,
+                                                                    "end": 734,
+                                                                    "text": "\""
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": ".",
+                                                            "start": 735,
+                                                            "end": 736,
+                                                            "text": "."
+                                                          },
+                                                          {
+                                                            "type": "parenthesized_expression",
+                                                            "start": 737,
+                                                            "end": 849,
+                                                            "children": [
+                                                              {
+                                                                "type": "(",
+                                                                "start": 737,
+                                                                "end": 738,
+                                                                "text": "("
+                                                              },
+                                                              {
+                                                                "type": "conditional_expression",
+                                                                "start": 738,
+                                                                "end": 848,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "function_call_expression",
+                                                                    "start": 738,
+                                                                    "end": 773,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "name",
+                                                                        "start": 738,
+                                                                        "end": 746,
+                                                                        "text": "is_float"
+                                                                      },
+                                                                      {
+                                                                        "type": "arguments",
+                                                                        "start": 746,
+                                                                        "end": 773,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "(",
+                                                                            "start": 746,
+                                                                            "end": 747,
+                                                                            "text": "("
+                                                                          },
+                                                                          {
+                                                                            "type": "argument",
+                                                                            "start": 747,
+                                                                            "end": 772,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "subscript_expression",
+                                                                                "start": 747,
+                                                                                "end": 772,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "variable_name",
+                                                                                    "start": 747,
+                                                                                    "end": 753,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "$",
+                                                                                        "start": 747,
+                                                                                        "end": 748,
+                                                                                        "text": "$"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "name",
+                                                                                        "start": 748,
+                                                                                        "end": 753,
+                                                                                        "text": "entry"
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "[",
+                                                                                    "start": 753,
+                                                                                    "end": 754,
+                                                                                    "text": "["
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "encapsed_string",
+                                                                                    "start": 754,
+                                                                                    "end": 771,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "\"",
+                                                                                        "start": 754,
+                                                                                        "end": 755,
+                                                                                        "text": "\""
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "string_content",
+                                                                                        "start": 755,
+                                                                                        "end": 770,
+                                                                                        "text": "orderCustomerId"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "\"",
+                                                                                        "start": 770,
+                                                                                        "end": 771,
+                                                                                        "text": "\""
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "]",
+                                                                                    "start": 771,
+                                                                                    "end": 772,
+                                                                                    "text": "]"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "type": ")",
+                                                                            "start": 772,
+                                                                            "end": 773,
+                                                                            "text": ")"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "?",
+                                                                    "start": 774,
+                                                                    "end": 775,
+                                                                    "text": "?"
+                                                                  },
+                                                                  {
+                                                                    "type": "function_call_expression",
+                                                                    "start": 776,
+                                                                    "end": 820,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "name",
+                                                                        "start": 776,
+                                                                        "end": 787,
+                                                                        "text": "json_encode"
+                                                                      },
+                                                                      {
+                                                                        "type": "arguments",
+                                                                        "start": 787,
+                                                                        "end": 820,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "(",
+                                                                            "start": 787,
+                                                                            "end": 788,
+                                                                            "text": "("
+                                                                          },
+                                                                          {
+                                                                            "type": "argument",
+                                                                            "start": 788,
+                                                                            "end": 813,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "subscript_expression",
+                                                                                "start": 788,
+                                                                                "end": 813,
+                                                                                "children": [
+                                                                                  {
+                                                                                    "type": "variable_name",
+                                                                                    "start": 788,
+                                                                                    "end": 794,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "$",
+                                                                                        "start": 788,
+                                                                                        "end": 789,
+                                                                                        "text": "$"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "name",
+                                                                                        "start": 789,
+                                                                                        "end": 794,
+                                                                                        "text": "entry"
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "[",
+                                                                                    "start": 794,
+                                                                                    "end": 795,
+                                                                                    "text": "["
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "encapsed_string",
+                                                                                    "start": 795,
+                                                                                    "end": 812,
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "type": "\"",
+                                                                                        "start": 795,
+                                                                                        "end": 796,
+                                                                                        "text": "\""
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "string_content",
+                                                                                        "start": 796,
+                                                                                        "end": 811,
+                                                                                        "text": "orderCustomerId"
+                                                                                      },
+                                                                                      {
+                                                                                        "type": "\"",
+                                                                                        "start": 811,
+                                                                                        "end": 812,
+                                                                                        "text": "\""
+                                                                                      }
+                                                                                    ]
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "]",
+                                                                                    "start": 812,
+                                                                                    "end": 813,
+                                                                                    "text": "]"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "type": ",",
+                                                                            "start": 813,
+                                                                            "end": 814,
+                                                                            "text": ","
+                                                                          },
+                                                                          {
+                                                                            "type": "argument",
+                                                                            "start": 815,
+                                                                            "end": 819,
+                                                                            "children": [
+                                                                              {
+                                                                                "type": "integer",
+                                                                                "start": 815,
+                                                                                "end": 819,
+                                                                                "text": "1344"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "type": ")",
+                                                                            "start": 819,
+                                                                            "end": 820,
+                                                                            "text": ")"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": ":",
+                                                                    "start": 821,
+                                                                    "end": 822,
+                                                                    "text": ":"
+                                                                  },
+                                                                  {
+                                                                    "type": "subscript_expression",
+                                                                    "start": 823,
+                                                                    "end": 848,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "variable_name",
+                                                                        "start": 823,
+                                                                        "end": 829,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "$",
+                                                                            "start": 823,
+                                                                            "end": 824,
+                                                                            "text": "$"
+                                                                          },
+                                                                          {
+                                                                            "type": "name",
+                                                                            "start": 824,
+                                                                            "end": 829,
+                                                                            "text": "entry"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "type": "[",
+                                                                        "start": 829,
+                                                                        "end": 830,
+                                                                        "text": "["
+                                                                      },
+                                                                      {
+                                                                        "type": "encapsed_string",
+                                                                        "start": 830,
+                                                                        "end": 847,
+                                                                        "children": [
+                                                                          {
+                                                                            "type": "\"",
+                                                                            "start": 830,
+                                                                            "end": 831,
+                                                                            "text": "\""
+                                                                          },
+                                                                          {
+                                                                            "type": "string_content",
+                                                                            "start": 831,
+                                                                            "end": 846,
+                                                                            "text": "orderCustomerId"
+                                                                          },
+                                                                          {
+                                                                            "type": "\"",
+                                                                            "start": 846,
+                                                                            "end": 847,
+                                                                            "text": "\""
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      {
+                                                                        "type": "]",
+                                                                        "start": 847,
+                                                                        "end": 848,
+                                                                        "text": "]"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "type": ")",
+                                                                "start": 848,
+                                                                "end": 849,
+                                                                "text": ")"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": ".",
+                                                        "start": 850,
+                                                        "end": 851,
+                                                        "text": "."
+                                                      },
+                                                      {
+                                                        "type": "encapsed_string",
+                                                        "start": 852,
+                                                        "end": 855,
+                                                        "children": [
+                                                          {
+                                                            "type": "\"",
+                                                            "start": 852,
+                                                            "end": 853,
+                                                            "text": "\""
+                                                          },
+                                                          {
+                                                            "type": "string_content",
+                                                            "start": 853,
+                                                            "end": 854,
+                                                            "text": " "
+                                                          },
+                                                          {
+                                                            "type": "\"",
+                                                            "start": 854,
+                                                            "end": 855,
+                                                            "text": "\""
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": ".",
+                                                    "start": 856,
+                                                    "end": 857,
+                                                    "text": "."
+                                                  },
+                                                  {
+                                                    "type": "encapsed_string",
+                                                    "start": 858,
+                                                    "end": 870,
+                                                    "children": [
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 858,
+                                                        "end": 859,
+                                                        "text": "\""
+                                                      },
+                                                      {
+                                                        "type": "string_content",
+                                                        "start": 859,
+                                                        "end": 869,
+                                                        "text": ", total: $"
+                                                      },
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 869,
+                                                        "end": 870,
+                                                        "text": "\""
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": ".",
+                                                "start": 871,
+                                                "end": 872,
+                                                "text": "."
+                                              },
+                                              {
+                                                "type": "encapsed_string",
+                                                "start": 873,
+                                                "end": 876,
+                                                "children": [
+                                                  {
+                                                    "type": "\"",
+                                                    "start": 873,
+                                                    "end": 874,
+                                                    "text": "\""
+                                                  },
+                                                  {
+                                                    "type": "string_content",
+                                                    "start": 874,
+                                                    "end": 875,
+                                                    "text": " "
+                                                  },
+                                                  {
+                                                    "type": "\"",
+                                                    "start": 875,
+                                                    "end": 876,
+                                                    "text": "\""
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": ".",
+                                            "start": 877,
+                                            "end": 878,
+                                            "text": "."
+                                          },
+                                          {
+                                            "type": "parenthesized_expression",
+                                            "start": 879,
+                                            "end": 976,
+                                            "children": [
+                                              {
+                                                "type": "(",
+                                                "start": 879,
+                                                "end": 880,
+                                                "text": "("
+                                              },
+                                              {
+                                                "type": "conditional_expression",
+                                                "start": 880,
+                                                "end": 975,
+                                                "children": [
+                                                  {
+                                                    "type": "function_call_expression",
+                                                    "start": 880,
+                                                    "end": 910,
+                                                    "children": [
+                                                      {
+                                                        "type": "name",
+                                                        "start": 880,
+                                                        "end": 888,
+                                                        "text": "is_float"
+                                                      },
+                                                      {
+                                                        "type": "arguments",
+                                                        "start": 888,
+                                                        "end": 910,
+                                                        "children": [
+                                                          {
+                                                            "type": "(",
+                                                            "start": 888,
+                                                            "end": 889,
+                                                            "text": "("
+                                                          },
+                                                          {
+                                                            "type": "argument",
+                                                            "start": 889,
+                                                            "end": 909,
+                                                            "children": [
+                                                              {
+                                                                "type": "subscript_expression",
+                                                                "start": 889,
+                                                                "end": 909,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "variable_name",
+                                                                    "start": 889,
+                                                                    "end": 895,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "$",
+                                                                        "start": 889,
+                                                                        "end": 890,
+                                                                        "text": "$"
+                                                                      },
+                                                                      {
+                                                                        "type": "name",
+                                                                        "start": 890,
+                                                                        "end": 895,
+                                                                        "text": "entry"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "[",
+                                                                    "start": 895,
+                                                                    "end": 896,
+                                                                    "text": "["
+                                                                  },
+                                                                  {
+                                                                    "type": "encapsed_string",
+                                                                    "start": 896,
+                                                                    "end": 908,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 896,
+                                                                        "end": 897,
+                                                                        "text": "\""
+                                                                      },
+                                                                      {
+                                                                        "type": "string_content",
+                                                                        "start": 897,
+                                                                        "end": 907,
+                                                                        "text": "orderTotal"
+                                                                      },
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 907,
+                                                                        "end": 908,
+                                                                        "text": "\""
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "]",
+                                                                    "start": 908,
+                                                                    "end": 909,
+                                                                    "text": "]"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": ")",
+                                                            "start": 909,
+                                                            "end": 910,
+                                                            "text": ")"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "?",
+                                                    "start": 911,
+                                                    "end": 912,
+                                                    "text": "?"
+                                                  },
+                                                  {
+                                                    "type": "function_call_expression",
+                                                    "start": 913,
+                                                    "end": 952,
+                                                    "children": [
+                                                      {
+                                                        "type": "name",
+                                                        "start": 913,
+                                                        "end": 924,
+                                                        "text": "json_encode"
+                                                      },
+                                                      {
+                                                        "type": "arguments",
+                                                        "start": 924,
+                                                        "end": 952,
+                                                        "children": [
+                                                          {
+                                                            "type": "(",
+                                                            "start": 924,
+                                                            "end": 925,
+                                                            "text": "("
+                                                          },
+                                                          {
+                                                            "type": "argument",
+                                                            "start": 925,
+                                                            "end": 945,
+                                                            "children": [
+                                                              {
+                                                                "type": "subscript_expression",
+                                                                "start": 925,
+                                                                "end": 945,
+                                                                "children": [
+                                                                  {
+                                                                    "type": "variable_name",
+                                                                    "start": 925,
+                                                                    "end": 931,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "$",
+                                                                        "start": 925,
+                                                                        "end": 926,
+                                                                        "text": "$"
+                                                                      },
+                                                                      {
+                                                                        "type": "name",
+                                                                        "start": 926,
+                                                                        "end": 931,
+                                                                        "text": "entry"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "[",
+                                                                    "start": 931,
+                                                                    "end": 932,
+                                                                    "text": "["
+                                                                  },
+                                                                  {
+                                                                    "type": "encapsed_string",
+                                                                    "start": 932,
+                                                                    "end": 944,
+                                                                    "children": [
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 932,
+                                                                        "end": 933,
+                                                                        "text": "\""
+                                                                      },
+                                                                      {
+                                                                        "type": "string_content",
+                                                                        "start": 933,
+                                                                        "end": 943,
+                                                                        "text": "orderTotal"
+                                                                      },
+                                                                      {
+                                                                        "type": "\"",
+                                                                        "start": 943,
+                                                                        "end": 944,
+                                                                        "text": "\""
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "type": "]",
+                                                                    "start": 944,
+                                                                    "end": 945,
+                                                                    "text": "]"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": ",",
+                                                            "start": 945,
+                                                            "end": 946,
+                                                            "text": ","
+                                                          },
+                                                          {
+                                                            "type": "argument",
+                                                            "start": 947,
+                                                            "end": 951,
+                                                            "children": [
+                                                              {
+                                                                "type": "integer",
+                                                                "start": 947,
+                                                                "end": 951,
+                                                                "text": "1344"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": ")",
+                                                            "start": 951,
+                                                            "end": 952,
+                                                            "text": ")"
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": ":",
+                                                    "start": 953,
+                                                    "end": 954,
+                                                    "text": ":"
+                                                  },
+                                                  {
+                                                    "type": "subscript_expression",
+                                                    "start": 955,
+                                                    "end": 975,
+                                                    "children": [
+                                                      {
+                                                        "type": "variable_name",
+                                                        "start": 955,
+                                                        "end": 961,
+                                                        "children": [
+                                                          {
+                                                            "type": "$",
+                                                            "start": 955,
+                                                            "end": 956,
+                                                            "text": "$"
+                                                          },
+                                                          {
+                                                            "type": "name",
+                                                            "start": 956,
+                                                            "end": 961,
+                                                            "text": "entry"
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "[",
+                                                        "start": 961,
+                                                        "end": 962,
+                                                        "text": "["
+                                                      },
+                                                      {
+                                                        "type": "encapsed_string",
+                                                        "start": 962,
+                                                        "end": 974,
+                                                        "children": [
+                                                          {
+                                                            "type": "\"",
+                                                            "start": 962,
+                                                            "end": 963,
+                                                            "text": "\""
+                                                          },
+                                                          {
+                                                            "type": "string_content",
+                                                            "start": 963,
+                                                            "end": 973,
+                                                            "text": "orderTotal"
+                                                          },
+                                                          {
+                                                            "type": "\"",
+                                                            "start": 973,
+                                                            "end": 974,
+                                                            "text": "\""
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "type": "]",
+                                                        "start": 974,
+                                                        "end": 975,
+                                                        "text": "]"
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": ")",
+                                                "start": 975,
+                                                "end": 976,
+                                                "text": ")"
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": ".",
+                                        "start": 977,
+                                        "end": 978,
+                                        "text": "."
+                                      },
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 979,
+                                        "end": 982,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 979,
+                                            "end": 980,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 980,
+                                            "end": 981,
+                                            "text": " "
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 981,
+                                            "end": 982,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": ".",
+                                    "start": 983,
+                                    "end": 984,
+                                    "text": "."
+                                  },
+                                  {
+                                    "type": "encapsed_string",
+                                    "start": 985,
+                                    "end": 1000,
+                                    "children": [
+                                      {
+                                        "type": "\"",
+                                        "start": 985,
+                                        "end": 986,
+                                        "text": "\""
+                                      },
+                                      {
+                                        "type": "string_content",
+                                        "start": 986,
+                                        "end": 999,
+                                        "text": ") paired with"
+                                      },
+                                      {
+                                        "type": "\"",
+                                        "start": 999,
+                                        "end": 1000,
+                                        "text": "\""
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": ".",
+                                "start": 1001,
+                                "end": 1002,
+                                "text": "."
+                              },
+                              {
+                                "type": "encapsed_string",
+                                "start": 1003,
+                                "end": 1006,
+                                "children": [
+                                  {
+                                    "type": "\"",
+                                    "start": 1003,
+                                    "end": 1004,
+                                    "text": "\""
+                                  },
+                                  {
+                                    "type": "string_content",
+                                    "start": 1004,
+                                    "end": 1005,
+                                    "text": " "
+                                  },
+                                  {
+                                    "type": "\"",
+                                    "start": 1005,
+                                    "end": 1006,
+                                    "text": "\""
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "type": ".",
+                            "start": 1007,
+                            "end": 1008,
+                            "text": "."
+                          },
+                          {
+                            "type": "parenthesized_expression",
+                            "start": 1009,
+                            "end": 1130,
+                            "children": [
+                              {
+                                "type": "(",
+                                "start": 1009,
+                                "end": 1010,
+                                "text": "("
+                              },
+                              {
+                                "type": "conditional_expression",
+                                "start": 1010,
+                                "end": 1129,
+                                "children": [
+                                  {
+                                    "type": "function_call_expression",
+                                    "start": 1010,
+                                    "end": 1048,
+                                    "children": [
+                                      {
+                                        "type": "name",
+                                        "start": 1010,
+                                        "end": 1018,
+                                        "text": "is_float"
+                                      },
+                                      {
+                                        "type": "arguments",
+                                        "start": 1018,
+                                        "end": 1048,
+                                        "children": [
+                                          {
+                                            "type": "(",
+                                            "start": 1018,
+                                            "end": 1019,
+                                            "text": "("
+                                          },
+                                          {
+                                            "type": "argument",
+                                            "start": 1019,
+                                            "end": 1047,
+                                            "children": [
+                                              {
+                                                "type": "subscript_expression",
+                                                "start": 1019,
+                                                "end": 1047,
+                                                "children": [
+                                                  {
+                                                    "type": "variable_name",
+                                                    "start": 1019,
+                                                    "end": 1025,
+                                                    "children": [
+                                                      {
+                                                        "type": "$",
+                                                        "start": 1019,
+                                                        "end": 1020,
+                                                        "text": "$"
+                                                      },
+                                                      {
+                                                        "type": "name",
+                                                        "start": 1020,
+                                                        "end": 1025,
+                                                        "text": "entry"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "[",
+                                                    "start": 1025,
+                                                    "end": 1026,
+                                                    "text": "["
+                                                  },
+                                                  {
+                                                    "type": "encapsed_string",
+                                                    "start": 1026,
+                                                    "end": 1046,
+                                                    "children": [
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 1026,
+                                                        "end": 1027,
+                                                        "text": "\""
+                                                      },
+                                                      {
+                                                        "type": "string_content",
+                                                        "start": 1027,
+                                                        "end": 1045,
+                                                        "text": "pairedCustomerName"
+                                                      },
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 1045,
+                                                        "end": 1046,
+                                                        "text": "\""
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "]",
+                                                    "start": 1046,
+                                                    "end": 1047,
+                                                    "text": "]"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": ")",
+                                            "start": 1047,
+                                            "end": 1048,
+                                            "text": ")"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "?",
+                                    "start": 1049,
+                                    "end": 1050,
+                                    "text": "?"
+                                  },
+                                  {
+                                    "type": "function_call_expression",
+                                    "start": 1051,
+                                    "end": 1098,
+                                    "children": [
+                                      {
+                                        "type": "name",
+                                        "start": 1051,
+                                        "end": 1062,
+                                        "text": "json_encode"
+                                      },
+                                      {
+                                        "type": "arguments",
+                                        "start": 1062,
+                                        "end": 1098,
+                                        "children": [
+                                          {
+                                            "type": "(",
+                                            "start": 1062,
+                                            "end": 1063,
+                                            "text": "("
+                                          },
+                                          {
+                                            "type": "argument",
+                                            "start": 1063,
+                                            "end": 1091,
+                                            "children": [
+                                              {
+                                                "type": "subscript_expression",
+                                                "start": 1063,
+                                                "end": 1091,
+                                                "children": [
+                                                  {
+                                                    "type": "variable_name",
+                                                    "start": 1063,
+                                                    "end": 1069,
+                                                    "children": [
+                                                      {
+                                                        "type": "$",
+                                                        "start": 1063,
+                                                        "end": 1064,
+                                                        "text": "$"
+                                                      },
+                                                      {
+                                                        "type": "name",
+                                                        "start": 1064,
+                                                        "end": 1069,
+                                                        "text": "entry"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "[",
+                                                    "start": 1069,
+                                                    "end": 1070,
+                                                    "text": "["
+                                                  },
+                                                  {
+                                                    "type": "encapsed_string",
+                                                    "start": 1070,
+                                                    "end": 1090,
+                                                    "children": [
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 1070,
+                                                        "end": 1071,
+                                                        "text": "\""
+                                                      },
+                                                      {
+                                                        "type": "string_content",
+                                                        "start": 1071,
+                                                        "end": 1089,
+                                                        "text": "pairedCustomerName"
+                                                      },
+                                                      {
+                                                        "type": "\"",
+                                                        "start": 1089,
+                                                        "end": 1090,
+                                                        "text": "\""
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "type": "]",
+                                                    "start": 1090,
+                                                    "end": 1091,
+                                                    "text": "]"
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": ",",
+                                            "start": 1091,
+                                            "end": 1092,
+                                            "text": ","
+                                          },
+                                          {
+                                            "type": "argument",
+                                            "start": 1093,
+                                            "end": 1097,
+                                            "children": [
+                                              {
+                                                "type": "integer",
+                                                "start": 1093,
+                                                "end": 1097,
+                                                "text": "1344"
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": ")",
+                                            "start": 1097,
+                                            "end": 1098,
+                                            "text": ")"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": ":",
+                                    "start": 1099,
+                                    "end": 1100,
+                                    "text": ":"
+                                  },
+                                  {
+                                    "type": "subscript_expression",
+                                    "start": 1101,
+                                    "end": 1129,
+                                    "children": [
+                                      {
+                                        "type": "variable_name",
+                                        "start": 1101,
+                                        "end": 1107,
+                                        "children": [
+                                          {
+                                            "type": "$",
+                                            "start": 1101,
+                                            "end": 1102,
+                                            "text": "$"
+                                          },
+                                          {
+                                            "type": "name",
+                                            "start": 1102,
+                                            "end": 1107,
+                                            "text": "entry"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "[",
+                                        "start": 1107,
+                                        "end": 1108,
+                                        "text": "["
+                                      },
+                                      {
+                                        "type": "encapsed_string",
+                                        "start": 1108,
+                                        "end": 1128,
+                                        "children": [
+                                          {
+                                            "type": "\"",
+                                            "start": 1108,
+                                            "end": 1109,
+                                            "text": "\""
+                                          },
+                                          {
+                                            "type": "string_content",
+                                            "start": 1109,
+                                            "end": 1127,
+                                            "text": "pairedCustomerName"
+                                          },
+                                          {
+                                            "type": "\"",
+                                            "start": 1127,
+                                            "end": 1128,
+                                            "text": "\""
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "]",
+                                        "start": 1128,
+                                        "end": 1129,
+                                        "text": "]"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": ")",
+                                "start": 1129,
+                                "end": 1130,
+                                "text": ")"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": ",",
+                        "start": 1130,
+                        "end": 1131,
+                        "text": ","
+                      },
+                      {
+                        "type": "name",
+                        "start": 1132,
+                        "end": 1139,
+                        "text": "PHP_EOL"
+                      }
+                    ]
+                  },
+                  {
+                    "type": ";",
+                    "start": 1139,
+                    "end": 1140,
+                    "text": ";"
+                  }
+                ]
+              },
+              {
+                "type": "}",
+                "start": 1141,
+                "end": 1142,
+                "text": "}"
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/tools/json-ast/x/php/ast.go
+++ b/tools/json-ast/x/php/ast.go
@@ -1,0 +1,38 @@
+package php
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+	phpts "github.com/smacker/go-tree-sitter/php"
+)
+
+// Node represents a tree-sitter node in PHP's syntax tree.
+type Node struct {
+	Type     string `json:"type"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Text     string `json:"text,omitempty"`
+	Children []Node `json:"children,omitempty"`
+}
+
+// convert converts a tree-sitter node to our Node structure.
+func convert(n *sitter.Node, src []byte) Node {
+	node := Node{Type: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	if n.ChildCount() == 0 {
+		node.Text = n.Content(src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		node.Children = append(node.Children, convert(child, src))
+	}
+	return node
+}
+
+// newParser returns a tree-sitter parser for PHP.
+func newParser() *sitter.Parser {
+	p := sitter.NewParser()
+	p.SetLanguage(phpts.GetLanguage())
+	return p
+}

--- a/tools/json-ast/x/php/inspect.go
+++ b/tools/json-ast/x/php/inspect.go
@@ -1,215 +1,22 @@
 package php
 
-import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"sync"
-	"time"
-)
-
-// Node represents a php-ast node.
-type Node struct {
-	Kind     string      `json:"kind"`
-	Flags    int         `json:"flags,omitempty"`
-	LineNo   int         `json:"lineno,omitempty"`
-	Children interface{} `json:"children,omitempty"`
-	raw      json.RawMessage
-}
-
-func (n *Node) UnmarshalJSON(data []byte) error {
-	n.raw = append(n.raw[:0], data...)
-	var aux struct {
-		Kind     string          `json:"kind"`
-		Flags    int             `json:"flags"`
-		LineNo   int             `json:"lineno"`
-		Children json.RawMessage `json:"children"`
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	n.Kind = aux.Kind
-	n.Flags = aux.Flags
-	n.LineNo = aux.LineNo
-	if len(aux.Children) == 0 {
-		return nil
-	}
-	switch aux.Children[0] {
-	case '{':
-		var obj map[string]json.RawMessage
-		if err := json.Unmarshal(aux.Children, &obj); err != nil {
-			return err
-		}
-		res := make(map[string]interface{}, len(obj))
-		for k, v := range obj {
-			if len(v) == 0 {
-				res[k] = nil
-				continue
-			}
-			switch v[0] {
-			case '{':
-				var c Node
-				if err := json.Unmarshal(v, &c); err != nil {
-					return err
-				}
-				res[k] = &c
-			case '[':
-				var arr []json.RawMessage
-				if err := json.Unmarshal(v, &arr); err != nil {
-					return err
-				}
-				slice := make([]interface{}, len(arr))
-				for i, e := range arr {
-					if len(e) == 0 {
-						slice[i] = nil
-						continue
-					}
-					if e[0] == '{' {
-						var c Node
-						if err := json.Unmarshal(e, &c); err == nil {
-							slice[i] = &c
-							continue
-						}
-					}
-					var val interface{}
-					_ = json.Unmarshal(e, &val)
-					slice[i] = val
-				}
-				res[k] = slice
-			default:
-				var val interface{}
-				if err := json.Unmarshal(v, &val); err != nil {
-					return err
-				}
-				res[k] = val
-			}
-		}
-		n.Children = res
-	case '[':
-		var arr []json.RawMessage
-		if err := json.Unmarshal(aux.Children, &arr); err != nil {
-			return err
-		}
-		slice := make([]interface{}, len(arr))
-		for i, e := range arr {
-			if len(e) == 0 {
-				slice[i] = nil
-				continue
-			}
-			if e[0] == '{' {
-				var c Node
-				if err := json.Unmarshal(e, &c); err == nil {
-					slice[i] = &c
-					continue
-				}
-			}
-			var val interface{}
-			_ = json.Unmarshal(e, &val)
-			slice[i] = val
-		}
-		n.Children = slice
-	default:
-		n.Children = aux.Children
-	}
-	return nil
-}
-
-func (n Node) MarshalJSON() ([]byte, error) {
-	if n.raw != nil {
-		return n.raw, nil
-	}
-	m := map[string]interface{}{
-		"kind":   n.Kind,
-		"flags":  n.Flags,
-		"lineno": n.LineNo,
-	}
-	if n.Children != nil {
-		m["children"] = n.Children
-	}
-	return json.Marshal(m)
-}
+import "encoding/json"
 
 // Program represents a parsed PHP file.
 type Program struct {
-	Root *Node `json:"root"`
+	Root Node `json:"root"`
 }
 
-var (
-	extOnce sync.Once
-	extErr  error
-	script  string
-)
-
-func ensureExt() error {
-	extOnce.Do(func() {
-		// Check if ast extension is available
-		cmd := exec.Command("php", "-d", "extension=ast.so", "-r", "exit(0);")
-		if err := cmd.Run(); err == nil {
-			return
-		}
-		dir := filepath.Join(os.TempDir(), "php-ast")
-		if err := os.RemoveAll(dir); err == nil {
-			_ = os.MkdirAll(dir, 0o755)
-		}
-		if out, err := exec.Command("git", "clone", "--depth=1", "https://github.com/nikic/php-ast.git", dir).CombinedOutput(); err != nil {
-			extErr = fmt.Errorf("clone ast: %v: %s", err, out)
-			return
-		}
-		build := func(name string, args ...string) error {
-			c := exec.Command(name, args...)
-			c.Dir = dir
-			if b, err := c.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %v: %s", name, err, b)
-			}
-			return nil
-		}
-		if err := build("phpize"); err != nil {
-			extErr = err
-			return
-		}
-		if err := build("./configure"); err != nil {
-			extErr = err
-			return
-		}
-		if err := build("make", "-j4"); err != nil {
-			extErr = err
-			return
-		}
-		if err := build("make", "install"); err != nil {
-			extErr = err
-			return
-		}
-	})
-	return extErr
-}
-
-func init() {
-	if _, file, _, ok := runtime.Caller(0); ok {
-		script = filepath.Join(filepath.Dir(file), "dump_ast.php")
-	}
-}
-
+// Inspect parses PHP source code using tree-sitter and returns its AST.
 func Inspect(src string) (*Program, error) {
-	if err := ensureExt(); err != nil {
-		return nil, fmt.Errorf("ensure ast: %w", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "php", "-d", "extension=ast.so", script)
-	cmd.Stdin = bytes.NewBufferString(src)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return nil, err
-	}
-	var root Node
-	if err := json.Unmarshal(out.Bytes(), &root); err != nil {
-		return nil, err
-	}
-	return &Program{Root: &root}, nil
+	parser := newParser()
+	tree := parser.Parse(nil, []byte(src))
+	root := convert(tree.RootNode(), []byte(src))
+	return &Program{Root: root}, nil
+}
+
+// MarshalJSON ensures stable output for Program.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
 }


### PR DESCRIPTION
## Summary
- add php AST types and converter
- switch php json-ast inspection to use tree-sitter
- update cross_join.php.json for new AST layout

## Testing
- `go test ./tools/json-ast/x/php -tags slow`
- `go vet ./tools/json-ast/x/php`
- `make lint` *(fails: errcheck, ineffassign, staticcheck, unused)*

------
https://chatgpt.com/codex/tasks/task_e_6889c18ed43c8320a7edf1bf9a5044a2