### PR TITLE
Add typed Rust AST

### DIFF
--- a/tests/json-ast/x/rs/cross_join.rs.json
+++ b/tests/json-ast/x/rs/cross_join.rs.json
@@ -1,5 +1,5 @@
 {
-  "file": {
+  "root": {
     "kind": "source_file",
     "start": 0,
     "end": 2561,

--- a/tools/json-ast/x/rs/ast.go
+++ b/tools/json-ast/x/rs/ast.go
@@ -1,0 +1,29 @@
+package rs
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node represents a node in the Rust syntax tree.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// Program represents a parsed Rust source file composed of AST nodes.
+type Program struct {
+	Root *Node `json:"root"`
+}
+
+// convert turns a tree-sitter node into our AST representation.
+func convert(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
+	}
+	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, convert(child))
+	}
+	return out
+}

--- a/tools/json-ast/x/rs/inspect.go
+++ b/tools/json-ast/x/rs/inspect.go
@@ -7,38 +7,13 @@ import (
 	rust "github.com/smacker/go-tree-sitter/rust"
 )
 
-// Node represents a node in the Rust syntax tree.
-type Node struct {
-	Kind     string  `json:"kind"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Children []*Node `json:"children,omitempty"`
-}
-
-// Program represents a parsed Rust source file.
-type Program struct {
-	File *Node `json:"file"`
-}
-
 // Inspect parses the given Rust source code using tree-sitter and returns
 // a Program describing its syntax tree.
 func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(rust.GetLanguage())
 	tree := p.Parse(nil, []byte(src))
-	return &Program{File: toNode(tree.RootNode())}, nil
-}
-
-func toNode(n *sitter.Node) *Node {
-	if n == nil {
-		return nil
-	}
-	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
-		out.Children = append(out.Children, toNode(child))
-	}
-	return out
+	return &Program{Root: convert(tree.RootNode())}, nil
 }
 
 // MarshalJSON implements json.Marshaler for Program, to ensure stable output.


### PR DESCRIPTION
## Summary
- create `ast.go` with Rust AST structs
- convert tree-sitter nodes to typed AST
- expose `Inspect` using new AST format
- regenerate Rust `cross_join` JSON fixture

## Testing
- `go test -tags slow -run TestInspect_Golden -update ./tools/json-ast/x/rs`

------
https://chatgpt.com/codex/tasks/task_e_6889c1ba50c88320ae081b694841f1d4