### PR TITLE
Add typed Racket AST conversion

### DIFF
--- a/tests/json-ast/x/rkt/cross_join.rkt.json
+++ b/tests/json-ast/x/rkt/cross_join.rkt.json
@@ -1,1039 +1,603 @@
 {
-  "root": {
-    "type": "program",
-    "start": 0,
-    "end": 1119,
-    "children": [
-      {
-        "type": "comment",
-        "start": 0,
-        "end": 55
-      },
-      {
-        "type": "extension",
-        "start": 56,
-        "end": 68,
-        "children": [
-          {
-            "type": "lang_name",
-            "start": 62,
-            "end": 68
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 69,
-        "end": 104,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 70,
-            "end": 77
-          },
-          {
-            "type": "symbol",
-            "start": 78,
-            "end": 89
-          },
-          {
-            "type": "symbol",
-            "start": 90,
-            "end": 103
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 106,
-        "end": 218,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 107,
-            "end": 113
-          },
-          {
-            "type": "symbol",
-            "start": 114,
-            "end": 123
-          },
-          {
-            "type": "list",
-            "start": 124,
-            "end": 217,
-            "children": [
-              {
-                "type": "symbol",
-                "start": 125,
-                "end": 129
-              },
-              {
-                "type": "list",
-                "start": 130,
-                "end": 158,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 131,
-                    "end": 135
-                  },
-                  {
-                    "type": "string",
-                    "start": 136,
-                    "end": 140
-                  },
-                  {
-                    "type": "number",
-                    "start": 141,
-                    "end": 142
-                  },
-                  {
-                    "type": "string",
-                    "start": 143,
-                    "end": 149
-                  },
-                  {
-                    "type": "string",
-                    "start": 150,
-                    "end": 157
-                  }
-                ]
-              },
-              {
-                "type": "list",
-                "start": 159,
-                "end": 185,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 160,
-                    "end": 164
-                  },
-                  {
-                    "type": "string",
-                    "start": 165,
-                    "end": 169
-                  },
-                  {
-                    "type": "number",
-                    "start": 170,
-                    "end": 171
-                  },
-                  {
-                    "type": "string",
-                    "start": 172,
-                    "end": 178
-                  },
-                  {
-                    "type": "string",
-                    "start": 179,
-                    "end": 184
-                  }
-                ]
-              },
-              {
-                "type": "list",
-                "start": 186,
-                "end": 216,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 187,
-                    "end": 191
-                  },
-                  {
-                    "type": "string",
-                    "start": 192,
-                    "end": 196
-                  },
-                  {
-                    "type": "number",
-                    "start": 197,
-                    "end": 198
-                  },
-                  {
-                    "type": "string",
-                    "start": 199,
-                    "end": 205
-                  },
-                  {
-                    "type": "string",
-                    "start": 206,
-                    "end": 215
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 219,
-        "end": 370,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 220,
-            "end": 226
-          },
-          {
-            "type": "symbol",
-            "start": 227,
-            "end": 233
-          },
-          {
-            "type": "list",
-            "start": 234,
-            "end": 369,
-            "children": [
-              {
-                "type": "symbol",
-                "start": 235,
-                "end": 239
-              },
-              {
-                "type": "list",
-                "start": 240,
-                "end": 282,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 241,
-                    "end": 245
-                  },
-                  {
-                    "type": "string",
-                    "start": 246,
-                    "end": 250
-                  },
-                  {
-                    "type": "number",
-                    "start": 251,
-                    "end": 254
-                  },
-                  {
-                    "type": "string",
-                    "start": 255,
-                    "end": 267
-                  },
-                  {
-                    "type": "number",
-                    "start": 268,
-                    "end": 269
-                  },
-                  {
-                    "type": "string",
-                    "start": 270,
-                    "end": 277
-                  },
-                  {
-                    "type": "number",
-                    "start": 278,
-                    "end": 281
-                  }
-                ]
-              },
-              {
-                "type": "list",
-                "start": 283,
-                "end": 325,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 284,
-                    "end": 288
-                  },
-                  {
-                    "type": "string",
-                    "start": 289,
-                    "end": 293
-                  },
-                  {
-                    "type": "number",
-                    "start": 294,
-                    "end": 297
-                  },
-                  {
-                    "type": "string",
-                    "start": 298,
-                    "end": 310
-                  },
-                  {
-                    "type": "number",
-                    "start": 311,
-                    "end": 312
-                  },
-                  {
-                    "type": "string",
-                    "start": 313,
-                    "end": 320
-                  },
-                  {
-                    "type": "number",
-                    "start": 321,
-                    "end": 324
-                  }
-                ]
-              },
-              {
-                "type": "list",
-                "start": 326,
-                "end": 368,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 327,
-                    "end": 331
-                  },
-                  {
-                    "type": "string",
-                    "start": 332,
-                    "end": 336
-                  },
-                  {
-                    "type": "number",
-                    "start": 337,
-                    "end": 340
-                  },
-                  {
-                    "type": "string",
-                    "start": 341,
-                    "end": 353
-                  },
-                  {
-                    "type": "number",
-                    "start": 354,
-                    "end": 355
-                  },
-                  {
-                    "type": "string",
-                    "start": 356,
-                    "end": 363
-                  },
-                  {
-                    "type": "number",
-                    "start": 364,
-                    "end": 367
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 371,
-        "end": 660,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 372,
-            "end": 378
-          },
-          {
-            "type": "symbol",
-            "start": 379,
-            "end": 385
-          },
-          {
-            "type": "list",
-            "start": 386,
-            "end": 659,
-            "children": [
-              {
-                "type": "symbol",
-                "start": 387,
-                "end": 390
-              },
-              {
-                "type": "list",
-                "start": 391,
-                "end": 403,
-                "children": [
-                  {
-                    "type": "list",
-                    "start": 392,
-                    "end": 402,
-                    "children": [
-                      {
-                        "type": "symbol",
-                        "start": 393,
-                        "end": 397
-                      },
-                      {
-                        "type": "quote",
-                        "start": 398,
-                        "end": 401,
-                        "children": [
-                          {
-                            "type": "list",
-                            "start": 399,
-                            "end": 401
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "list",
-                "start": 406,
-                "end": 651,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 407,
-                    "end": 410
-                  },
-                  {
-                    "type": "list",
-                    "start": 411,
-                    "end": 423,
-                    "children": [
-                      {
-                        "type": "list",
-                        "start": 412,
-                        "end": 422,
-                        "children": [
-                          {
-                            "type": "symbol",
-                            "start": 413,
-                            "end": 414
-                          },
-                          {
-                            "type": "symbol",
-                            "start": 415,
-                            "end": 421
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "list",
-                    "start": 428,
-                    "end": 647,
-                    "children": [
-                      {
-                        "type": "symbol",
-                        "start": 429,
-                        "end": 432
-                      },
-                      {
-                        "type": "list",
-                        "start": 433,
-                        "end": 448,
-                        "children": [
-                          {
-                            "type": "list",
-                            "start": 434,
-                            "end": 447,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 435,
-                                "end": 436
-                              },
-                              {
-                                "type": "symbol",
-                                "start": 437,
-                                "end": 446
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "type": "list",
-                        "start": 455,
-                        "end": 641,
-                        "children": [
-                          {
-                            "type": "symbol",
-                            "start": 456,
-                            "end": 460
-                          },
-                          {
-                            "type": "symbol",
-                            "start": 461,
-                            "end": 465
-                          },
-                          {
-                            "type": "list",
-                            "start": 466,
-                            "end": 640,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 467,
-                                "end": 473
-                              },
-                              {
-                                "type": "symbol",
-                                "start": 474,
-                                "end": 478
-                              },
-                              {
-                                "type": "list",
-                                "start": 479,
-                                "end": 639,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 480,
-                                    "end": 484
-                                  },
-                                  {
-                                    "type": "list",
-                                    "start": 485,
-                                    "end": 638,
-                                    "children": [
-                                      {
-                                        "type": "symbol",
-                                        "start": 486,
-                                        "end": 490
-                                      },
-                                      {
-                                        "type": "string",
-                                        "start": 491,
-                                        "end": 500
-                                      },
-                                      {
-                                        "type": "list",
-                                        "start": 501,
-                                        "end": 518,
-                                        "children": [
-                                          {
-                                            "type": "symbol",
-                                            "start": 502,
-                                            "end": 510
-                                          },
-                                          {
-                                            "type": "symbol",
-                                            "start": 511,
-                                            "end": 512
-                                          },
-                                          {
-                                            "type": "string",
-                                            "start": 513,
-                                            "end": 517
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "string",
-                                        "start": 519,
-                                        "end": 536
-                                      },
-                                      {
-                                        "type": "list",
-                                        "start": 537,
-                                        "end": 562,
-                                        "children": [
-                                          {
-                                            "type": "symbol",
-                                            "start": 538,
-                                            "end": 546
-                                          },
-                                          {
-                                            "type": "symbol",
-                                            "start": 547,
-                                            "end": 548
-                                          },
-                                          {
-                                            "type": "string",
-                                            "start": 549,
-                                            "end": 561
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "string",
-                                        "start": 563,
-                                        "end": 583
-                                      },
-                                      {
-                                        "type": "list",
-                                        "start": 584,
-                                        "end": 603,
-                                        "children": [
-                                          {
-                                            "type": "symbol",
-                                            "start": 585,
-                                            "end": 593
-                                          },
-                                          {
-                                            "type": "symbol",
-                                            "start": 594,
-                                            "end": 595
-                                          },
-                                          {
-                                            "type": "string",
-                                            "start": 596,
-                                            "end": 602
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "string",
-                                        "start": 604,
-                                        "end": 616
-                                      },
-                                      {
-                                        "type": "list",
-                                        "start": 617,
-                                        "end": 637,
-                                        "children": [
-                                          {
-                                            "type": "symbol",
-                                            "start": 618,
-                                            "end": 626
-                                          },
-                                          {
-                                            "type": "symbol",
-                                            "start": 627,
-                                            "end": 628
-                                          },
-                                          {
-                                            "type": "string",
-                                            "start": 629,
-                                            "end": 636
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "symbol",
-                "start": 654,
-                "end": 658
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 661,
-        "end": 719,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 662,
-            "end": 671
-          },
-          {
-            "type": "string",
-            "start": 672,
-            "end": 718
-          }
-        ]
-      },
-      {
-        "type": "list",
-        "start": 720,
-        "end": 1118,
-        "children": [
-          {
-            "type": "symbol",
-            "start": 721,
-            "end": 724
-          },
-          {
-            "type": "list",
-            "start": 725,
-            "end": 741,
-            "children": [
-              {
-                "type": "list",
-                "start": 726,
-                "end": 740,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 727,
-                    "end": 732
-                  },
-                  {
-                    "type": "symbol",
-                    "start": 733,
-                    "end": 739
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "list",
-            "start": 742,
-            "end": 1116,
-            "children": [
-              {
-                "type": "symbol",
-                "start": 743,
-                "end": 752
-              },
-              {
-                "type": "list",
-                "start": 753,
-                "end": 1115,
-                "children": [
-                  {
-                    "type": "symbol",
-                    "start": 754,
-                    "end": 765
-                  },
-                  {
-                    "type": "list",
-                    "start": 766,
-                    "end": 1110,
-                    "children": [
-                      {
-                        "type": "symbol",
-                        "start": 767,
-                        "end": 773
-                      },
-                      {
-                        "type": "list",
-                        "start": 774,
-                        "end": 808,
-                        "children": [
-                          {
-                            "type": "symbol",
-                            "start": 775,
-                            "end": 781
-                          },
-                          {
-                            "type": "list",
-                            "start": 782,
-                            "end": 785,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 783,
-                                "end": 784
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 786,
-                            "end": 807,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 787,
-                                "end": 790
-                              },
-                              {
-                                "type": "list",
-                                "start": 791,
-                                "end": 806,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 792,
-                                    "end": 800
-                                  },
-                                  {
-                                    "type": "symbol",
-                                    "start": 801,
-                                    "end": 802
-                                  },
-                                  {
-                                    "type": "string",
-                                    "start": 803,
-                                    "end": 805
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "type": "list",
-                        "start": 809,
-                        "end": 1109,
-                        "children": [
-                          {
-                            "type": "symbol",
-                            "start": 810,
-                            "end": 814
-                          },
-                          {
-                            "type": "list",
-                            "start": 815,
-                            "end": 836,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 816,
-                                "end": 822
-                              },
-                              {
-                                "type": "string",
-                                "start": 823,
-                                "end": 827
-                              },
-                              {
-                                "type": "string",
-                                "start": 828,
-                                "end": 835
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 837,
-                            "end": 877,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 838,
-                                "end": 844
-                              },
-                              {
-                                "type": "string",
-                                "start": 845,
-                                "end": 849
-                              },
-                              {
-                                "type": "list",
-                                "start": 850,
-                                "end": 876,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 851,
-                                    "end": 859
-                                  },
-                                  {
-                                    "type": "symbol",
-                                    "start": 860,
-                                    "end": 865
-                                  },
-                                  {
-                                    "type": "string",
-                                    "start": 866,
-                                    "end": 875
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 878,
-                            "end": 906,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 879,
-                                "end": 885
-                              },
-                              {
-                                "type": "string",
-                                "start": 886,
-                                "end": 890
-                              },
-                              {
-                                "type": "string",
-                                "start": 891,
-                                "end": 905
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 907,
-                            "end": 955,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 908,
-                                "end": 914
-                              },
-                              {
-                                "type": "string",
-                                "start": 915,
-                                "end": 919
-                              },
-                              {
-                                "type": "list",
-                                "start": 920,
-                                "end": 954,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 921,
-                                    "end": 929
-                                  },
-                                  {
-                                    "type": "symbol",
-                                    "start": 930,
-                                    "end": 935
-                                  },
-                                  {
-                                    "type": "string",
-                                    "start": 936,
-                                    "end": 953
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 956,
-                            "end": 982,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 957,
-                                "end": 963
-                              },
-                              {
-                                "type": "string",
-                                "start": 964,
-                                "end": 968
-                              },
-                              {
-                                "type": "string",
-                                "start": 969,
-                                "end": 981
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 983,
-                            "end": 1026,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 984,
-                                "end": 990
-                              },
-                              {
-                                "type": "string",
-                                "start": 991,
-                                "end": 995
-                              },
-                              {
-                                "type": "list",
-                                "start": 996,
-                                "end": 1025,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 997,
-                                    "end": 1005
-                                  },
-                                  {
-                                    "type": "symbol",
-                                    "start": 1006,
-                                    "end": 1011
-                                  },
-                                  {
-                                    "type": "string",
-                                    "start": 1012,
-                                    "end": 1024
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 1027,
-                            "end": 1056,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 1028,
-                                "end": 1034
-                              },
-                              {
-                                "type": "string",
-                                "start": 1035,
-                                "end": 1039
-                              },
-                              {
-                                "type": "string",
-                                "start": 1040,
-                                "end": 1055
-                              }
-                            ]
-                          },
-                          {
-                            "type": "list",
-                            "start": 1057,
-                            "end": 1108,
-                            "children": [
-                              {
-                                "type": "symbol",
-                                "start": 1058,
-                                "end": 1064
-                              },
-                              {
-                                "type": "string",
-                                "start": 1065,
-                                "end": 1069
-                              },
-                              {
-                                "type": "list",
-                                "start": 1070,
-                                "end": 1107,
-                                "children": [
-                                  {
-                                    "type": "symbol",
-                                    "start": 1071,
-                                    "end": 1079
-                                  },
-                                  {
-                                    "type": "symbol",
-                                    "start": 1080,
-                                    "end": 1085
-                                  },
-                                  {
-                                    "type": "string",
-                                    "start": 1086,
-                                    "end": 1106
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "start": 1111,
-                    "end": 1114
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+  "forms": [
+    {
+      "comment": ";; Generated by Mochi 0.10.33 on 2025-07-21 18:06 +0700"
+    },
+    {
+      "lang": "racket"
+    },
+    {
+      "list": [
+        {
+          "symbol": "require"
+        },
+        {
+          "symbol": "racket/list"
+        },
+        {
+          "symbol": "racket/string"
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "symbol": "define"
+        },
+        {
+          "symbol": "customers"
+        },
+        {
+          "list": [
+            {
+              "symbol": "list"
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "1"
+                },
+                {
+                  "string": "\"name\""
+                },
+                {
+                  "string": "\"Alice\""
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "2"
+                },
+                {
+                  "string": "\"name\""
+                },
+                {
+                  "string": "\"Bob\""
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "3"
+                },
+                {
+                  "string": "\"name\""
+                },
+                {
+                  "string": "\"Charlie\""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "symbol": "define"
+        },
+        {
+          "symbol": "orders"
+        },
+        {
+          "list": [
+            {
+              "symbol": "list"
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "100"
+                },
+                {
+                  "string": "\"customerId\""
+                },
+                {
+                  "number": "1"
+                },
+                {
+                  "string": "\"total\""
+                },
+                {
+                  "number": "250"
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "101"
+                },
+                {
+                  "string": "\"customerId\""
+                },
+                {
+                  "number": "2"
+                },
+                {
+                  "string": "\"total\""
+                },
+                {
+                  "number": "125"
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "symbol": "hash"
+                },
+                {
+                  "string": "\"id\""
+                },
+                {
+                  "number": "102"
+                },
+                {
+                  "string": "\"customerId\""
+                },
+                {
+                  "number": "1"
+                },
+                {
+                  "string": "\"total\""
+                },
+                {
+                  "number": "300"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "symbol": "define"
+        },
+        {
+          "symbol": "result"
+        },
+        {
+          "list": [
+            {
+              "symbol": "let"
+            },
+            {
+              "list": [
+                {
+                  "list": [
+                    {
+                      "symbol": "_res"
+                    },
+                    {
+                      "quote": {}
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "list": [
+                {
+                  "symbol": "for"
+                },
+                {
+                  "list": [
+                    {
+                      "list": [
+                        {
+                          "symbol": "o"
+                        },
+                        {
+                          "symbol": "orders"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "list": [
+                    {
+                      "symbol": "for"
+                    },
+                    {
+                      "list": [
+                        {
+                          "list": [
+                            {
+                              "symbol": "c"
+                            },
+                            {
+                              "symbol": "customers"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "list": [
+                        {
+                          "symbol": "set!"
+                        },
+                        {
+                          "symbol": "_res"
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "append"
+                            },
+                            {
+                              "symbol": "_res"
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "list"
+                                },
+                                {
+                                  "list": [
+                                    {
+                                      "symbol": "hash"
+                                    },
+                                    {
+                                      "string": "\"orderId\""
+                                    },
+                                    {
+                                      "list": [
+                                        {
+                                          "symbol": "hash-ref"
+                                        },
+                                        {
+                                          "symbol": "o"
+                                        },
+                                        {
+                                          "string": "\"id\""
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "string": "\"orderCustomerId\""
+                                    },
+                                    {
+                                      "list": [
+                                        {
+                                          "symbol": "hash-ref"
+                                        },
+                                        {
+                                          "symbol": "o"
+                                        },
+                                        {
+                                          "string": "\"customerId\""
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "string": "\"pairedCustomerName\""
+                                    },
+                                    {
+                                      "list": [
+                                        {
+                                          "symbol": "hash-ref"
+                                        },
+                                        {
+                                          "symbol": "c"
+                                        },
+                                        {
+                                          "string": "\"name\""
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "string": "\"orderTotal\""
+                                    },
+                                    {
+                                      "list": [
+                                        {
+                                          "symbol": "hash-ref"
+                                        },
+                                        {
+                                          "symbol": "o"
+                                        },
+                                        {
+                                          "string": "\"total\""
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "symbol": "_res"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "symbol": "displayln"
+        },
+        {
+          "string": "\"--- Cross Join: All order-customer pairs ---\""
+        }
+      ]
+    },
+    {
+      "list": [
+        {
+          "symbol": "for"
+        },
+        {
+          "list": [
+            {
+              "list": [
+                {
+                  "symbol": "entry"
+                },
+                {
+                  "symbol": "result"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "list": [
+            {
+              "symbol": "displayln"
+            },
+            {
+              "list": [
+                {
+                  "symbol": "string-join"
+                },
+                {
+                  "list": [
+                    {
+                      "symbol": "filter"
+                    },
+                    {
+                      "list": [
+                        {
+                          "symbol": "lambda"
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "s"
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "not"
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "string=?"
+                                },
+                                {
+                                  "symbol": "s"
+                                },
+                                {
+                                  "string": "\"\""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "list": [
+                        {
+                          "symbol": "list"
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "string": "\"Order\""
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "hash-ref"
+                                },
+                                {
+                                  "symbol": "entry"
+                                },
+                                {
+                                  "string": "\"orderId\""
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "string": "\"(customerId:\""
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "hash-ref"
+                                },
+                                {
+                                  "symbol": "entry"
+                                },
+                                {
+                                  "string": "\"orderCustomerId\""
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "string": "\", total: $\""
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "hash-ref"
+                                },
+                                {
+                                  "symbol": "entry"
+                                },
+                                {
+                                  "string": "\"orderTotal\""
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "string": "\") paired with\""
+                            }
+                          ]
+                        },
+                        {
+                          "list": [
+                            {
+                              "symbol": "format"
+                            },
+                            {
+                              "string": "\"~a\""
+                            },
+                            {
+                              "list": [
+                                {
+                                  "symbol": "hash-ref"
+                                },
+                                {
+                                  "symbol": "entry"
+                                },
+                                {
+                                  "string": "\"pairedCustomerName\""
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "string": "\" \""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/tools/json-ast/x/rkt/ast.go
+++ b/tools/json-ast/x/rkt/ast.go
@@ -1,0 +1,68 @@
+package rkt
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node represents a simplified Racket AST node.
+type Node struct {
+	Symbol  string  `json:"symbol,omitempty"`
+	String  string  `json:"string,omitempty"`
+	Number  string  `json:"number,omitempty"`
+	Lang    string  `json:"lang,omitempty"`
+	Comment string  `json:"comment,omitempty"`
+	List    []*Node `json:"list,omitempty"`
+	Quote   *Node   `json:"quote,omitempty"`
+}
+
+// convertProgram converts the root tree-sitter node into a Program.
+func convertProgram(root *sitter.Node, src []byte) *Program {
+	if root == nil {
+		return &Program{}
+	}
+	var forms []*Node
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		forms = append(forms, convert(root.NamedChild(i), src))
+	}
+	return &Program{Forms: forms}
+}
+
+// convert converts a tree-sitter node into a Node structure.
+func convert(n *sitter.Node, src []byte) *Node {
+	if n == nil {
+		return nil
+	}
+	switch n.Type() {
+	case "comment":
+		return &Node{Comment: n.Content(src)}
+	case "extension":
+		if child := n.NamedChild(0); child != nil {
+			return &Node{Lang: child.Content(src)}
+		}
+		return &Node{}
+	case "list", "program":
+		list := make([]*Node, 0, n.NamedChildCount())
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			list = append(list, convert(n.NamedChild(i), src))
+		}
+		return &Node{List: list}
+	case "symbol", "lang_name":
+		return &Node{Symbol: n.Content(src)}
+	case "string":
+		return &Node{String: n.Content(src)}
+	case "number":
+		return &Node{Number: n.Content(src)}
+	case "quote":
+		if n.NamedChildCount() > 0 {
+			return &Node{Quote: convert(n.NamedChild(0), src)}
+		}
+		return &Node{Quote: &Node{}}
+	default:
+		list := make([]*Node, 0, n.NamedChildCount())
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			list = append(list, convert(n.NamedChild(i), src))
+		}
+		if len(list) > 0 {
+			return &Node{List: list}
+		}
+		return &Node{Symbol: n.Content(src)}
+	}
+}

--- a/tools/json-ast/x/rkt/inspect.go
+++ b/tools/json-ast/x/rkt/inspect.go
@@ -5,17 +5,9 @@ import (
 	racket "github.com/tree-sitter/tree-sitter-racket/bindings/go"
 )
 
-// Node mirrors a tree-sitter node in a simplified form.
-type Node struct {
-	Type     string  `json:"type"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Children []*Node `json:"children,omitempty"`
-}
-
 // Program represents a parsed Racket source file.
 type Program struct {
-	Root *Node `json:"root"`
+	Forms []*Node `json:"forms"`
 }
 
 // Inspect parses Racket source code using tree-sitter and returns a Program
@@ -24,17 +16,5 @@ func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(sitter.NewLanguage(racket.Language()))
 	tree := p.Parse(nil, []byte(src))
-	return &Program{Root: convert(tree.RootNode())}, nil
-}
-
-func convert(n *sitter.Node) *Node {
-	if n == nil {
-		return nil
-	}
-	node := &Node{Type: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
-		node.Children = append(node.Children, convert(child))
-	}
-	return node
+	return convertProgram(tree.RootNode(), []byte(src)), nil
 }


### PR DESCRIPTION
## Summary
- define Racket AST types and conversion helpers
- refactor inspector to produce structured AST
- regenerate `cross_join.rkt.json`

## Testing
- `go test ./tools/json-ast/x/rkt -tags slow -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_6889c1b21de48320a6e3b37e7a0854c3