### PR TITLE
Add Zig AST struct conversion

### DIFF
--- a/tools/json-ast/x/zig/ast.go
+++ b/tools/json-ast/x/zig/ast.go
@@ -1,0 +1,32 @@
+package zig
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node represents a tree-sitter node in Zig's syntax tree.
+type Node struct {
+	Type     string `json:"type"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	Text     string `json:"text,omitempty"`
+	Children []Node `json:"children,omitempty"`
+}
+
+// convertNode converts a tree-sitter Node into our AST Node.
+func convertNode(n *sitter.Node, src []byte) Node {
+	node := Node{
+		Type:  n.Type(),
+		Start: int(n.StartByte()),
+		End:   int(n.EndByte()),
+	}
+	if n.ChildCount() == 0 {
+		node.Text = n.Content(src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		node.Children = append(node.Children, convertNode(child, src))
+	}
+	return node
+}

--- a/tools/json-ast/x/zig/inspect.go
+++ b/tools/json-ast/x/zig/inspect.go
@@ -10,15 +10,6 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-// Node represents a tree-sitter node in Zig's syntax tree.
-type Node struct {
-	Type     string `json:"type"`
-	Start    int    `json:"start"`
-	End      int    `json:"end"`
-	Text     string `json:"text,omitempty"`
-	Children []Node `json:"children,omitempty"`
-}
-
 // Program describes a parsed Zig source file.
 type Program struct {
 	Root Node `json:"root"`
@@ -34,23 +25,4 @@ func Inspect(src string) (*Program, error) {
 	}
 	root := convertNode(tree.RootNode(), []byte(src))
 	return &Program{Root: root}, nil
-}
-
-func convertNode(n *sitter.Node, src []byte) Node {
-	node := Node{
-		Type:  n.Type(),
-		Start: int(n.StartByte()),
-		End:   int(n.EndByte()),
-	}
-	if n.ChildCount() == 0 {
-		node.Text = n.Content(src)
-	}
-	for i := 0; i < int(n.ChildCount()); i++ {
-		child := n.Child(i)
-		if child == nil {
-			continue
-		}
-		node.Children = append(node.Children, convertNode(child, src))
-	}
-	return node
 }


### PR DESCRIPTION
## Summary
- define `ast.go` with Zig AST node structures
- update inspector to use new AST structures
- regenerate Zig AST tests

## Testing
- `go test -tags=slow ./tools/json-ast/x/zig -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_6889c1d966a483208f946ecdc5b18705