### PR TITLE
Add typed AST for Haskell json-ast tool

### DIFF
--- a/tools/json-ast/x/haskell/ast.go
+++ b/tools/json-ast/x/haskell/ast.go
@@ -1,0 +1,29 @@
+package haskell
+
+import sitter "github.com/smacker/go-tree-sitter"
+
+// Node represents a node in the parsed Haskell AST.
+type Node struct {
+	Type     string        `json:"node"`
+	Children []interface{} `json:"children,omitempty"`
+}
+
+// convert recursively converts a tree-sitter node into our Node structure.
+// Leaf nodes that have no named children store their source text as a string
+// in the Children slice.
+func convert(n *sitter.Node, src []byte) Node {
+	node := Node{Type: n.Type()}
+	if n.NamedChildCount() == 0 {
+		// If the node has no named children we keep its raw text.
+		node.Children = append(node.Children, n.Content(src))
+		return node
+	}
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		node.Children = append(node.Children, convert(child, src))
+	}
+	return node
+}

--- a/tools/json-ast/x/haskell/inspect.go
+++ b/tools/json-ast/x/haskell/inspect.go
@@ -14,7 +14,7 @@ import (
 var parseScript string
 
 type Program struct {
-	AST json.RawMessage `json:"ast"`
+	AST Node `json:"ast"`
 }
 
 // Inspect parses the given Haskell source code using runghc and
@@ -59,9 +59,9 @@ func Inspect(src string) (*Program, error) {
 		}
 		return nil, err
 	}
-	var raw json.RawMessage
-	if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+	var node Node
+	if err := json.Unmarshal(out.Bytes(), &node); err != nil {
 		return nil, err
 	}
-	return &Program{AST: raw}, nil
+	return &Program{AST: node}, nil
 }


### PR DESCRIPTION
## Summary
- add `Node` type for Haskell AST conversion
- convert runghc output into `Node` in `Inspect`
- (no change in golden file as structure is preserved)

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6889c7a6bda083208f0f8a62f35a3cde