### PR TITLE
Simplify Erlang AST JSON

### DIFF
--- a/tests/json-ast/x/erlang/cross_join.erl.json
+++ b/tests/json-ast/x/erlang/cross_join.erl.json
@@ -10,46 +10,16 @@
         "end": 22,
         "children": [
           {
-            "kind": "#",
-            "start": 0,
-            "end": 1,
-            "text": "#"
-          },
-          {
-            "kind": "!",
-            "start": 1,
-            "end": 2,
-            "text": "!"
-          },
-          {
-            "kind": "/",
-            "start": 2,
-            "end": 3,
-            "text": "/"
-          },
-          {
             "kind": "atom",
             "start": 3,
             "end": 6,
             "text": "usr"
           },
           {
-            "kind": "/",
-            "start": 6,
-            "end": 7,
-            "text": "/"
-          },
-          {
             "kind": "atom",
             "start": 7,
             "end": 10,
             "text": "bin"
-          },
-          {
-            "kind": "/",
-            "start": 10,
-            "end": 11,
-            "text": "/"
           },
           {
             "kind": "atom",
@@ -71,40 +41,10 @@
         "end": 37,
         "children": [
           {
-            "kind": "-",
-            "start": 23,
-            "end": 24,
-            "text": "-"
-          },
-          {
-            "kind": "module",
-            "start": 24,
-            "end": 30,
-            "text": "module"
-          },
-          {
-            "kind": "(",
-            "start": 30,
-            "end": 31,
-            "text": "("
-          },
-          {
             "kind": "atom",
             "start": 31,
             "end": 35,
             "text": "main"
-          },
-          {
-            "kind": ")",
-            "start": 35,
-            "end": 36,
-            "text": ")"
-          },
-          {
-            "kind": ".",
-            "start": 36,
-            "end": 37,
-            "text": "."
           }
         ]
       },
@@ -113,30 +53,6 @@
         "start": 38,
         "end": 56,
         "children": [
-          {
-            "kind": "-",
-            "start": 38,
-            "end": 39,
-            "text": "-"
-          },
-          {
-            "kind": "export",
-            "start": 39,
-            "end": 45,
-            "text": "export"
-          },
-          {
-            "kind": "(",
-            "start": 45,
-            "end": 46,
-            "text": "("
-          },
-          {
-            "kind": "[",
-            "start": 46,
-            "end": 47,
-            "text": "["
-          },
           {
             "kind": "fa",
             "start": 47,
@@ -154,12 +70,6 @@
                 "end": 53,
                 "children": [
                   {
-                    "kind": "/",
-                    "start": 51,
-                    "end": 52,
-                    "text": "/"
-                  },
-                  {
                     "kind": "integer",
                     "start": 52,
                     "end": 53,
@@ -168,24 +78,6 @@
                 ]
               }
             ]
-          },
-          {
-            "kind": "]",
-            "start": 53,
-            "end": 54,
-            "text": "]"
-          },
-          {
-            "kind": ")",
-            "start": 54,
-            "end": 55,
-            "text": ")"
-          },
-          {
-            "kind": ".",
-            "start": 55,
-            "end": 56,
-            "text": "."
           }
         ]
       },
@@ -217,22 +109,10 @@
                 "end": 145,
                 "children": [
                   {
-                    "kind": "(",
-                    "start": 142,
-                    "end": 143,
-                    "text": "("
-                  },
-                  {
                     "kind": "var",
                     "start": 143,
                     "end": 144,
                     "text": "_"
-                  },
-                  {
-                    "kind": ")",
-                    "start": 144,
-                    "end": 145,
-                    "text": ")"
                   }
                 ]
               },
@@ -241,12 +121,6 @@
                 "start": 146,
                 "end": 998,
                 "children": [
-                  {
-                    "kind": "-\u003e",
-                    "start": 146,
-                    "end": 148,
-                    "text": "-\u003e"
-                  },
                   {
                     "kind": "match_expr",
                     "start": 153,
@@ -259,39 +133,15 @@
                         "text": "Customers"
                       },
                       {
-                        "kind": "=",
-                        "start": 163,
-                        "end": 164,
-                        "text": "="
-                      },
-                      {
                         "kind": "list",
                         "start": 165,
                         "end": 264,
                         "children": [
                           {
-                            "kind": "[",
-                            "start": 165,
-                            "end": 166,
-                            "text": "["
-                          },
-                          {
                             "kind": "map_expr",
                             "start": 166,
                             "end": 197,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 166,
-                                "end": 167,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 167,
-                                "end": 168,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 168,
@@ -304,24 +154,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 173,
-                                    "end": 175,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 176,
                                     "end": 177,
                                     "text": "1"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 177,
-                                "end": 178,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -335,50 +173,20 @@
                                     "text": "\"name\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 186,
-                                    "end": 188,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "string",
                                     "start": 189,
                                     "end": 196,
                                     "text": "\"Alice\""
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 196,
-                                "end": 197,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": ",",
-                            "start": 197,
-                            "end": 198,
-                            "text": ","
                           },
                           {
                             "kind": "map_expr",
                             "start": 199,
                             "end": 228,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 199,
-                                "end": 200,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 200,
-                                "end": 201,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 201,
@@ -391,24 +199,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 206,
-                                    "end": 208,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 209,
                                     "end": 210,
                                     "text": "2"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 210,
-                                "end": 211,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -422,50 +218,20 @@
                                     "text": "\"name\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 219,
-                                    "end": 221,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "string",
                                     "start": 222,
                                     "end": 227,
                                     "text": "\"Bob\""
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 227,
-                                "end": 228,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": ",",
-                            "start": 228,
-                            "end": 229,
-                            "text": ","
                           },
                           {
                             "kind": "map_expr",
                             "start": 230,
                             "end": 263,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 230,
-                                "end": 231,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 231,
-                                "end": 232,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 232,
@@ -478,24 +244,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 237,
-                                    "end": 239,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 240,
                                     "end": 241,
                                     "text": "3"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 241,
-                                "end": 242,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -509,42 +263,18 @@
                                     "text": "\"name\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 250,
-                                    "end": 252,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "string",
                                     "start": 253,
                                     "end": 262,
                                     "text": "\"Charlie\""
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 262,
-                                "end": 263,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": "]",
-                            "start": 263,
-                            "end": 264,
-                            "text": "]"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ",",
-                    "start": 264,
-                    "end": 265,
-                    "text": ","
                   },
                   {
                     "kind": "match_expr",
@@ -558,39 +288,15 @@
                         "text": "Orders"
                       },
                       {
-                        "kind": "=",
-                        "start": 277,
-                        "end": 278,
-                        "text": "="
-                      },
-                      {
                         "kind": "list",
                         "start": 279,
                         "end": 432,
                         "children": [
                           {
-                            "kind": "[",
-                            "start": 279,
-                            "end": 280,
-                            "text": "["
-                          },
-                          {
                             "kind": "map_expr",
                             "start": 280,
                             "end": 329,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 280,
-                                "end": 281,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 281,
-                                "end": 282,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 282,
@@ -603,24 +309,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 287,
-                                    "end": 289,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 290,
                                     "end": 293,
                                     "text": "100"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 293,
-                                "end": 294,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -634,24 +328,12 @@
                                     "text": "\"customerId\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 308,
-                                    "end": 310,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 311,
                                     "end": 312,
                                     "text": "1"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 312,
-                                "end": 313,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -665,50 +347,20 @@
                                     "text": "\"total\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 322,
-                                    "end": 324,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 325,
                                     "end": 328,
                                     "text": "250"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 328,
-                                "end": 329,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": ",",
-                            "start": 329,
-                            "end": 330,
-                            "text": ","
                           },
                           {
                             "kind": "map_expr",
                             "start": 331,
                             "end": 380,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 331,
-                                "end": 332,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 332,
-                                "end": 333,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 333,
@@ -721,24 +373,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 338,
-                                    "end": 340,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 341,
                                     "end": 344,
                                     "text": "101"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 344,
-                                "end": 345,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -752,24 +392,12 @@
                                     "text": "\"customerId\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 359,
-                                    "end": 361,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 362,
                                     "end": 363,
                                     "text": "2"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 363,
-                                "end": 364,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -783,50 +411,20 @@
                                     "text": "\"total\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 373,
-                                    "end": 375,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 376,
                                     "end": 379,
                                     "text": "125"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 379,
-                                "end": 380,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": ",",
-                            "start": 380,
-                            "end": 381,
-                            "text": ","
                           },
                           {
                             "kind": "map_expr",
                             "start": 382,
                             "end": 431,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 382,
-                                "end": 383,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 383,
-                                "end": 384,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 384,
@@ -839,24 +437,12 @@
                                     "text": "\"id\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 389,
-                                    "end": 391,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 392,
                                     "end": 395,
                                     "text": "102"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 395,
-                                "end": 396,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -870,24 +456,12 @@
                                     "text": "\"customerId\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 410,
-                                    "end": 412,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 413,
                                     "end": 414,
                                     "text": "1"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 414,
-                                "end": 415,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -901,42 +475,18 @@
                                     "text": "\"total\""
                                   },
                                   {
-                                    "kind": "=\u003e",
-                                    "start": 424,
-                                    "end": 426,
-                                    "text": "=\u003e"
-                                  },
-                                  {
                                     "kind": "integer",
                                     "start": 427,
                                     "end": 430,
                                     "text": "300"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 430,
-                                "end": 431,
-                                "text": "}"
                               }
                             ]
-                          },
-                          {
-                            "kind": "]",
-                            "start": 431,
-                            "end": 432,
-                            "text": "]"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ",",
-                    "start": 432,
-                    "end": 433,
-                    "text": ","
                   },
                   {
                     "kind": "match_expr",
@@ -950,39 +500,15 @@
                         "text": "Result"
                       },
                       {
-                        "kind": "=",
-                        "start": 445,
-                        "end": 446,
-                        "text": "="
-                      },
-                      {
                         "kind": "list_comprehension",
                         "start": 447,
                         "end": 644,
                         "children": [
                           {
-                            "kind": "[",
-                            "start": 447,
-                            "end": 448,
-                            "text": "["
-                          },
-                          {
                             "kind": "map_expr",
                             "start": 448,
                             "end": 612,
                             "children": [
-                              {
-                                "kind": "#",
-                                "start": 448,
-                                "end": 449,
-                                "text": "#"
-                              },
-                              {
-                                "kind": "{",
-                                "start": 449,
-                                "end": 450,
-                                "text": "{"
-                              },
                               {
                                 "kind": "map_field",
                                 "start": 450,
@@ -993,12 +519,6 @@
                                     "start": 450,
                                     "end": 459,
                                     "text": "\"orderId\""
-                                  },
-                                  {
-                                    "kind": "=\u003e",
-                                    "start": 460,
-                                    "end": 462,
-                                    "text": "=\u003e"
                                   },
                                   {
                                     "kind": "call",
@@ -1020,12 +540,6 @@
                                                 "start": 463,
                                                 "end": 467,
                                                 "text": "maps"
-                                              },
-                                              {
-                                                "kind": ":",
-                                                "start": 467,
-                                                "end": 468,
-                                                "text": ":"
                                               }
                                             ]
                                           },
@@ -1043,46 +557,22 @@
                                         "end": 480,
                                         "children": [
                                           {
-                                            "kind": "(",
-                                            "start": 471,
-                                            "end": 472,
-                                            "text": "("
-                                          },
-                                          {
                                             "kind": "string",
                                             "start": 472,
                                             "end": 476,
                                             "text": "\"id\""
                                           },
                                           {
-                                            "kind": ",",
-                                            "start": 476,
-                                            "end": 477,
-                                            "text": ","
-                                          },
-                                          {
                                             "kind": "var",
                                             "start": 478,
                                             "end": 479,
                                             "text": "O"
-                                          },
-                                          {
-                                            "kind": ")",
-                                            "start": 479,
-                                            "end": 480,
-                                            "text": ")"
                                           }
                                         ]
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 480,
-                                "end": 481,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -1094,12 +584,6 @@
                                     "start": 482,
                                     "end": 499,
                                     "text": "\"orderCustomerId\""
-                                  },
-                                  {
-                                    "kind": "=\u003e",
-                                    "start": 500,
-                                    "end": 502,
-                                    "text": "=\u003e"
                                   },
                                   {
                                     "kind": "call",
@@ -1121,12 +605,6 @@
                                                 "start": 503,
                                                 "end": 507,
                                                 "text": "maps"
-                                              },
-                                              {
-                                                "kind": ":",
-                                                "start": 507,
-                                                "end": 508,
-                                                "text": ":"
                                               }
                                             ]
                                           },
@@ -1144,46 +622,22 @@
                                         "end": 528,
                                         "children": [
                                           {
-                                            "kind": "(",
-                                            "start": 511,
-                                            "end": 512,
-                                            "text": "("
-                                          },
-                                          {
                                             "kind": "string",
                                             "start": 512,
                                             "end": 524,
                                             "text": "\"customerId\""
                                           },
                                           {
-                                            "kind": ",",
-                                            "start": 524,
-                                            "end": 525,
-                                            "text": ","
-                                          },
-                                          {
                                             "kind": "var",
                                             "start": 526,
                                             "end": 527,
                                             "text": "O"
-                                          },
-                                          {
-                                            "kind": ")",
-                                            "start": 527,
-                                            "end": 528,
-                                            "text": ")"
                                           }
                                         ]
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 528,
-                                "end": 529,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -1195,12 +649,6 @@
                                     "start": 530,
                                     "end": 550,
                                     "text": "\"pairedCustomerName\""
-                                  },
-                                  {
-                                    "kind": "=\u003e",
-                                    "start": 551,
-                                    "end": 553,
-                                    "text": "=\u003e"
                                   },
                                   {
                                     "kind": "call",
@@ -1222,12 +670,6 @@
                                                 "start": 554,
                                                 "end": 558,
                                                 "text": "maps"
-                                              },
-                                              {
-                                                "kind": ":",
-                                                "start": 558,
-                                                "end": 559,
-                                                "text": ":"
                                               }
                                             ]
                                           },
@@ -1245,46 +687,22 @@
                                         "end": 573,
                                         "children": [
                                           {
-                                            "kind": "(",
-                                            "start": 562,
-                                            "end": 563,
-                                            "text": "("
-                                          },
-                                          {
                                             "kind": "string",
                                             "start": 563,
                                             "end": 569,
                                             "text": "\"name\""
                                           },
                                           {
-                                            "kind": ",",
-                                            "start": 569,
-                                            "end": 570,
-                                            "text": ","
-                                          },
-                                          {
                                             "kind": "var",
                                             "start": 571,
                                             "end": 572,
                                             "text": "C"
-                                          },
-                                          {
-                                            "kind": ")",
-                                            "start": 572,
-                                            "end": 573,
-                                            "text": ")"
                                           }
                                         ]
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 573,
-                                "end": 574,
-                                "text": ","
                               },
                               {
                                 "kind": "map_field",
@@ -1296,12 +714,6 @@
                                     "start": 575,
                                     "end": 587,
                                     "text": "\"orderTotal\""
-                                  },
-                                  {
-                                    "kind": "=\u003e",
-                                    "start": 588,
-                                    "end": 590,
-                                    "text": "=\u003e"
                                   },
                                   {
                                     "kind": "call",
@@ -1323,12 +735,6 @@
                                                 "start": 591,
                                                 "end": 595,
                                                 "text": "maps"
-                                              },
-                                              {
-                                                "kind": ":",
-                                                "start": 595,
-                                                "end": 596,
-                                                "text": ":"
                                               }
                                             ]
                                           },
@@ -1346,46 +752,22 @@
                                         "end": 611,
                                         "children": [
                                           {
-                                            "kind": "(",
-                                            "start": 599,
-                                            "end": 600,
-                                            "text": "("
-                                          },
-                                          {
                                             "kind": "string",
                                             "start": 600,
                                             "end": 607,
                                             "text": "\"total\""
                                           },
                                           {
-                                            "kind": ",",
-                                            "start": 607,
-                                            "end": 608,
-                                            "text": ","
-                                          },
-                                          {
                                             "kind": "var",
                                             "start": 609,
                                             "end": 610,
                                             "text": "O"
-                                          },
-                                          {
-                                            "kind": ")",
-                                            "start": 610,
-                                            "end": 611,
-                                            "text": ")"
                                           }
                                         ]
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 611,
-                                "end": 612,
-                                "text": "}"
                               }
                             ]
                           },
@@ -1394,12 +776,6 @@
                             "start": 613,
                             "end": 643,
                             "children": [
-                              {
-                                "kind": "||",
-                                "start": 613,
-                                "end": 615,
-                                "text": "||"
-                              },
                               {
                                 "kind": "generator",
                                 "start": 616,
@@ -1412,24 +788,12 @@
                                     "text": "O"
                                   },
                                   {
-                                    "kind": "\u003c-",
-                                    "start": 618,
-                                    "end": 620,
-                                    "text": "\u003c-"
-                                  },
-                                  {
                                     "kind": "var",
                                     "start": 621,
                                     "end": 627,
                                     "text": "Orders"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 627,
-                                "end": 628,
-                                "text": ","
                               },
                               {
                                 "kind": "generator",
@@ -1443,12 +807,6 @@
                                     "text": "C"
                                   },
                                   {
-                                    "kind": "\u003c-",
-                                    "start": 631,
-                                    "end": 633,
-                                    "text": "\u003c-"
-                                  },
-                                  {
                                     "kind": "var",
                                     "start": 634,
                                     "end": 643,
@@ -1457,22 +815,10 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": "]",
-                            "start": 643,
-                            "end": 644,
-                            "text": "]"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ",",
-                    "start": 644,
-                    "end": 645,
-                    "text": ","
                   },
                   {
                     "kind": "call",
@@ -1494,12 +840,6 @@
                                 "start": 650,
                                 "end": 652,
                                 "text": "io"
-                              },
-                              {
-                                "kind": ":",
-                                "start": 652,
-                                "end": 653,
-                                "text": ":"
                               }
                             ]
                           },
@@ -1517,22 +857,10 @@
                         "end": 717,
                         "children": [
                           {
-                            "kind": "(",
-                            "start": 659,
-                            "end": 660,
-                            "text": "("
-                          },
-                          {
                             "kind": "string",
                             "start": 660,
                             "end": 666,
                             "text": "\"~s~n\""
-                          },
-                          {
-                            "kind": ",",
-                            "start": 666,
-                            "end": 667,
-                            "text": ","
                           },
                           {
                             "kind": "list",
@@ -1540,40 +868,16 @@
                             "end": 716,
                             "children": [
                               {
-                                "kind": "[",
-                                "start": 668,
-                                "end": 669,
-                                "text": "["
-                              },
-                              {
                                 "kind": "string",
                                 "start": 669,
                                 "end": 715,
                                 "text": "\"--- Cross Join: All order-customer pairs ---\""
-                              },
-                              {
-                                "kind": "]",
-                                "start": 715,
-                                "end": 716,
-                                "text": "]"
                               }
                             ]
-                          },
-                          {
-                            "kind": ")",
-                            "start": 716,
-                            "end": 717,
-                            "text": ")"
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ",",
-                    "start": 717,
-                    "end": 718,
-                    "text": ","
                   },
                   {
                     "kind": "call",
@@ -1595,12 +899,6 @@
                                 "start": 723,
                                 "end": 728,
                                 "text": "lists"
-                              },
-                              {
-                                "kind": ":",
-                                "start": 728,
-                                "end": 729,
-                                "text": ":"
                               }
                             ]
                           },
@@ -1618,22 +916,10 @@
                         "end": 998,
                         "children": [
                           {
-                            "kind": "(",
-                            "start": 736,
-                            "end": 737,
-                            "text": "("
-                          },
-                          {
                             "kind": "anonymous_fun",
                             "start": 737,
                             "end": 989,
                             "children": [
-                              {
-                                "kind": "fun",
-                                "start": 737,
-                                "end": 740,
-                                "text": "fun"
-                              },
                               {
                                 "kind": "fun_clause",
                                 "start": 740,
@@ -1645,22 +931,10 @@
                                     "end": 747,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 740,
-                                        "end": 741,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "var",
                                         "start": 741,
                                         "end": 746,
                                         "text": "Entry"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 746,
-                                        "end": 747,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -1669,12 +943,6 @@
                                     "start": 748,
                                     "end": 985,
                                     "children": [
-                                      {
-                                        "kind": "-\u003e",
-                                        "start": 748,
-                                        "end": 750,
-                                        "text": "-\u003e"
-                                      },
                                       {
                                         "kind": "call",
                                         "start": 755,
@@ -1695,12 +963,6 @@
                                                     "start": 755,
                                                     "end": 757,
                                                     "text": "io"
-                                                  },
-                                                  {
-                                                    "kind": ":",
-                                                    "start": 757,
-                                                    "end": 758,
-                                                    "text": ":"
                                                   }
                                                 ]
                                               },
@@ -1718,22 +980,10 @@
                                             "end": 985,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 764,
-                                                "end": 765,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string",
                                                 "start": 765,
                                                 "end": 792,
                                                 "text": "\"~s ~p ~s ~p ~s ~p ~s ~p~n\""
-                                              },
-                                              {
-                                                "kind": ",",
-                                                "start": 792,
-                                                "end": 793,
-                                                "text": ","
                                               },
                                               {
                                                 "kind": "list",
@@ -1741,22 +991,10 @@
                                                 "end": 984,
                                                 "children": [
                                                   {
-                                                    "kind": "[",
-                                                    "start": 794,
-                                                    "end": 795,
-                                                    "text": "["
-                                                  },
-                                                  {
                                                     "kind": "string",
                                                     "start": 795,
                                                     "end": 802,
                                                     "text": "\"Order\""
-                                                  },
-                                                  {
-                                                    "kind": ",",
-                                                    "start": 802,
-                                                    "end": 803,
-                                                    "text": ","
                                                   },
                                                   {
                                                     "kind": "call",
@@ -1778,12 +1016,6 @@
                                                                 "start": 804,
                                                                 "end": 808,
                                                                 "text": "maps"
-                                                              },
-                                                              {
-                                                                "kind": ":",
-                                                                "start": 808,
-                                                                "end": 809,
-                                                                "text": ":"
                                                               }
                                                             ]
                                                           },
@@ -1801,56 +1033,26 @@
                                                         "end": 830,
                                                         "children": [
                                                           {
-                                                            "kind": "(",
-                                                            "start": 812,
-                                                            "end": 813,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "kind": "string",
                                                             "start": 813,
                                                             "end": 822,
                                                             "text": "\"orderId\""
                                                           },
                                                           {
-                                                            "kind": ",",
-                                                            "start": 822,
-                                                            "end": 823,
-                                                            "text": ","
-                                                          },
-                                                          {
                                                             "kind": "var",
                                                             "start": 824,
                                                             "end": 829,
                                                             "text": "Entry"
-                                                          },
-                                                          {
-                                                            "kind": ")",
-                                                            "start": 829,
-                                                            "end": 830,
-                                                            "text": ")"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   },
                                                   {
-                                                    "kind": ",",
-                                                    "start": 830,
-                                                    "end": 831,
-                                                    "text": ","
-                                                  },
-                                                  {
                                                     "kind": "string",
                                                     "start": 832,
                                                     "end": 846,
                                                     "text": "\"(customerId:\""
-                                                  },
-                                                  {
-                                                    "kind": ",",
-                                                    "start": 846,
-                                                    "end": 847,
-                                                    "text": ","
                                                   },
                                                   {
                                                     "kind": "call",
@@ -1872,12 +1074,6 @@
                                                                 "start": 848,
                                                                 "end": 852,
                                                                 "text": "maps"
-                                                              },
-                                                              {
-                                                                "kind": ":",
-                                                                "start": 852,
-                                                                "end": 853,
-                                                                "text": ":"
                                                               }
                                                             ]
                                                           },
@@ -1895,56 +1091,26 @@
                                                         "end": 882,
                                                         "children": [
                                                           {
-                                                            "kind": "(",
-                                                            "start": 856,
-                                                            "end": 857,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "kind": "string",
                                                             "start": 857,
                                                             "end": 874,
                                                             "text": "\"orderCustomerId\""
                                                           },
                                                           {
-                                                            "kind": ",",
-                                                            "start": 874,
-                                                            "end": 875,
-                                                            "text": ","
-                                                          },
-                                                          {
                                                             "kind": "var",
                                                             "start": 876,
                                                             "end": 881,
                                                             "text": "Entry"
-                                                          },
-                                                          {
-                                                            "kind": ")",
-                                                            "start": 881,
-                                                            "end": 882,
-                                                            "text": ")"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   },
                                                   {
-                                                    "kind": ",",
-                                                    "start": 882,
-                                                    "end": 883,
-                                                    "text": ","
-                                                  },
-                                                  {
                                                     "kind": "string",
                                                     "start": 884,
                                                     "end": 896,
                                                     "text": "\", total: $\""
-                                                  },
-                                                  {
-                                                    "kind": ",",
-                                                    "start": 896,
-                                                    "end": 897,
-                                                    "text": ","
                                                   },
                                                   {
                                                     "kind": "call",
@@ -1966,12 +1132,6 @@
                                                                 "start": 898,
                                                                 "end": 902,
                                                                 "text": "maps"
-                                                              },
-                                                              {
-                                                                "kind": ":",
-                                                                "start": 902,
-                                                                "end": 903,
-                                                                "text": ":"
                                                               }
                                                             ]
                                                           },
@@ -1989,56 +1149,26 @@
                                                         "end": 927,
                                                         "children": [
                                                           {
-                                                            "kind": "(",
-                                                            "start": 906,
-                                                            "end": 907,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "kind": "string",
                                                             "start": 907,
                                                             "end": 919,
                                                             "text": "\"orderTotal\""
                                                           },
                                                           {
-                                                            "kind": ",",
-                                                            "start": 919,
-                                                            "end": 920,
-                                                            "text": ","
-                                                          },
-                                                          {
                                                             "kind": "var",
                                                             "start": 921,
                                                             "end": 926,
                                                             "text": "Entry"
-                                                          },
-                                                          {
-                                                            "kind": ")",
-                                                            "start": 926,
-                                                            "end": 927,
-                                                            "text": ")"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   },
                                                   {
-                                                    "kind": ",",
-                                                    "start": 927,
-                                                    "end": 928,
-                                                    "text": ","
-                                                  },
-                                                  {
                                                     "kind": "string",
                                                     "start": 929,
                                                     "end": 944,
                                                     "text": "\") paired with\""
-                                                  },
-                                                  {
-                                                    "kind": ",",
-                                                    "start": 944,
-                                                    "end": 945,
-                                                    "text": ","
                                                   },
                                                   {
                                                     "kind": "call",
@@ -2060,12 +1190,6 @@
                                                                 "start": 946,
                                                                 "end": 950,
                                                                 "text": "maps"
-                                                              },
-                                                              {
-                                                                "kind": ":",
-                                                                "start": 950,
-                                                                "end": 951,
-                                                                "text": ":"
                                                               }
                                                             ]
                                                           },
@@ -2083,52 +1207,22 @@
                                                         "end": 983,
                                                         "children": [
                                                           {
-                                                            "kind": "(",
-                                                            "start": 954,
-                                                            "end": 955,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "kind": "string",
                                                             "start": 955,
                                                             "end": 975,
                                                             "text": "\"pairedCustomerName\""
                                                           },
                                                           {
-                                                            "kind": ",",
-                                                            "start": 975,
-                                                            "end": 976,
-                                                            "text": ","
-                                                          },
-                                                          {
                                                             "kind": "var",
                                                             "start": 977,
                                                             "end": 982,
                                                             "text": "Entry"
-                                                          },
-                                                          {
-                                                            "kind": ")",
-                                                            "start": 982,
-                                                            "end": 983,
-                                                            "text": ")"
                                                           }
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": "]",
-                                                    "start": 983,
-                                                    "end": 984,
-                                                    "text": "]"
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 984,
-                                                "end": 985,
-                                                "text": ")"
                                               }
                                             ]
                                           }
@@ -2137,32 +1231,14 @@
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "end",
-                                "start": 986,
-                                "end": 989,
-                                "text": "end"
                               }
                             ]
-                          },
-                          {
-                            "kind": ",",
-                            "start": 989,
-                            "end": 990,
-                            "text": ","
                           },
                           {
                             "kind": "var",
                             "start": 991,
                             "end": 997,
                             "text": "Result"
-                          },
-                          {
-                            "kind": ")",
-                            "start": 997,
-                            "end": 998,
-                            "text": ")"
                           }
                         ]
                       }
@@ -2171,12 +1247,6 @@
                 ]
               }
             ]
-          },
-          {
-            "kind": ".",
-            "start": 998,
-            "end": 999,
-            "text": "."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- trim punctuation when converting Erlang tree‑sitter nodes
- regenerate `cross_join.erl.json` with the minimal structure

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889cbf776288320bd244b603d1e423d