### PR TITLE
Simplify C JSON AST

### DIFF
--- a/tests/json-ast/x/c/cross_join.c.json
+++ b/tests/json-ast/x/c/cross_join.c.json
@@ -16,12 +16,6 @@
         "end": 75,
         "children": [
           {
-            "kind": "#include",
-            "start": 56,
-            "end": 64,
-            "text": "#include"
-          },
-          {
             "kind": "system_lib_string",
             "start": 65,
             "end": 74,
@@ -34,12 +28,6 @@
         "start": 75,
         "end": 95,
         "children": [
-          {
-            "kind": "#include",
-            "start": 75,
-            "end": 83,
-            "text": "#include"
-          },
           {
             "kind": "system_lib_string",
             "start": 84,
@@ -54,22 +42,10 @@
         "end": 123,
         "children": [
           {
-            "kind": "typedef",
-            "start": 96,
-            "end": 103,
-            "text": "typedef"
-          },
-          {
             "kind": "struct_specifier",
             "start": 104,
             "end": 116,
             "children": [
-              {
-                "kind": "struct",
-                "start": 104,
-                "end": 110,
-                "text": "struct"
-              },
               {
                 "kind": "type_identifier",
                 "start": 111,
@@ -83,12 +59,6 @@
             "start": 117,
             "end": 122,
             "text": "Anon5"
-          },
-          {
-            "kind": ";",
-            "start": 122,
-            "end": 123,
-            "text": ";"
           }
         ]
       },
@@ -98,22 +68,10 @@
         "end": 159,
         "children": [
           {
-            "kind": "typedef",
-            "start": 124,
-            "end": 131,
-            "text": "typedef"
-          },
-          {
             "kind": "struct_specifier",
             "start": 132,
             "end": 148,
             "children": [
-              {
-                "kind": "struct",
-                "start": 132,
-                "end": 138,
-                "text": "struct"
-              },
               {
                 "kind": "type_identifier",
                 "start": 139,
@@ -127,12 +85,6 @@
             "start": 149,
             "end": 158,
             "text": "Customers"
-          },
-          {
-            "kind": ";",
-            "start": 158,
-            "end": 159,
-            "text": ";"
           }
         ]
       },
@@ -142,22 +94,10 @@
         "end": 187,
         "children": [
           {
-            "kind": "typedef",
-            "start": 160,
-            "end": 167,
-            "text": "typedef"
-          },
-          {
             "kind": "struct_specifier",
             "start": 168,
             "end": 180,
             "children": [
-              {
-                "kind": "struct",
-                "start": 168,
-                "end": 174,
-                "text": "struct"
-              },
               {
                 "kind": "type_identifier",
                 "start": 175,
@@ -171,12 +111,6 @@
             "start": 181,
             "end": 186,
             "text": "Data2"
-          },
-          {
-            "kind": ";",
-            "start": 186,
-            "end": 187,
-            "text": ";"
           }
         ]
       },
@@ -186,22 +120,10 @@
         "end": 215,
         "children": [
           {
-            "kind": "typedef",
-            "start": 188,
-            "end": 195,
-            "text": "typedef"
-          },
-          {
             "kind": "struct_specifier",
             "start": 196,
             "end": 208,
             "children": [
-              {
-                "kind": "struct",
-                "start": 196,
-                "end": 202,
-                "text": "struct"
-              },
               {
                 "kind": "type_identifier",
                 "start": 203,
@@ -215,12 +137,6 @@
             "start": 209,
             "end": 214,
             "text": "Data4"
-          },
-          {
-            "kind": ";",
-            "start": 214,
-            "end": 215,
-            "text": ";"
           }
         ]
       },
@@ -230,22 +146,10 @@
         "end": 245,
         "children": [
           {
-            "kind": "typedef",
-            "start": 216,
-            "end": 223,
-            "text": "typedef"
-          },
-          {
             "kind": "struct_specifier",
             "start": 224,
             "end": 237,
             "children": [
-              {
-                "kind": "struct",
-                "start": 224,
-                "end": 230,
-                "text": "struct"
-              },
               {
                 "kind": "type_identifier",
                 "start": 231,
@@ -259,12 +163,6 @@
             "start": 238,
             "end": 244,
             "text": "Orders"
-          },
-          {
-            "kind": ";",
-            "start": 244,
-            "end": 245,
-            "text": ";"
           }
         ]
       },
@@ -273,12 +171,6 @@
         "start": 247,
         "end": 361,
         "children": [
-          {
-            "kind": "struct",
-            "start": 247,
-            "end": 253,
-            "text": "struct"
-          },
           {
             "kind": "type_identifier",
             "start": 254,
@@ -291,12 +183,6 @@
             "end": 361,
             "children": [
               {
-                "kind": "{",
-                "start": 260,
-                "end": 261,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 266,
                 "end": 286,
@@ -306,18 +192,6 @@
                     "start": 266,
                     "end": 269,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 270,
-                    "end": 285,
-                    "text": "orderCustomerId"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 285,
-                    "end": 286,
-                    "text": ";"
                   }
                 ]
               },
@@ -331,18 +205,6 @@
                     "start": 291,
                     "end": 294,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 295,
-                    "end": 302,
-                    "text": "orderId"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 302,
-                    "end": 303,
-                    "text": ";"
                   }
                 ]
               },
@@ -356,18 +218,6 @@
                     "start": 308,
                     "end": 311,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 312,
-                    "end": 322,
-                    "text": "orderTotal"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 322,
-                    "end": 323,
-                    "text": ";"
                   }
                 ]
               },
@@ -377,78 +227,22 @@
                 "end": 359,
                 "children": [
                   {
-                    "kind": "type_qualifier",
-                    "start": 328,
-                    "end": 333,
-                    "children": [
-                      {
-                        "kind": "const",
-                        "start": 328,
-                        "end": 333,
-                        "text": "const"
-                      }
-                    ]
-                  },
-                  {
                     "kind": "primitive_type",
                     "start": 334,
                     "end": 338,
                     "text": "char"
-                  },
-                  {
-                    "kind": "pointer_declarator",
-                    "start": 338,
-                    "end": 358,
-                    "children": [
-                      {
-                        "kind": "*",
-                        "start": 338,
-                        "end": 339,
-                        "text": "*"
-                      },
-                      {
-                        "kind": "field_identifier",
-                        "start": 340,
-                        "end": 358,
-                        "text": "pairedCustomerName"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 358,
-                    "end": 359,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 360,
-                "end": 361,
-                "text": "}"
               }
             ]
           }
         ]
       },
       {
-        "kind": ";",
-        "start": 361,
-        "end": 362,
-        "text": ";"
-      },
-      {
         "kind": "struct_specifier",
         "start": 364,
         "end": 418,
         "children": [
-          {
-            "kind": "struct",
-            "start": 364,
-            "end": 370,
-            "text": "struct"
-          },
           {
             "kind": "type_identifier",
             "start": 371,
@@ -461,12 +255,6 @@
             "end": 418,
             "children": [
               {
-                "kind": "{",
-                "start": 381,
-                "end": 382,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 387,
                 "end": 394,
@@ -476,18 +264,6 @@
                     "start": 387,
                     "end": 390,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 391,
-                    "end": 393,
-                    "text": "id"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 393,
-                    "end": 394,
-                    "text": ";"
                   }
                 ]
               },
@@ -497,78 +273,22 @@
                 "end": 416,
                 "children": [
                   {
-                    "kind": "type_qualifier",
-                    "start": 399,
-                    "end": 404,
-                    "children": [
-                      {
-                        "kind": "const",
-                        "start": 399,
-                        "end": 404,
-                        "text": "const"
-                      }
-                    ]
-                  },
-                  {
                     "kind": "primitive_type",
                     "start": 405,
                     "end": 409,
                     "text": "char"
-                  },
-                  {
-                    "kind": "pointer_declarator",
-                    "start": 409,
-                    "end": 415,
-                    "children": [
-                      {
-                        "kind": "*",
-                        "start": 409,
-                        "end": 410,
-                        "text": "*"
-                      },
-                      {
-                        "kind": "field_identifier",
-                        "start": 411,
-                        "end": 415,
-                        "text": "name"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 415,
-                    "end": 416,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 417,
-                "end": 418,
-                "text": "}"
               }
             ]
           }
         ]
       },
       {
-        "kind": ";",
-        "start": 418,
-        "end": 419,
-        "text": ";"
-      },
-      {
         "kind": "struct_specifier",
         "start": 421,
         "end": 471,
         "children": [
-          {
-            "kind": "struct",
-            "start": 421,
-            "end": 427,
-            "text": "struct"
-          },
           {
             "kind": "type_identifier",
             "start": 428,
@@ -581,12 +301,6 @@
             "end": 471,
             "children": [
               {
-                "kind": "{",
-                "start": 434,
-                "end": 435,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 440,
                 "end": 447,
@@ -596,18 +310,6 @@
                     "start": 440,
                     "end": 443,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 444,
-                    "end": 446,
-                    "text": "id"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 446,
-                    "end": 447,
-                    "text": ";"
                   }
                 ]
               },
@@ -617,78 +319,22 @@
                 "end": 469,
                 "children": [
                   {
-                    "kind": "type_qualifier",
-                    "start": 452,
-                    "end": 457,
-                    "children": [
-                      {
-                        "kind": "const",
-                        "start": 452,
-                        "end": 457,
-                        "text": "const"
-                      }
-                    ]
-                  },
-                  {
                     "kind": "primitive_type",
                     "start": 458,
                     "end": 462,
                     "text": "char"
-                  },
-                  {
-                    "kind": "pointer_declarator",
-                    "start": 462,
-                    "end": 468,
-                    "children": [
-                      {
-                        "kind": "*",
-                        "start": 462,
-                        "end": 463,
-                        "text": "*"
-                      },
-                      {
-                        "kind": "field_identifier",
-                        "start": 464,
-                        "end": 468,
-                        "text": "name"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 468,
-                    "end": 469,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 470,
-                "end": 471,
-                "text": "}"
               }
             ]
           }
         ]
       },
       {
-        "kind": ";",
-        "start": 471,
-        "end": 472,
-        "text": ";"
-      },
-      {
         "kind": "struct_specifier",
         "start": 474,
         "end": 537,
         "children": [
-          {
-            "kind": "struct",
-            "start": 474,
-            "end": 480,
-            "text": "struct"
-          },
           {
             "kind": "type_identifier",
             "start": 481,
@@ -701,12 +347,6 @@
             "end": 537,
             "children": [
               {
-                "kind": "{",
-                "start": 487,
-                "end": 488,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 493,
                 "end": 500,
@@ -716,18 +356,6 @@
                     "start": 493,
                     "end": 496,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 497,
-                    "end": 499,
-                    "text": "id"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 499,
-                    "end": 500,
-                    "text": ";"
                   }
                 ]
               },
@@ -741,18 +369,6 @@
                     "start": 505,
                     "end": 508,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 509,
-                    "end": 519,
-                    "text": "customerId"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 519,
-                    "end": 520,
-                    "text": ";"
                   }
                 ]
               },
@@ -766,48 +382,18 @@
                     "start": 525,
                     "end": 528,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 529,
-                    "end": 534,
-                    "text": "total"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 534,
-                    "end": 535,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 536,
-                "end": 537,
-                "text": "}"
               }
             ]
           }
         ]
       },
       {
-        "kind": ";",
-        "start": 537,
-        "end": 538,
-        "text": ";"
-      },
-      {
         "kind": "struct_specifier",
         "start": 540,
         "end": 604,
         "children": [
-          {
-            "kind": "struct",
-            "start": 540,
-            "end": 546,
-            "text": "struct"
-          },
           {
             "kind": "type_identifier",
             "start": 547,
@@ -820,12 +406,6 @@
             "end": 604,
             "children": [
               {
-                "kind": "{",
-                "start": 554,
-                "end": 555,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 560,
                 "end": 567,
@@ -835,18 +415,6 @@
                     "start": 560,
                     "end": 563,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 564,
-                    "end": 566,
-                    "text": "id"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 566,
-                    "end": 567,
-                    "text": ";"
                   }
                 ]
               },
@@ -860,18 +428,6 @@
                     "start": 572,
                     "end": 575,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 576,
-                    "end": 586,
-                    "text": "customerId"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 586,
-                    "end": 587,
-                    "text": ";"
                   }
                 ]
               },
@@ -885,36 +441,12 @@
                     "start": 592,
                     "end": 595,
                     "text": "int"
-                  },
-                  {
-                    "kind": "field_identifier",
-                    "start": 596,
-                    "end": 601,
-                    "text": "total"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 601,
-                    "end": 602,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 603,
-                "end": 604,
-                "text": "}"
               }
             ]
           }
         ]
-      },
-      {
-        "kind": ";",
-        "start": 604,
-        "end": 605,
-        "text": ";"
       },
       {
         "kind": "declaration",
@@ -942,26 +474,8 @@
                     "start": 617,
                     "end": 626,
                     "text": "customers"
-                  },
-                  {
-                    "kind": "[",
-                    "start": 626,
-                    "end": 627,
-                    "text": "["
-                  },
-                  {
-                    "kind": "]",
-                    "start": 627,
-                    "end": 628,
-                    "text": "]"
                   }
                 ]
-              },
-              {
-                "kind": "=",
-                "start": 629,
-                "end": 630,
-                "text": "="
               },
               {
                 "kind": "initializer_list",
@@ -969,22 +483,10 @@
                 "end": 750,
                 "children": [
                   {
-                    "kind": "{",
-                    "start": 631,
-                    "end": 632,
-                    "text": "{"
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 633,
                     "end": 670,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 633,
-                        "end": 634,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 634,
@@ -999,52 +501,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 643,
-                        "end": 644,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 644,
                         "end": 670,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 644,
-                            "end": 645,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 645,
                             "end": 652,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 645,
-                                "end": 648,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 645,
-                                    "end": 646,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 646,
-                                    "end": 648,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 649,
-                                "end": 650,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 651,
@@ -1054,95 +519,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 652,
-                            "end": 653,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 654,
                             "end": 669,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 654,
-                                "end": 659,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 654,
-                                    "end": 655,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 655,
-                                    "end": 659,
-                                    "text": "name"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 660,
-                                "end": 661,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 662,
                                 "end": 669,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 662,
-                                    "end": 663,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 663,
                                     "end": 668,
                                     "text": "Alice"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 668,
-                                    "end": 669,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 669,
-                            "end": 670,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 670,
-                    "end": 671,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 672,
                     "end": 707,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 672,
-                        "end": 673,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 673,
@@ -1157,52 +561,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 682,
-                        "end": 683,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 683,
                         "end": 707,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 683,
-                            "end": 684,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 684,
                             "end": 691,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 684,
-                                "end": 687,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 684,
-                                    "end": 685,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 685,
-                                    "end": 687,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 688,
-                                "end": 689,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 690,
@@ -1212,95 +579,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 691,
-                            "end": 692,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 693,
                             "end": 706,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 693,
-                                "end": 698,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 693,
-                                    "end": 694,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 694,
-                                    "end": 698,
-                                    "text": "name"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 699,
-                                "end": 700,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 701,
                                 "end": 706,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 701,
-                                    "end": 702,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 702,
                                     "end": 705,
                                     "text": "Bob"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 705,
-                                    "end": 706,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 706,
-                            "end": 707,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 707,
-                    "end": 708,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 709,
                     "end": 748,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 709,
-                        "end": 710,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 710,
@@ -1315,52 +621,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 719,
-                        "end": 720,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 720,
                         "end": 748,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 720,
-                            "end": 721,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 721,
                             "end": 728,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 721,
-                                "end": 724,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 721,
-                                    "end": 722,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 722,
-                                    "end": 724,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 725,
-                                "end": 726,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 727,
@@ -1370,93 +639,32 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 728,
-                            "end": 729,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 730,
                             "end": 747,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 730,
-                                "end": 735,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 730,
-                                    "end": 731,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 731,
-                                    "end": 735,
-                                    "text": "name"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 736,
-                                "end": 737,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 738,
                                 "end": 747,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 738,
-                                    "end": 739,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 739,
                                     "end": 746,
                                     "text": "Charlie"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 746,
-                                    "end": 747,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 747,
-                            "end": 748,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": "}",
-                    "start": 749,
-                    "end": 750,
-                    "text": "}"
                   }
                 ]
               }
             ]
-          },
-          {
-            "kind": ";",
-            "start": 750,
-            "end": 751,
-            "text": ";"
           }
         ]
       },
@@ -1486,26 +694,8 @@
                     "start": 759,
                     "end": 765,
                     "text": "orders"
-                  },
-                  {
-                    "kind": "[",
-                    "start": 765,
-                    "end": 766,
-                    "text": "["
-                  },
-                  {
-                    "kind": "]",
-                    "start": 766,
-                    "end": 767,
-                    "text": "]"
                   }
                 ]
-              },
-              {
-                "kind": "=",
-                "start": 768,
-                "end": 769,
-                "text": "="
               },
               {
                 "kind": "initializer_list",
@@ -1513,22 +703,10 @@
                 "end": 928,
                 "children": [
                   {
-                    "kind": "{",
-                    "start": 770,
-                    "end": 771,
-                    "text": "{"
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 772,
                     "end": 822,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 772,
-                        "end": 773,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 773,
@@ -1543,52 +721,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 779,
-                        "end": 780,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 780,
                         "end": 822,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 780,
-                            "end": 781,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 781,
                             "end": 790,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 781,
-                                "end": 784,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 781,
-                                    "end": 782,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 782,
-                                    "end": 784,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 785,
-                                "end": 786,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 787,
@@ -1598,41 +739,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 790,
-                            "end": 791,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 792,
                             "end": 807,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 792,
-                                "end": 803,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 792,
-                                    "end": 793,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 793,
-                                    "end": 803,
-                                    "text": "customerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 804,
-                                "end": 805,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 806,
@@ -1642,41 +752,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 807,
-                            "end": 808,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 809,
                             "end": 821,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 809,
-                                "end": 815,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 809,
-                                    "end": 810,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 810,
-                                    "end": 815,
-                                    "text": "total"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 816,
-                                "end": 817,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 818,
@@ -1684,34 +763,16 @@
                                 "text": "250"
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 821,
-                            "end": 822,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 822,
-                    "end": 823,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 824,
                     "end": 874,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 824,
-                        "end": 825,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 825,
@@ -1726,52 +787,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 831,
-                        "end": 832,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 832,
                         "end": 874,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 832,
-                            "end": 833,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 833,
                             "end": 842,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 833,
-                                "end": 836,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 833,
-                                    "end": 834,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 834,
-                                    "end": 836,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 837,
-                                "end": 838,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 839,
@@ -1781,41 +805,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 842,
-                            "end": 843,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 844,
                             "end": 859,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 844,
-                                "end": 855,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 844,
-                                    "end": 845,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 845,
-                                    "end": 855,
-                                    "text": "customerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 856,
-                                "end": 857,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 858,
@@ -1825,41 +818,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 859,
-                            "end": 860,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 861,
                             "end": 873,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 861,
-                                "end": 867,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 861,
-                                    "end": 862,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 862,
-                                    "end": 867,
-                                    "text": "total"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 868,
-                                "end": 869,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 870,
@@ -1867,34 +829,16 @@
                                 "text": "125"
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 873,
-                            "end": 874,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 874,
-                    "end": 875,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 876,
                     "end": 926,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 876,
-                        "end": 877,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 877,
@@ -1909,52 +853,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 883,
-                        "end": 884,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 884,
                         "end": 926,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 884,
-                            "end": 885,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 885,
                             "end": 894,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 885,
-                                "end": 888,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 885,
-                                    "end": 886,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 886,
-                                    "end": 888,
-                                    "text": "id"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 889,
-                                "end": 890,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 891,
@@ -1964,41 +871,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 894,
-                            "end": 895,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 896,
                             "end": 911,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 896,
-                                "end": 907,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 896,
-                                    "end": 897,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 897,
-                                    "end": 907,
-                                    "text": "customerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 908,
-                                "end": 909,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 910,
@@ -2008,41 +884,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 911,
-                            "end": 912,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 913,
                             "end": 925,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 913,
-                                "end": 919,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 913,
-                                    "end": 914,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 914,
-                                    "end": 919,
-                                    "text": "total"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 920,
-                                "end": 921,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 922,
@@ -2050,32 +895,14 @@
                                 "text": "300"
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 925,
-                            "end": 926,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": "}",
-                    "start": 927,
-                    "end": 928,
-                    "text": "}"
                   }
                 ]
               }
             ]
-          },
-          {
-            "kind": ";",
-            "start": 928,
-            "end": 929,
-            "text": ";"
           }
         ]
       },
@@ -2105,26 +932,8 @@
                     "start": 936,
                     "end": 942,
                     "text": "result"
-                  },
-                  {
-                    "kind": "[",
-                    "start": 942,
-                    "end": 943,
-                    "text": "["
-                  },
-                  {
-                    "kind": "]",
-                    "start": 943,
-                    "end": 944,
-                    "text": "]"
                   }
                 ]
-              },
-              {
-                "kind": "=",
-                "start": 945,
-                "end": 946,
-                "text": "="
               },
               {
                 "kind": "initializer_list",
@@ -2132,22 +941,10 @@
                 "end": 1822,
                 "children": [
                   {
-                    "kind": "{",
-                    "start": 947,
-                    "end": 948,
-                    "text": "{"
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 949,
                     "end": 1044,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 949,
-                        "end": 950,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 950,
@@ -2162,52 +959,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 955,
-                        "end": 956,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 956,
                         "end": 1044,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 956,
-                            "end": 957,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 957,
                             "end": 977,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 957,
-                                "end": 973,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 957,
-                                    "end": 958,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 958,
-                                    "end": 973,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 974,
-                                "end": 975,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 976,
@@ -2217,41 +977,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 977,
-                            "end": 978,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 979,
                             "end": 993,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 979,
-                                "end": 987,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 979,
-                                    "end": 980,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 980,
-                                    "end": 987,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 988,
-                                "end": 989,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 990,
@@ -2261,41 +990,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 993,
-                            "end": 994,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 995,
                             "end": 1012,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 995,
-                                "end": 1006,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 995,
-                                    "end": 996,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 996,
-                                    "end": 1006,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1007,
-                                "end": 1008,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1009,
@@ -2305,95 +1003,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1012,
-                            "end": 1013,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1014,
                             "end": 1043,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1014,
-                                "end": 1033,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1014,
-                                    "end": 1015,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1015,
-                                    "end": 1033,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1034,
-                                "end": 1035,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1036,
                                 "end": 1043,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1036,
-                                    "end": 1037,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1037,
                                     "end": 1042,
                                     "text": "Alice"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1042,
-                                    "end": 1043,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1043,
-                            "end": 1044,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1044,
-                    "end": 1045,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1046,
                     "end": 1139,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1046,
-                        "end": 1047,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1047,
@@ -2408,52 +1045,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1052,
-                        "end": 1053,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1053,
                         "end": 1139,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1053,
-                            "end": 1054,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1054,
                             "end": 1074,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1054,
-                                "end": 1070,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1054,
-                                    "end": 1055,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1055,
-                                    "end": 1070,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1071,
-                                "end": 1072,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1073,
@@ -2463,41 +1063,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1074,
-                            "end": 1075,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1076,
                             "end": 1090,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1076,
-                                "end": 1084,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1076,
-                                    "end": 1077,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1077,
-                                    "end": 1084,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1085,
-                                "end": 1086,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1087,
@@ -2507,41 +1076,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1090,
-                            "end": 1091,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1092,
                             "end": 1109,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1092,
-                                "end": 1103,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1092,
-                                    "end": 1093,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1093,
-                                    "end": 1103,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1104,
-                                "end": 1105,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1106,
@@ -2551,95 +1089,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1109,
-                            "end": 1110,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1111,
                             "end": 1138,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1111,
-                                "end": 1130,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1111,
-                                    "end": 1112,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1112,
-                                    "end": 1130,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1131,
-                                "end": 1132,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1133,
                                 "end": 1138,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1133,
-                                    "end": 1134,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1134,
                                     "end": 1137,
                                     "text": "Bob"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1137,
-                                    "end": 1138,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1138,
-                            "end": 1139,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1139,
-                    "end": 1140,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1141,
                     "end": 1238,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1141,
-                        "end": 1142,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1142,
@@ -2654,52 +1131,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1147,
-                        "end": 1148,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1148,
                         "end": 1238,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1148,
-                            "end": 1149,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1149,
                             "end": 1169,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1149,
-                                "end": 1165,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1149,
-                                    "end": 1150,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1150,
-                                    "end": 1165,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1166,
-                                "end": 1167,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1168,
@@ -2709,41 +1149,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1169,
-                            "end": 1170,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1171,
                             "end": 1185,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1171,
-                                "end": 1179,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1171,
-                                    "end": 1172,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1172,
-                                    "end": 1179,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1180,
-                                "end": 1181,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1182,
@@ -2753,41 +1162,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1185,
-                            "end": 1186,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1187,
                             "end": 1204,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1187,
-                                "end": 1198,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1187,
-                                    "end": 1188,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1188,
-                                    "end": 1198,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1199,
-                                "end": 1200,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1201,
@@ -2797,95 +1175,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1204,
-                            "end": 1205,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1206,
                             "end": 1237,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1206,
-                                "end": 1225,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1206,
-                                    "end": 1207,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1207,
-                                    "end": 1225,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1226,
-                                "end": 1227,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1228,
                                 "end": 1237,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1228,
-                                    "end": 1229,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1229,
                                     "end": 1236,
                                     "text": "Charlie"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1236,
-                                    "end": 1237,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1237,
-                            "end": 1238,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1238,
-                    "end": 1239,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1240,
                     "end": 1335,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1240,
-                        "end": 1241,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1241,
@@ -2900,52 +1217,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1246,
-                        "end": 1247,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1247,
                         "end": 1335,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1247,
-                            "end": 1248,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1248,
                             "end": 1268,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1248,
-                                "end": 1264,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1248,
-                                    "end": 1249,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1249,
-                                    "end": 1264,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1265,
-                                "end": 1266,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1267,
@@ -2955,41 +1235,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1268,
-                            "end": 1269,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1270,
                             "end": 1284,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1270,
-                                "end": 1278,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1270,
-                                    "end": 1271,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1271,
-                                    "end": 1278,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1279,
-                                "end": 1280,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1281,
@@ -2999,41 +1248,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1284,
-                            "end": 1285,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1286,
                             "end": 1303,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1286,
-                                "end": 1297,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1286,
-                                    "end": 1287,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1287,
-                                    "end": 1297,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1298,
-                                "end": 1299,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1300,
@@ -3043,95 +1261,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1303,
-                            "end": 1304,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1305,
                             "end": 1334,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1305,
-                                "end": 1324,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1305,
-                                    "end": 1306,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1306,
-                                    "end": 1324,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1325,
-                                "end": 1326,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1327,
                                 "end": 1334,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1327,
-                                    "end": 1328,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1328,
                                     "end": 1333,
                                     "text": "Alice"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1333,
-                                    "end": 1334,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1334,
-                            "end": 1335,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1335,
-                    "end": 1336,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1337,
                     "end": 1430,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1337,
-                        "end": 1338,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1338,
@@ -3146,52 +1303,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1343,
-                        "end": 1344,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1344,
                         "end": 1430,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1344,
-                            "end": 1345,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1345,
                             "end": 1365,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1345,
-                                "end": 1361,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1345,
-                                    "end": 1346,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1346,
-                                    "end": 1361,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1362,
-                                "end": 1363,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1364,
@@ -3201,41 +1321,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1365,
-                            "end": 1366,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1367,
                             "end": 1381,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1367,
-                                "end": 1375,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1367,
-                                    "end": 1368,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1368,
-                                    "end": 1375,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1376,
-                                "end": 1377,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1378,
@@ -3245,41 +1334,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1381,
-                            "end": 1382,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1383,
                             "end": 1400,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1383,
-                                "end": 1394,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1383,
-                                    "end": 1384,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1384,
-                                    "end": 1394,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1395,
-                                "end": 1396,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1397,
@@ -3289,95 +1347,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1400,
-                            "end": 1401,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1402,
                             "end": 1429,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1402,
-                                "end": 1421,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1402,
-                                    "end": 1403,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1403,
-                                    "end": 1421,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1422,
-                                "end": 1423,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1424,
                                 "end": 1429,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1424,
-                                    "end": 1425,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1425,
                                     "end": 1428,
                                     "text": "Bob"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1428,
-                                    "end": 1429,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1429,
-                            "end": 1430,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1430,
-                    "end": 1431,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1432,
                     "end": 1529,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1432,
-                        "end": 1433,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1433,
@@ -3392,52 +1389,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1438,
-                        "end": 1439,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1439,
                         "end": 1529,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1439,
-                            "end": 1440,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1440,
                             "end": 1460,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1440,
-                                "end": 1456,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1440,
-                                    "end": 1441,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1441,
-                                    "end": 1456,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1457,
-                                "end": 1458,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1459,
@@ -3447,41 +1407,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1460,
-                            "end": 1461,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1462,
                             "end": 1476,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1462,
-                                "end": 1470,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1462,
-                                    "end": 1463,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1463,
-                                    "end": 1470,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1471,
-                                "end": 1472,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1473,
@@ -3491,41 +1420,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1476,
-                            "end": 1477,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1478,
                             "end": 1495,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1478,
-                                "end": 1489,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1478,
-                                    "end": 1479,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1479,
-                                    "end": 1489,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1490,
-                                "end": 1491,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1492,
@@ -3535,95 +1433,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1495,
-                            "end": 1496,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1497,
                             "end": 1528,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1497,
-                                "end": 1516,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1497,
-                                    "end": 1498,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1498,
-                                    "end": 1516,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1517,
-                                "end": 1518,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1519,
                                 "end": 1528,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1519,
-                                    "end": 1520,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1520,
                                     "end": 1527,
                                     "text": "Charlie"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1527,
-                                    "end": 1528,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1528,
-                            "end": 1529,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1529,
-                    "end": 1530,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1531,
                     "end": 1626,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1531,
-                        "end": 1532,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1532,
@@ -3638,52 +1475,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1537,
-                        "end": 1538,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1538,
                         "end": 1626,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1538,
-                            "end": 1539,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1539,
                             "end": 1559,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1539,
-                                "end": 1555,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1539,
-                                    "end": 1540,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1540,
-                                    "end": 1555,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1556,
-                                "end": 1557,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1558,
@@ -3693,41 +1493,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1559,
-                            "end": 1560,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1561,
                             "end": 1575,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1561,
-                                "end": 1569,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1561,
-                                    "end": 1562,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1562,
-                                    "end": 1569,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1570,
-                                "end": 1571,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1572,
@@ -3737,41 +1506,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1575,
-                            "end": 1576,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1577,
                             "end": 1594,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1577,
-                                "end": 1588,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1577,
-                                    "end": 1578,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1578,
-                                    "end": 1588,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1589,
-                                "end": 1590,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1591,
@@ -3781,95 +1519,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1594,
-                            "end": 1595,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1596,
                             "end": 1625,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1596,
-                                "end": 1615,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1596,
-                                    "end": 1597,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1597,
-                                    "end": 1615,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1616,
-                                "end": 1617,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1618,
                                 "end": 1625,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1618,
-                                    "end": 1619,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1619,
                                     "end": 1624,
                                     "text": "Alice"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1624,
-                                    "end": 1625,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1625,
-                            "end": 1626,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1626,
-                    "end": 1627,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1628,
                     "end": 1721,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1628,
-                        "end": 1629,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1629,
@@ -3884,52 +1561,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1634,
-                        "end": 1635,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1635,
                         "end": 1721,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1635,
-                            "end": 1636,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1636,
                             "end": 1656,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1636,
-                                "end": 1652,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1636,
-                                    "end": 1637,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1637,
-                                    "end": 1652,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1653,
-                                "end": 1654,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1655,
@@ -3939,41 +1579,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1656,
-                            "end": 1657,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1658,
                             "end": 1672,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1658,
-                                "end": 1666,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1658,
-                                    "end": 1659,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1659,
-                                    "end": 1666,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1667,
-                                "end": 1668,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1669,
@@ -3983,41 +1592,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1672,
-                            "end": 1673,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1674,
                             "end": 1691,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1674,
-                                "end": 1685,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1674,
-                                    "end": 1675,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1675,
-                                    "end": 1685,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1686,
-                                "end": 1687,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1688,
@@ -4027,95 +1605,34 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1691,
-                            "end": 1692,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1693,
                             "end": 1720,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1693,
-                                "end": 1712,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1693,
-                                    "end": 1694,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1694,
-                                    "end": 1712,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1713,
-                                "end": 1714,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1715,
                                 "end": 1720,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1715,
-                                    "end": 1716,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1716,
                                     "end": 1719,
                                     "text": "Bob"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1719,
-                                    "end": 1720,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1720,
-                            "end": 1721,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   },
                   {
-                    "kind": ",",
-                    "start": 1721,
-                    "end": 1722,
-                    "text": ","
-                  },
-                  {
                     "kind": "compound_literal_expression",
                     "start": 1723,
                     "end": 1820,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 1723,
-                        "end": 1724,
-                        "text": "("
-                      },
                       {
                         "kind": "type_descriptor",
                         "start": 1724,
@@ -4130,52 +1647,15 @@
                         ]
                       },
                       {
-                        "kind": ")",
-                        "start": 1729,
-                        "end": 1730,
-                        "text": ")"
-                      },
-                      {
                         "kind": "initializer_list",
                         "start": 1730,
                         "end": 1820,
                         "children": [
                           {
-                            "kind": "{",
-                            "start": 1730,
-                            "end": 1731,
-                            "text": "{"
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1731,
                             "end": 1751,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1731,
-                                "end": 1747,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1731,
-                                    "end": 1732,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1732,
-                                    "end": 1747,
-                                    "text": "orderCustomerId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1748,
-                                "end": 1749,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1750,
@@ -4185,41 +1665,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1751,
-                            "end": 1752,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1753,
                             "end": 1767,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1753,
-                                "end": 1761,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1753,
-                                    "end": 1754,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1754,
-                                    "end": 1761,
-                                    "text": "orderId"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1762,
-                                "end": 1763,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1764,
@@ -4229,41 +1678,10 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1767,
-                            "end": 1768,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1769,
                             "end": 1786,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1769,
-                                "end": 1780,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1769,
-                                    "end": 1770,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1770,
-                                    "end": 1780,
-                                    "text": "orderTotal"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1781,
-                                "end": 1782,
-                                "text": "="
-                              },
                               {
                                 "kind": "number_literal",
                                 "start": 1783,
@@ -4273,93 +1691,32 @@
                             ]
                           },
                           {
-                            "kind": ",",
-                            "start": 1786,
-                            "end": 1787,
-                            "text": ","
-                          },
-                          {
                             "kind": "initializer_pair",
                             "start": 1788,
                             "end": 1819,
                             "children": [
-                              {
-                                "kind": "field_designator",
-                                "start": 1788,
-                                "end": 1807,
-                                "children": [
-                                  {
-                                    "kind": ".",
-                                    "start": 1788,
-                                    "end": 1789,
-                                    "text": "."
-                                  },
-                                  {
-                                    "kind": "field_identifier",
-                                    "start": 1789,
-                                    "end": 1807,
-                                    "text": "pairedCustomerName"
-                                  }
-                                ]
-                              },
-                              {
-                                "kind": "=",
-                                "start": 1808,
-                                "end": 1809,
-                                "text": "="
-                              },
                               {
                                 "kind": "string_literal",
                                 "start": 1810,
                                 "end": 1819,
                                 "children": [
                                   {
-                                    "kind": "\"",
-                                    "start": 1810,
-                                    "end": 1811,
-                                    "text": "\""
-                                  },
-                                  {
                                     "kind": "string_content",
                                     "start": 1811,
                                     "end": 1818,
                                     "text": "Charlie"
-                                  },
-                                  {
-                                    "kind": "\"",
-                                    "start": 1818,
-                                    "end": 1819,
-                                    "text": "\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 1819,
-                            "end": 1820,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": "}",
-                    "start": 1821,
-                    "end": 1822,
-                    "text": "}"
                   }
                 ]
               }
             ]
-          },
-          {
-            "kind": ";",
-            "start": 1822,
-            "end": 1823,
-            "text": ";"
           }
         ]
       },
@@ -4391,12 +1748,6 @@
                 "end": 1839,
                 "children": [
                   {
-                    "kind": "(",
-                    "start": 1833,
-                    "end": 1834,
-                    "text": "("
-                  },
-                  {
                     "kind": "parameter_declaration",
                     "start": 1834,
                     "end": 1838,
@@ -4408,12 +1759,6 @@
                         "text": "void"
                       }
                     ]
-                  },
-                  {
-                    "kind": ")",
-                    "start": 1838,
-                    "end": 1839,
-                    "text": ")"
                   }
                 ]
               }
@@ -4424,12 +1769,6 @@
             "start": 1840,
             "end": 3185,
             "children": [
-              {
-                "kind": "{",
-                "start": 1840,
-                "end": 1841,
-                "text": "{"
-              },
               {
                 "kind": "expression_statement",
                 "start": 1846,
@@ -4452,51 +1791,21 @@
                         "end": 1898,
                         "children": [
                           {
-                            "kind": "(",
-                            "start": 1850,
-                            "end": 1851,
-                            "text": "("
-                          },
-                          {
                             "kind": "string_literal",
                             "start": 1851,
                             "end": 1897,
                             "children": [
                               {
-                                "kind": "\"",
-                                "start": 1851,
-                                "end": 1852,
-                                "text": "\""
-                              },
-                              {
                                 "kind": "string_content",
                                 "start": 1852,
                                 "end": 1896,
                                 "text": "--- Cross Join: All order-customer pairs ---"
-                              },
-                              {
-                                "kind": "\"",
-                                "start": 1896,
-                                "end": 1897,
-                                "text": "\""
                               }
                             ]
-                          },
-                          {
-                            "kind": ")",
-                            "start": 1897,
-                            "end": 1898,
-                            "text": ")"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 1898,
-                    "end": 1899,
-                    "text": ";"
                   }
                 ]
               },
@@ -4505,12 +1814,6 @@
                 "start": 1904,
                 "end": 3169,
                 "children": [
-                  {
-                    "kind": "{",
-                    "start": 1904,
-                    "end": 1905,
-                    "text": "{"
-                  },
                   {
                     "kind": "declaration",
                     "start": 1914,
@@ -4537,26 +1840,8 @@
                                 "start": 1920,
                                 "end": 1929,
                                 "text": "entry_arr"
-                              },
-                              {
-                                "kind": "[",
-                                "start": 1929,
-                                "end": 1930,
-                                "text": "["
-                              },
-                              {
-                                "kind": "]",
-                                "start": 1930,
-                                "end": 1931,
-                                "text": "]"
                               }
                             ]
-                          },
-                          {
-                            "kind": "=",
-                            "start": 1932,
-                            "end": 1933,
-                            "text": "="
                           },
                           {
                             "kind": "initializer_list",
@@ -4564,22 +1849,10 @@
                             "end": 2807,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 1934,
-                                "end": 1935,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 1935,
                                 "end": 2030,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 1935,
-                                    "end": 1936,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 1936,
@@ -4594,52 +1867,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 1941,
-                                    "end": 1942,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 1942,
                                     "end": 2030,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 1942,
-                                        "end": 1943,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 1943,
                                         "end": 1963,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 1943,
-                                            "end": 1959,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 1943,
-                                                "end": 1944,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 1944,
-                                                "end": 1959,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 1960,
-                                            "end": 1961,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 1962,
@@ -4649,41 +1885,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 1963,
-                                        "end": 1964,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 1965,
                                         "end": 1979,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 1965,
-                                            "end": 1973,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 1965,
-                                                "end": 1966,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 1966,
-                                                "end": 1973,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 1974,
-                                            "end": 1975,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 1976,
@@ -4693,41 +1898,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 1979,
-                                        "end": 1980,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 1981,
                                         "end": 1998,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 1981,
-                                            "end": 1992,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 1981,
-                                                "end": 1982,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 1982,
-                                                "end": 1992,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 1993,
-                                            "end": 1994,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 1995,
@@ -4737,95 +1911,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 1998,
-                                        "end": 1999,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2000,
                                         "end": 2029,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2000,
-                                            "end": 2019,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2000,
-                                                "end": 2001,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2001,
-                                                "end": 2019,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2020,
-                                            "end": 2021,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2022,
                                             "end": 2029,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2022,
-                                                "end": 2023,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2023,
                                                 "end": 2028,
                                                 "text": "Alice"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2028,
-                                                "end": 2029,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2029,
-                                        "end": 2030,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2030,
-                                "end": 2031,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2032,
                                 "end": 2125,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2032,
-                                    "end": 2033,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2033,
@@ -4840,52 +1953,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2038,
-                                    "end": 2039,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2039,
                                     "end": 2125,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2039,
-                                        "end": 2040,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2040,
                                         "end": 2060,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2040,
-                                            "end": 2056,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2040,
-                                                "end": 2041,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2041,
-                                                "end": 2056,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2057,
-                                            "end": 2058,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2059,
@@ -4895,41 +1971,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2060,
-                                        "end": 2061,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2062,
                                         "end": 2076,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2062,
-                                            "end": 2070,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2062,
-                                                "end": 2063,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2063,
-                                                "end": 2070,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2071,
-                                            "end": 2072,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2073,
@@ -4939,41 +1984,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2076,
-                                        "end": 2077,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2078,
                                         "end": 2095,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2078,
-                                            "end": 2089,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2078,
-                                                "end": 2079,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2079,
-                                                "end": 2089,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2090,
-                                            "end": 2091,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2092,
@@ -4983,95 +1997,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2095,
-                                        "end": 2096,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2097,
                                         "end": 2124,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2097,
-                                            "end": 2116,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2097,
-                                                "end": 2098,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2098,
-                                                "end": 2116,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2117,
-                                            "end": 2118,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2119,
                                             "end": 2124,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2119,
-                                                "end": 2120,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2120,
                                                 "end": 2123,
                                                 "text": "Bob"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2123,
-                                                "end": 2124,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2124,
-                                        "end": 2125,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2125,
-                                "end": 2126,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2127,
                                 "end": 2224,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2127,
-                                    "end": 2128,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2128,
@@ -5086,52 +2039,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2133,
-                                    "end": 2134,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2134,
                                     "end": 2224,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2134,
-                                        "end": 2135,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2135,
                                         "end": 2155,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2135,
-                                            "end": 2151,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2135,
-                                                "end": 2136,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2136,
-                                                "end": 2151,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2152,
-                                            "end": 2153,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2154,
@@ -5141,41 +2057,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2155,
-                                        "end": 2156,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2157,
                                         "end": 2171,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2157,
-                                            "end": 2165,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2157,
-                                                "end": 2158,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2158,
-                                                "end": 2165,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2166,
-                                            "end": 2167,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2168,
@@ -5185,41 +2070,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2171,
-                                        "end": 2172,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2173,
                                         "end": 2190,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2173,
-                                            "end": 2184,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2173,
-                                                "end": 2174,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2174,
-                                                "end": 2184,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2185,
-                                            "end": 2186,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2187,
@@ -5229,95 +2083,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2190,
-                                        "end": 2191,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2192,
                                         "end": 2223,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2192,
-                                            "end": 2211,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2192,
-                                                "end": 2193,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2193,
-                                                "end": 2211,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2212,
-                                            "end": 2213,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2214,
                                             "end": 2223,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2214,
-                                                "end": 2215,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2215,
                                                 "end": 2222,
                                                 "text": "Charlie"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2222,
-                                                "end": 2223,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2223,
-                                        "end": 2224,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2224,
-                                "end": 2225,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2226,
                                 "end": 2321,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2226,
-                                    "end": 2227,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2227,
@@ -5332,52 +2125,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2232,
-                                    "end": 2233,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2233,
                                     "end": 2321,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2233,
-                                        "end": 2234,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2234,
                                         "end": 2254,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2234,
-                                            "end": 2250,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2234,
-                                                "end": 2235,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2235,
-                                                "end": 2250,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2251,
-                                            "end": 2252,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2253,
@@ -5387,41 +2143,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2254,
-                                        "end": 2255,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2256,
                                         "end": 2270,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2256,
-                                            "end": 2264,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2256,
-                                                "end": 2257,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2257,
-                                                "end": 2264,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2265,
-                                            "end": 2266,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2267,
@@ -5431,41 +2156,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2270,
-                                        "end": 2271,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2272,
                                         "end": 2289,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2272,
-                                            "end": 2283,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2272,
-                                                "end": 2273,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2273,
-                                                "end": 2283,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2284,
-                                            "end": 2285,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2286,
@@ -5475,95 +2169,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2289,
-                                        "end": 2290,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2291,
                                         "end": 2320,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2291,
-                                            "end": 2310,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2291,
-                                                "end": 2292,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2292,
-                                                "end": 2310,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2311,
-                                            "end": 2312,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2313,
                                             "end": 2320,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2313,
-                                                "end": 2314,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2314,
                                                 "end": 2319,
                                                 "text": "Alice"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2319,
-                                                "end": 2320,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2320,
-                                        "end": 2321,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2321,
-                                "end": 2322,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2323,
                                 "end": 2416,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2323,
-                                    "end": 2324,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2324,
@@ -5578,52 +2211,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2329,
-                                    "end": 2330,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2330,
                                     "end": 2416,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2330,
-                                        "end": 2331,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2331,
                                         "end": 2351,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2331,
-                                            "end": 2347,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2331,
-                                                "end": 2332,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2332,
-                                                "end": 2347,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2348,
-                                            "end": 2349,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2350,
@@ -5633,41 +2229,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2351,
-                                        "end": 2352,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2353,
                                         "end": 2367,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2353,
-                                            "end": 2361,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2353,
-                                                "end": 2354,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2354,
-                                                "end": 2361,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2362,
-                                            "end": 2363,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2364,
@@ -5677,41 +2242,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2367,
-                                        "end": 2368,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2369,
                                         "end": 2386,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2369,
-                                            "end": 2380,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2369,
-                                                "end": 2370,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2370,
-                                                "end": 2380,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2381,
-                                            "end": 2382,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2383,
@@ -5721,95 +2255,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2386,
-                                        "end": 2387,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2388,
                                         "end": 2415,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2388,
-                                            "end": 2407,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2388,
-                                                "end": 2389,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2389,
-                                                "end": 2407,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2408,
-                                            "end": 2409,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2410,
                                             "end": 2415,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2410,
-                                                "end": 2411,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2411,
                                                 "end": 2414,
                                                 "text": "Bob"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2414,
-                                                "end": 2415,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2415,
-                                        "end": 2416,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2416,
-                                "end": 2417,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2418,
                                 "end": 2515,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2418,
-                                    "end": 2419,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2419,
@@ -5824,52 +2297,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2424,
-                                    "end": 2425,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2425,
                                     "end": 2515,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2425,
-                                        "end": 2426,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2426,
                                         "end": 2446,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2426,
-                                            "end": 2442,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2426,
-                                                "end": 2427,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2427,
-                                                "end": 2442,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2443,
-                                            "end": 2444,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2445,
@@ -5879,41 +2315,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2446,
-                                        "end": 2447,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2448,
                                         "end": 2462,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2448,
-                                            "end": 2456,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2448,
-                                                "end": 2449,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2449,
-                                                "end": 2456,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2457,
-                                            "end": 2458,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2459,
@@ -5923,41 +2328,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2462,
-                                        "end": 2463,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2464,
                                         "end": 2481,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2464,
-                                            "end": 2475,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2464,
-                                                "end": 2465,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2465,
-                                                "end": 2475,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2476,
-                                            "end": 2477,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2478,
@@ -5967,95 +2341,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2481,
-                                        "end": 2482,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2483,
                                         "end": 2514,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2483,
-                                            "end": 2502,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2483,
-                                                "end": 2484,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2484,
-                                                "end": 2502,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2503,
-                                            "end": 2504,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2505,
                                             "end": 2514,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2505,
-                                                "end": 2506,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2506,
                                                 "end": 2513,
                                                 "text": "Charlie"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2513,
-                                                "end": 2514,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2514,
-                                        "end": 2515,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2515,
-                                "end": 2516,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2517,
                                 "end": 2612,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2517,
-                                    "end": 2518,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2518,
@@ -6070,52 +2383,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2523,
-                                    "end": 2524,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2524,
                                     "end": 2612,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2524,
-                                        "end": 2525,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2525,
                                         "end": 2545,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2525,
-                                            "end": 2541,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2525,
-                                                "end": 2526,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2526,
-                                                "end": 2541,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2542,
-                                            "end": 2543,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2544,
@@ -6125,41 +2401,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2545,
-                                        "end": 2546,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2547,
                                         "end": 2561,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2547,
-                                            "end": 2555,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2547,
-                                                "end": 2548,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2548,
-                                                "end": 2555,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2556,
-                                            "end": 2557,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2558,
@@ -6169,41 +2414,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2561,
-                                        "end": 2562,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2563,
                                         "end": 2580,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2563,
-                                            "end": 2574,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2563,
-                                                "end": 2564,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2564,
-                                                "end": 2574,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2575,
-                                            "end": 2576,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2577,
@@ -6213,95 +2427,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2580,
-                                        "end": 2581,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2582,
                                         "end": 2611,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2582,
-                                            "end": 2601,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2582,
-                                                "end": 2583,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2583,
-                                                "end": 2601,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2602,
-                                            "end": 2603,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2604,
                                             "end": 2611,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2604,
-                                                "end": 2605,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2605,
                                                 "end": 2610,
                                                 "text": "Alice"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2610,
-                                                "end": 2611,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2611,
-                                        "end": 2612,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2612,
-                                "end": 2613,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2614,
                                 "end": 2707,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2614,
-                                    "end": 2615,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2615,
@@ -6316,52 +2469,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2620,
-                                    "end": 2621,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2621,
                                     "end": 2707,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2621,
-                                        "end": 2622,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2622,
                                         "end": 2642,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2622,
-                                            "end": 2638,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2622,
-                                                "end": 2623,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2623,
-                                                "end": 2638,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2639,
-                                            "end": 2640,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2641,
@@ -6371,41 +2487,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2642,
-                                        "end": 2643,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2644,
                                         "end": 2658,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2644,
-                                            "end": 2652,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2644,
-                                                "end": 2645,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2645,
-                                                "end": 2652,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2653,
-                                            "end": 2654,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2655,
@@ -6415,41 +2500,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2658,
-                                        "end": 2659,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2660,
                                         "end": 2677,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2660,
-                                            "end": 2671,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2660,
-                                                "end": 2661,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2661,
-                                                "end": 2671,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2672,
-                                            "end": 2673,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2674,
@@ -6459,95 +2513,34 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2677,
-                                        "end": 2678,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2679,
                                         "end": 2706,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2679,
-                                            "end": 2698,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2679,
-                                                "end": 2680,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2680,
-                                                "end": 2698,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2699,
-                                            "end": 2700,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2701,
                                             "end": 2706,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2701,
-                                                "end": 2702,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2702,
                                                 "end": 2705,
                                                 "text": "Bob"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2705,
-                                                "end": 2706,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2706,
-                                        "end": 2707,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 2707,
-                                "end": 2708,
-                                "text": ","
-                              },
-                              {
                                 "kind": "compound_literal_expression",
                                 "start": 2709,
                                 "end": 2806,
                                 "children": [
-                                  {
-                                    "kind": "(",
-                                    "start": 2709,
-                                    "end": 2710,
-                                    "text": "("
-                                  },
                                   {
                                     "kind": "type_descriptor",
                                     "start": 2710,
@@ -6562,52 +2555,15 @@
                                     ]
                                   },
                                   {
-                                    "kind": ")",
-                                    "start": 2715,
-                                    "end": 2716,
-                                    "text": ")"
-                                  },
-                                  {
                                     "kind": "initializer_list",
                                     "start": 2716,
                                     "end": 2806,
                                     "children": [
                                       {
-                                        "kind": "{",
-                                        "start": 2716,
-                                        "end": 2717,
-                                        "text": "{"
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2717,
                                         "end": 2737,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2717,
-                                            "end": 2733,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2717,
-                                                "end": 2718,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2718,
-                                                "end": 2733,
-                                                "text": "orderCustomerId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2734,
-                                            "end": 2735,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2736,
@@ -6617,41 +2573,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2737,
-                                        "end": 2738,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2739,
                                         "end": 2753,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2739,
-                                            "end": 2747,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2739,
-                                                "end": 2740,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2740,
-                                                "end": 2747,
-                                                "text": "orderId"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2748,
-                                            "end": 2749,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2750,
@@ -6661,41 +2586,10 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2753,
-                                        "end": 2754,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2755,
                                         "end": 2772,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2755,
-                                            "end": 2766,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2755,
-                                                "end": 2756,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2756,
-                                                "end": 2766,
-                                                "text": "orderTotal"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2767,
-                                            "end": 2768,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "number_literal",
                                             "start": 2769,
@@ -6705,93 +2599,32 @@
                                         ]
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 2772,
-                                        "end": 2773,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "initializer_pair",
                                         "start": 2774,
                                         "end": 2805,
                                         "children": [
-                                          {
-                                            "kind": "field_designator",
-                                            "start": 2774,
-                                            "end": 2793,
-                                            "children": [
-                                              {
-                                                "kind": ".",
-                                                "start": 2774,
-                                                "end": 2775,
-                                                "text": "."
-                                              },
-                                              {
-                                                "kind": "field_identifier",
-                                                "start": 2775,
-                                                "end": 2793,
-                                                "text": "pairedCustomerName"
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "kind": "=",
-                                            "start": 2794,
-                                            "end": 2795,
-                                            "text": "="
-                                          },
                                           {
                                             "kind": "string_literal",
                                             "start": 2796,
                                             "end": 2805,
                                             "children": [
                                               {
-                                                "kind": "\"",
-                                                "start": 2796,
-                                                "end": 2797,
-                                                "text": "\""
-                                              },
-                                              {
                                                 "kind": "string_content",
                                                 "start": 2797,
                                                 "end": 2804,
                                                 "text": "Charlie"
-                                              },
-                                              {
-                                                "kind": "\"",
-                                                "start": 2804,
-                                                "end": 2805,
-                                                "text": "\""
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": "}",
-                                        "start": 2805,
-                                        "end": 2806,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 2806,
-                                "end": 2807,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": ";",
-                        "start": 2807,
-                        "end": 2808,
-                        "text": ";"
                       }
                     ]
                   },
@@ -6818,12 +2651,6 @@
                             "text": "entry_len"
                           },
                           {
-                            "kind": "=",
-                            "start": 2834,
-                            "end": 2835,
-                            "text": "="
-                          },
-                          {
                             "kind": "binary_expression",
                             "start": 2836,
                             "end": 2876,
@@ -6834,43 +2661,19 @@
                                 "end": 2853,
                                 "children": [
                                   {
-                                    "kind": "sizeof",
-                                    "start": 2836,
-                                    "end": 2842,
-                                    "text": "sizeof"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2842,
                                     "end": 2853,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 2842,
-                                        "end": 2843,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 2843,
                                         "end": 2852,
                                         "text": "entry_arr"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2852,
-                                        "end": 2853,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "/",
-                                "start": 2854,
-                                "end": 2855,
-                                "text": "/"
                               },
                               {
                                 "kind": "sizeof_expression",
@@ -6878,22 +2681,10 @@
                                 "end": 2876,
                                 "children": [
                                   {
-                                    "kind": "sizeof",
-                                    "start": 2856,
-                                    "end": 2862,
-                                    "text": "sizeof"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2862,
                                     "end": 2876,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 2862,
-                                        "end": 2863,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "subscript_expression",
                                         "start": 2863,
@@ -6906,30 +2697,12 @@
                                             "text": "entry_arr"
                                           },
                                           {
-                                            "kind": "[",
-                                            "start": 2872,
-                                            "end": 2873,
-                                            "text": "["
-                                          },
-                                          {
                                             "kind": "number_literal",
                                             "start": 2873,
                                             "end": 2874,
                                             "text": "0"
-                                          },
-                                          {
-                                            "kind": "]",
-                                            "start": 2874,
-                                            "end": 2875,
-                                            "text": "]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2875,
-                                        "end": 2876,
-                                        "text": ")"
                                       }
                                     ]
                                   }
@@ -6938,12 +2711,6 @@
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": ";",
-                        "start": 2876,
-                        "end": 2877,
-                        "text": ";"
                       }
                     ]
                   },
@@ -6952,18 +2719,6 @@
                     "start": 2886,
                     "end": 3163,
                     "children": [
-                      {
-                        "kind": "for",
-                        "start": 2886,
-                        "end": 2889,
-                        "text": "for"
-                      },
-                      {
-                        "kind": "(",
-                        "start": 2890,
-                        "end": 2891,
-                        "text": "("
-                      },
                       {
                         "kind": "declaration",
                         "start": 2891,
@@ -6987,24 +2742,12 @@
                                 "text": "i"
                               },
                               {
-                                "kind": "=",
-                                "start": 2900,
-                                "end": 2901,
-                                "text": "="
-                              },
-                              {
                                 "kind": "number_literal",
                                 "start": 2902,
                                 "end": 2903,
                                 "text": "0"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 2903,
-                            "end": 2904,
-                            "text": ";"
                           }
                         ]
                       },
@@ -7020,24 +2763,12 @@
                             "text": "i"
                           },
                           {
-                            "kind": "\u003c",
-                            "start": 2907,
-                            "end": 2908,
-                            "text": "\u003c"
-                          },
-                          {
                             "kind": "identifier",
                             "start": 2909,
                             "end": 2918,
                             "text": "entry_len"
                           }
                         ]
-                      },
-                      {
-                        "kind": ";",
-                        "start": 2918,
-                        "end": 2919,
-                        "text": ";"
                       },
                       {
                         "kind": "update_expression",
@@ -7049,32 +2780,14 @@
                             "start": 2920,
                             "end": 2921,
                             "text": "i"
-                          },
-                          {
-                            "kind": "++",
-                            "start": 2921,
-                            "end": 2923,
-                            "text": "++"
                           }
                         ]
-                      },
-                      {
-                        "kind": ")",
-                        "start": 2923,
-                        "end": 2924,
-                        "text": ")"
                       },
                       {
                         "kind": "compound_statement",
                         "start": 2925,
                         "end": 3163,
                         "children": [
-                          {
-                            "kind": "{",
-                            "start": 2925,
-                            "end": 2926,
-                            "text": "{"
-                          },
                           {
                             "kind": "declaration",
                             "start": 2939,
@@ -7098,12 +2811,6 @@
                                     "text": "entry"
                                   },
                                   {
-                                    "kind": "=",
-                                    "start": 2951,
-                                    "end": 2952,
-                                    "text": "="
-                                  },
-                                  {
                                     "kind": "subscript_expression",
                                     "start": 2953,
                                     "end": 2965,
@@ -7115,32 +2822,14 @@
                                         "text": "entry_arr"
                                       },
                                       {
-                                        "kind": "[",
-                                        "start": 2962,
-                                        "end": 2963,
-                                        "text": "["
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 2963,
                                         "end": 2964,
                                         "text": "i"
-                                      },
-                                      {
-                                        "kind": "]",
-                                        "start": 2964,
-                                        "end": 2965,
-                                        "text": "]"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ";",
-                                "start": 2965,
-                                "end": 2966,
-                                "text": ";"
                               }
                             ]
                           },
@@ -7166,22 +2855,10 @@
                                     "end": 3152,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 2985,
-                                        "end": 2986,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "string_literal",
                                         "start": 2986,
                                         "end": 3013,
                                         "children": [
-                                          {
-                                            "kind": "\"",
-                                            "start": 2986,
-                                            "end": 2987,
-                                            "text": "\""
-                                          },
                                           {
                                             "kind": "string_content",
                                             "start": 2987,
@@ -7193,20 +2870,8 @@
                                             "start": 3010,
                                             "end": 3012,
                                             "text": "\\n"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 3012,
-                                            "end": 3013,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3013,
-                                        "end": 3014,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -7214,30 +2879,12 @@
                                         "end": 3022,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 3015,
-                                            "end": 3016,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_content",
                                             "start": 3016,
                                             "end": 3021,
                                             "text": "Order"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 3021,
-                                            "end": 3022,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3022,
-                                        "end": 3023,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "field_expression",
@@ -7249,26 +2896,8 @@
                                             "start": 3024,
                                             "end": 3029,
                                             "text": "entry"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 3029,
-                                            "end": 3030,
-                                            "text": "."
-                                          },
-                                          {
-                                            "kind": "field_identifier",
-                                            "start": 3030,
-                                            "end": 3037,
-                                            "text": "orderId"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3037,
-                                        "end": 3038,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -7276,30 +2905,12 @@
                                         "end": 3053,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 3039,
-                                            "end": 3040,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_content",
                                             "start": 3040,
                                             "end": 3052,
                                             "text": "(customerId:"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 3052,
-                                            "end": 3053,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3053,
-                                        "end": 3054,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "field_expression",
@@ -7311,26 +2922,8 @@
                                             "start": 3055,
                                             "end": 3060,
                                             "text": "entry"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 3060,
-                                            "end": 3061,
-                                            "text": "."
-                                          },
-                                          {
-                                            "kind": "field_identifier",
-                                            "start": 3061,
-                                            "end": 3076,
-                                            "text": "orderCustomerId"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3076,
-                                        "end": 3077,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -7338,30 +2931,12 @@
                                         "end": 3090,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 3078,
-                                            "end": 3079,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_content",
                                             "start": 3079,
                                             "end": 3089,
                                             "text": ", total: $"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 3089,
-                                            "end": 3090,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3090,
-                                        "end": 3091,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "field_expression",
@@ -7373,26 +2948,8 @@
                                             "start": 3092,
                                             "end": 3097,
                                             "text": "entry"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 3097,
-                                            "end": 3098,
-                                            "text": "."
-                                          },
-                                          {
-                                            "kind": "field_identifier",
-                                            "start": 3098,
-                                            "end": 3108,
-                                            "text": "orderTotal"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3108,
-                                        "end": 3109,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -7400,30 +2957,12 @@
                                         "end": 3125,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 3110,
-                                            "end": 3111,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_content",
                                             "start": 3111,
                                             "end": 3124,
                                             "text": ") paired with"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 3124,
-                                            "end": 3125,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 3125,
-                                        "end": 3126,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "field_expression",
@@ -7435,54 +2974,18 @@
                                             "start": 3127,
                                             "end": 3132,
                                             "text": "entry"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 3132,
-                                            "end": 3133,
-                                            "text": "."
-                                          },
-                                          {
-                                            "kind": "field_identifier",
-                                            "start": 3133,
-                                            "end": 3151,
-                                            "text": "pairedCustomerName"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 3151,
-                                        "end": 3152,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ";",
-                                "start": 3152,
-                                "end": 3153,
-                                "text": ";"
                               }
                             ]
-                          },
-                          {
-                            "kind": "}",
-                            "start": 3162,
-                            "end": 3163,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": "}",
-                    "start": 3168,
-                    "end": 3169,
-                    "text": "}"
                   }
                 ]
               },
@@ -7492,30 +2995,12 @@
                 "end": 3183,
                 "children": [
                   {
-                    "kind": "return",
-                    "start": 3174,
-                    "end": 3180,
-                    "text": "return"
-                  },
-                  {
                     "kind": "number_literal",
                     "start": 3181,
                     "end": 3182,
                     "text": "0"
-                  },
-                  {
-                    "kind": ";",
-                    "start": 3182,
-                    "end": 3183,
-                    "text": ";"
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 3184,
-                "end": 3185,
-                "text": "}"
               }
             ]
           }

--- a/tools/json-ast/x/c/ast.go
+++ b/tools/json-ast/x/c/ast.go
@@ -1,37 +1,63 @@
 package c
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+        sitter "github.com/smacker/go-tree-sitter"
 )
 
 // Node represents a tree-sitter node with byte offsets and optional text.
 type Node struct {
-	Kind     string  `json:"kind"`
-	Start    int     `json:"start"`
-	End      int     `json:"end"`
-	Text     string  `json:"text,omitempty"`
-	Children []*Node `json:"children,omitempty"`
+        Kind     string  `json:"kind"`
+        Start    int     `json:"start"`
+        End      int     `json:"end"`
+        Text     string  `json:"text,omitempty"`
+        Children []*Node `json:"children,omitempty"`
 }
 
 // toNode converts a tree-sitter node into our Node type.
 func toNode(n *sitter.Node, src []byte) *Node {
-	if n == nil {
-		return nil
-	}
-	node := &Node{
-		Kind:  n.Type(),
-		Start: int(n.StartByte()),
-		End:   int(n.EndByte()),
-	}
-	if n.ChildCount() == 0 {
-		node.Text = n.Content(src)
-	}
-	for i := 0; i < int(n.ChildCount()); i++ {
-		child := n.Child(i)
-		if child == nil {
-			continue
-		}
-		node.Children = append(node.Children, toNode(child, src))
-	}
-	return node
+        if n == nil {
+                return nil
+        }
+        node := &Node{
+                Kind:  n.Type(),
+                Start: int(n.StartByte()),
+                End:   int(n.EndByte()),
+        }
+
+        if n.NamedChildCount() == 0 {
+                if isValueNode(n.Type()) {
+                        node.Text = n.Content(src)
+                } else if node.Kind == "comment" {
+                        node.Text = n.Content(src)
+                } else {
+                        // skip pure syntax leaves
+                        return nil
+                }
+        }
+
+        for i := 0; i < int(n.NamedChildCount()); i++ {
+                child := n.NamedChild(i)
+                if child == nil {
+                        continue
+                }
+                if c := toNode(child, src); c != nil {
+                        node.Children = append(node.Children, c)
+                }
+        }
+
+        if len(node.Children) == 0 && node.Text == "" {
+                return nil
+        }
+        return node
+}
+
+func isValueNode(kind string) bool {
+        switch kind {
+        case "identifier", "number_literal", "char_literal", "string_literal",
+                "system_lib_string", "primitive_type", "type_identifier",
+                "string_content", "escape_sequence", "comment":
+                return true
+        default:
+                return false
+        }
 }


### PR DESCRIPTION
## Summary
- filter out syntax-only nodes when building C JSON AST
- generate `cross_join.c.json` with the new AST

## Testing
- `go test ./tools/json-ast/x/c -run TestInspectGolden/cross_join$ -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6889cb4f130c83209b85a2e19b8e23f2