### PR TITLE
Enhance swift AST export

### DIFF
--- a/tools/json-ast/x/swift/ast.go
+++ b/tools/json-ast/x/swift/ast.go
@@ -1,0 +1,47 @@
+package swift
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Node represents a node in the Swift syntax tree.
+// Each node carries its kind and byte offsets as reported by tree-sitter.
+// Children only include named nodes to keep the structure compact.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// SourceFile is the root of a Swift AST.
+type SourceFile struct {
+	Node
+}
+
+// convertNode transforms a tree-sitter node into the Go AST representation.
+// The conversion is recursive and ignores anonymous children.
+func convertNode(n *sitter.Node) *Node {
+	if n == nil {
+		return nil
+	}
+	out := &Node{
+		Kind:  n.Type(),
+		Start: int(n.StartByte()),
+		End:   int(n.EndByte()),
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		out.Children = append(out.Children, convertNode(child))
+	}
+	return out
+}
+
+// ConvertFile converts the tree-sitter root node of a Swift file into a
+// SourceFile AST value.
+func ConvertFile(n *sitter.Node) *SourceFile {
+	if n == nil {
+		return nil
+	}
+	return &SourceFile{Node: *convertNode(n)}
+}

--- a/tools/json-ast/x/swift/inspect.go
+++ b/tools/json-ast/x/swift/inspect.go
@@ -7,17 +7,9 @@ import (
 	ts "github.com/smacker/go-tree-sitter/swift"
 )
 
-// Node represents a node in the Swift syntax tree.
-type Node struct {
-	Kind     string  `json:"kind"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Children []*Node `json:"children,omitempty"`
-}
-
 // Program represents a parsed Swift source file.
 type Program struct {
-	File *Node `json:"file"`
+	File *SourceFile `json:"file"`
 }
 
 // Inspect parses the given Swift source code using tree-sitter and returns
@@ -26,19 +18,7 @@ func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(ts.GetLanguage())
 	tree := p.Parse(nil, []byte(src))
-	return &Program{File: toNode(tree.RootNode())}, nil
-}
-
-func toNode(n *sitter.Node) *Node {
-	if n == nil {
-		return nil
-	}
-	out := &Node{Kind: n.Type(), Start: int(n.StartByte()), End: int(n.EndByte())}
-	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := n.NamedChild(i)
-		out.Children = append(out.Children, toNode(child))
-	}
-	return out
+	return &Program{File: ConvertFile(tree.RootNode())}, nil
 }
 
 // MarshalJSON implements json.Marshaler for Program to ensure stable output.


### PR DESCRIPTION
## Summary
- add typed AST structs in `tools/json-ast/x/swift/ast.go`
- convert tree-sitter nodes to typed AST
- refactor `Program` to use the new structs
- regenerate json-ast test data

## Testing
- `go test ./tools/json-ast/x/swift -tags=slow -run TestInspect_Golden -update -v`

------
https://chatgpt.com/codex/tasks/task_e_6889c1cd0b608320b896ed8cdaba591f