### PR TITLE
Simplify Java JSON AST

### DIFF
--- a/tests/json-ast/x/java/cross_join.java.json
+++ b/tests/json-ast/x/java/cross_join.java.json
@@ -13,20 +13,7 @@
             "kind": "modifiers",
             "start": 0,
             "end": 6,
-            "children": [
-              {
-                "kind": "public",
-                "start": 0,
-                "end": 6,
-                "text": "public"
-              }
-            ]
-          },
-          {
-            "kind": "class",
-            "start": 7,
-            "end": 12,
-            "text": "class"
+            "text": "public"
           },
           {
             "kind": "identifier",
@@ -40,12 +27,6 @@
             "end": 2738,
             "children": [
               {
-                "kind": "{",
-                "start": 18,
-                "end": 19,
-                "text": "{"
-              },
-              {
                 "kind": "field_declaration",
                 "start": 24,
                 "end": 132,
@@ -54,14 +35,7 @@
                     "kind": "modifiers",
                     "start": 24,
                     "end": 30,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 24,
-                        "end": 30,
-                        "text": "static"
-                      }
-                    ]
+                    "text": "static"
                   },
                   {
                     "kind": "array_type",
@@ -78,20 +52,7 @@
                         "kind": "dimensions",
                         "start": 36,
                         "end": 38,
-                        "children": [
-                          {
-                            "kind": "[",
-                            "start": 36,
-                            "end": 37,
-                            "text": "["
-                          },
-                          {
-                            "kind": "]",
-                            "start": 37,
-                            "end": 38,
-                            "text": "]"
-                          }
-                        ]
+                        "text": "[]"
                       }
                     ]
                   },
@@ -107,22 +68,10 @@
                         "text": "customers"
                       },
                       {
-                        "kind": "=",
-                        "start": 49,
-                        "end": 50,
-                        "text": "="
-                      },
-                      {
                         "kind": "array_creation_expression",
                         "start": 51,
                         "end": 131,
                         "children": [
-                          {
-                            "kind": "new",
-                            "start": 51,
-                            "end": 54,
-                            "text": "new"
-                          },
                           {
                             "kind": "type_identifier",
                             "start": 55,
@@ -133,20 +82,7 @@
                             "kind": "dimensions",
                             "start": 60,
                             "end": 62,
-                            "children": [
-                              {
-                                "kind": "[",
-                                "start": 60,
-                                "end": 61,
-                                "text": "["
-                              },
-                              {
-                                "kind": "]",
-                                "start": 61,
-                                "end": 62,
-                                "text": "]"
-                              }
-                            ]
+                            "text": "[]"
                           },
                           {
                             "kind": "array_initializer",
@@ -154,22 +90,10 @@
                             "end": 131,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 62,
-                                "end": 63,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 63,
                                 "end": 84,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 63,
-                                    "end": 66,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 67,
@@ -182,22 +106,10 @@
                                     "end": 84,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 72,
-                                        "end": 73,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 73,
                                         "end": 74,
                                         "text": "1"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 74,
-                                        "end": 75,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -205,52 +117,22 @@
                                         "end": 83,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 76,
-                                            "end": 77,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_fragment",
                                             "start": 77,
                                             "end": 82,
                                             "text": "Alice"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 82,
-                                            "end": 83,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 83,
-                                        "end": 84,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 84,
-                                "end": 85,
-                                "text": ","
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 86,
                                 "end": 105,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 86,
-                                    "end": 89,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 90,
@@ -263,22 +145,10 @@
                                     "end": 105,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 95,
-                                        "end": 96,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 96,
                                         "end": 97,
                                         "text": "2"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 97,
-                                        "end": 98,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -286,52 +156,22 @@
                                         "end": 104,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 99,
-                                            "end": 100,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_fragment",
                                             "start": 100,
                                             "end": 103,
                                             "text": "Bob"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 103,
-                                            "end": 104,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 104,
-                                        "end": 105,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 105,
-                                "end": 106,
-                                "text": ","
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 107,
                                 "end": 130,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 107,
-                                    "end": 110,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 111,
@@ -344,22 +184,10 @@
                                     "end": 130,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 116,
-                                        "end": 117,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 117,
                                         "end": 118,
                                         "text": "3"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 118,
-                                        "end": 119,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "string_literal",
@@ -367,52 +195,22 @@
                                         "end": 129,
                                         "children": [
                                           {
-                                            "kind": "\"",
-                                            "start": 120,
-                                            "end": 121,
-                                            "text": "\""
-                                          },
-                                          {
                                             "kind": "string_fragment",
                                             "start": 121,
                                             "end": 128,
                                             "text": "Charlie"
-                                          },
-                                          {
-                                            "kind": "\"",
-                                            "start": 128,
-                                            "end": 129,
-                                            "text": "\""
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 129,
-                                        "end": 130,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 130,
-                                "end": 131,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 131,
-                    "end": 132,
-                    "text": ";"
                   }
                 ]
               },
@@ -425,20 +223,7 @@
                     "kind": "modifiers",
                     "start": 137,
                     "end": 143,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 137,
-                        "end": 143,
-                        "text": "static"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "class",
-                    "start": 144,
-                    "end": 149,
-                    "text": "class"
+                    "text": "static"
                   },
                   {
                     "kind": "identifier",
@@ -452,12 +237,6 @@
                     "end": 471,
                     "children": [
                       {
-                        "kind": "{",
-                        "start": 156,
-                        "end": 157,
-                        "text": "{"
-                      },
-                      {
                         "kind": "field_declaration",
                         "start": 166,
                         "end": 173,
@@ -466,14 +245,7 @@
                             "kind": "integral_type",
                             "start": 166,
                             "end": 169,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 166,
-                                "end": 169,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -487,12 +259,6 @@
                                 "text": "id"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 172,
-                            "end": 173,
-                            "text": ";"
                           }
                         ]
                       },
@@ -519,12 +285,6 @@
                                 "text": "name"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 193,
-                            "end": 194,
-                            "text": ";"
                           }
                         ]
                       },
@@ -545,12 +305,6 @@
                             "end": 229,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 208,
-                                "end": 209,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 209,
                                 "end": 215,
@@ -559,14 +313,7 @@
                                     "kind": "integral_type",
                                     "start": 209,
                                     "end": 212,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 209,
-                                        "end": 212,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -575,12 +322,6 @@
                                     "text": "id"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 215,
-                                "end": 216,
-                                "text": ","
                               },
                               {
                                 "kind": "formal_parameter",
@@ -600,12 +341,6 @@
                                     "text": "name"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 228,
-                                "end": 229,
-                                "text": ")"
                               }
                             ]
                           },
@@ -614,12 +349,6 @@
                             "start": 230,
                             "end": 297,
                             "children": [
-                              {
-                                "kind": "{",
-                                "start": 230,
-                                "end": 231,
-                                "text": "{"
-                              },
                               {
                                 "kind": "expression_statement",
                                 "start": 244,
@@ -642,12 +371,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 248,
-                                            "end": 249,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 249,
                                             "end": 251,
@@ -656,24 +379,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 252,
-                                        "end": 253,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 254,
                                         "end": 256,
                                         "text": "id"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 256,
-                                    "end": 257,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -699,12 +410,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 274,
-                                            "end": 275,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 275,
                                             "end": 279,
@@ -713,32 +418,14 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 280,
-                                        "end": 281,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 282,
                                         "end": 286,
                                         "text": "name"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 286,
-                                    "end": 287,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 296,
-                                "end": 297,
-                                "text": "}"
                               }
                             ]
                           }
@@ -767,12 +454,6 @@
                             "end": 335,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 325,
-                                "end": 326,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 326,
                                 "end": 334,
@@ -790,12 +471,6 @@
                                     "text": "k"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 334,
-                                "end": 335,
-                                "text": ")"
                               }
                             ]
                           },
@@ -805,33 +480,15 @@
                             "end": 465,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 336,
-                                "end": 337,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "if_statement",
                                 "start": 350,
                                 "end": 382,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 350,
-                                    "end": 352,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 353,
                                     "end": 369,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 353,
-                                        "end": 354,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 354,
@@ -842,12 +499,6 @@
                                             "start": 354,
                                             "end": 355,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 355,
-                                            "end": 356,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -861,51 +512,21 @@
                                             "end": 368,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 362,
-                                                "end": 363,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 363,
                                                 "end": 367,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 363,
-                                                    "end": 364,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 364,
                                                     "end": 366,
                                                     "text": "id"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 366,
-                                                    "end": 367,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 367,
-                                                "end": 368,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 368,
-                                        "end": 369,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -915,22 +536,10 @@
                                     "end": 382,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 370,
-                                        "end": 376,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 377,
                                         "end": 381,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 381,
-                                        "end": 382,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -942,22 +551,10 @@
                                 "end": 429,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 395,
-                                    "end": 397,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 398,
                                     "end": 416,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 398,
-                                        "end": 399,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 399,
@@ -968,12 +565,6 @@
                                             "start": 399,
                                             "end": 400,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 400,
-                                            "end": 401,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -987,51 +578,21 @@
                                             "end": 415,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 407,
-                                                "end": 408,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 408,
                                                 "end": 414,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 408,
-                                                    "end": 409,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 409,
                                                     "end": 413,
                                                     "text": "name"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 413,
-                                                    "end": 414,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 414,
-                                                "end": 415,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 415,
-                                        "end": 416,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -1041,22 +602,10 @@
                                     "end": 429,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 417,
-                                        "end": 423,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 424,
                                         "end": 428,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 428,
-                                        "end": 429,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -1068,40 +617,16 @@
                                 "end": 455,
                                 "children": [
                                   {
-                                    "kind": "return",
-                                    "start": 442,
-                                    "end": 448,
-                                    "text": "return"
-                                  },
-                                  {
                                     "kind": "false",
                                     "start": 449,
                                     "end": 454,
                                     "text": "false"
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 454,
-                                    "end": 455,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 464,
-                                "end": 465,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "}",
-                        "start": 470,
-                        "end": 471,
-                        "text": "}"
                       }
                     ]
                   }
@@ -1116,14 +641,7 @@
                     "kind": "modifiers",
                     "start": 477,
                     "end": 483,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 477,
-                        "end": 483,
-                        "text": "static"
-                      }
-                    ]
+                    "text": "static"
                   },
                   {
                     "kind": "array_type",
@@ -1140,20 +658,7 @@
                         "kind": "dimensions",
                         "start": 489,
                         "end": 491,
-                        "children": [
-                          {
-                            "kind": "[",
-                            "start": 489,
-                            "end": 490,
-                            "text": "["
-                          },
-                          {
-                            "kind": "]",
-                            "start": 490,
-                            "end": 491,
-                            "text": "]"
-                          }
-                        ]
+                        "text": "[]"
                       }
                     ]
                   },
@@ -1169,22 +674,10 @@
                         "text": "orders"
                       },
                       {
-                        "kind": "=",
-                        "start": 499,
-                        "end": 500,
-                        "text": "="
-                      },
-                      {
                         "kind": "array_creation_expression",
                         "start": 501,
                         "end": 584,
                         "children": [
-                          {
-                            "kind": "new",
-                            "start": 501,
-                            "end": 504,
-                            "text": "new"
-                          },
                           {
                             "kind": "type_identifier",
                             "start": 505,
@@ -1195,20 +688,7 @@
                             "kind": "dimensions",
                             "start": 510,
                             "end": 512,
-                            "children": [
-                              {
-                                "kind": "[",
-                                "start": 510,
-                                "end": 511,
-                                "text": "["
-                              },
-                              {
-                                "kind": "]",
-                                "start": 511,
-                                "end": 512,
-                                "text": "]"
-                              }
-                            ]
+                            "text": "[]"
                           },
                           {
                             "kind": "array_initializer",
@@ -1216,22 +696,10 @@
                             "end": 584,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 512,
-                                "end": 513,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 513,
                                 "end": 535,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 513,
-                                    "end": 516,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 517,
@@ -1244,22 +712,10 @@
                                     "end": 535,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 522,
-                                        "end": 523,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 523,
                                         "end": 526,
                                         "text": "100"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 526,
-                                        "end": 527,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
@@ -1268,44 +724,20 @@
                                         "text": "1"
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 529,
-                                        "end": 530,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 531,
                                         "end": 534,
                                         "text": "250"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 534,
-                                        "end": 535,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 535,
-                                "end": 536,
-                                "text": ","
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 537,
                                 "end": 559,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 537,
-                                    "end": 540,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 541,
@@ -1318,22 +750,10 @@
                                     "end": 559,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 546,
-                                        "end": 547,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 547,
                                         "end": 550,
                                         "text": "101"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 550,
-                                        "end": 551,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
@@ -1342,44 +762,20 @@
                                         "text": "2"
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 553,
-                                        "end": 554,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 555,
                                         "end": 558,
                                         "text": "125"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 558,
-                                        "end": 559,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 559,
-                                "end": 560,
-                                "text": ","
-                              },
-                              {
                                 "kind": "object_creation_expression",
                                 "start": 561,
                                 "end": 583,
                                 "children": [
-                                  {
-                                    "kind": "new",
-                                    "start": 561,
-                                    "end": 564,
-                                    "text": "new"
-                                  },
                                   {
                                     "kind": "type_identifier",
                                     "start": 565,
@@ -1392,22 +788,10 @@
                                     "end": 583,
                                     "children": [
                                       {
-                                        "kind": "(",
-                                        "start": 570,
-                                        "end": 571,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 571,
                                         "end": 574,
                                         "text": "102"
-                                      },
-                                      {
-                                        "kind": ",",
-                                        "start": 574,
-                                        "end": 575,
-                                        "text": ","
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
@@ -1416,44 +800,20 @@
                                         "text": "1"
                                       },
                                       {
-                                        "kind": ",",
-                                        "start": 577,
-                                        "end": 578,
-                                        "text": ","
-                                      },
-                                      {
                                         "kind": "decimal_integer_literal",
                                         "start": 579,
                                         "end": 582,
                                         "text": "300"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 582,
-                                        "end": 583,
-                                        "text": ")"
                                       }
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 583,
-                                "end": 584,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 584,
-                    "end": 585,
-                    "text": ";"
                   }
                 ]
               },
@@ -1466,20 +826,7 @@
                     "kind": "modifiers",
                     "start": 590,
                     "end": 596,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 590,
-                        "end": 596,
-                        "text": "static"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "class",
-                    "start": 597,
-                    "end": 602,
-                    "text": "class"
+                    "text": "static"
                   },
                   {
                     "kind": "identifier",
@@ -1493,12 +840,6 @@
                     "end": 1058,
                     "children": [
                       {
-                        "kind": "{",
-                        "start": 609,
-                        "end": 610,
-                        "text": "{"
-                      },
-                      {
                         "kind": "field_declaration",
                         "start": 619,
                         "end": 626,
@@ -1507,14 +848,7 @@
                             "kind": "integral_type",
                             "start": 619,
                             "end": 622,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 619,
-                                "end": 622,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -1528,12 +862,6 @@
                                 "text": "id"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 625,
-                            "end": 626,
-                            "text": ";"
                           }
                         ]
                       },
@@ -1546,14 +874,7 @@
                             "kind": "integral_type",
                             "start": 635,
                             "end": 638,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 635,
-                                "end": 638,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -1567,12 +888,6 @@
                                 "text": "customerId"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 649,
-                            "end": 650,
-                            "text": ";"
                           }
                         ]
                       },
@@ -1585,14 +900,7 @@
                             "kind": "integral_type",
                             "start": 659,
                             "end": 662,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 659,
-                                "end": 662,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -1606,12 +914,6 @@
                                 "text": "total"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 668,
-                            "end": 669,
-                            "text": ";"
                           }
                         ]
                       },
@@ -1632,12 +934,6 @@
                             "end": 718,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 683,
-                                "end": 684,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 684,
                                 "end": 690,
@@ -1646,14 +942,7 @@
                                     "kind": "integral_type",
                                     "start": 684,
                                     "end": 687,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 684,
-                                        "end": 687,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -1664,12 +953,6 @@
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 690,
-                                "end": 691,
-                                "text": ","
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 692,
                                 "end": 706,
@@ -1678,14 +961,7 @@
                                     "kind": "integral_type",
                                     "start": 692,
                                     "end": 695,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 692,
-                                        "end": 695,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -1696,12 +972,6 @@
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 706,
-                                "end": 707,
-                                "text": ","
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 708,
                                 "end": 717,
@@ -1710,14 +980,7 @@
                                     "kind": "integral_type",
                                     "start": 708,
                                     "end": 711,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 708,
-                                        "end": 711,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -1726,12 +989,6 @@
                                     "text": "total"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 717,
-                                "end": 718,
-                                "text": ")"
                               }
                             ]
                           },
@@ -1740,12 +997,6 @@
                             "start": 719,
                             "end": 830,
                             "children": [
-                              {
-                                "kind": "{",
-                                "start": 719,
-                                "end": 720,
-                                "text": "{"
-                              },
                               {
                                 "kind": "expression_statement",
                                 "start": 733,
@@ -1768,12 +1019,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 737,
-                                            "end": 738,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 738,
                                             "end": 740,
@@ -1782,24 +1027,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 741,
-                                        "end": 742,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 743,
                                         "end": 745,
                                         "text": "id"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 745,
-                                    "end": 746,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -1825,12 +1058,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 763,
-                                            "end": 764,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 764,
                                             "end": 774,
@@ -1839,24 +1066,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 775,
-                                        "end": 776,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 777,
                                         "end": 787,
                                         "text": "customerId"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 787,
-                                    "end": 788,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -1882,12 +1097,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 805,
-                                            "end": 806,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 806,
                                             "end": 811,
@@ -1896,32 +1105,14 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 812,
-                                        "end": 813,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 814,
                                         "end": 819,
                                         "text": "total"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 819,
-                                    "end": 820,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 829,
-                                "end": 830,
-                                "text": "}"
                               }
                             ]
                           }
@@ -1950,12 +1141,6 @@
                             "end": 868,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 858,
-                                "end": 859,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 859,
                                 "end": 867,
@@ -1973,12 +1158,6 @@
                                     "text": "k"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 867,
-                                "end": 868,
-                                "text": ")"
                               }
                             ]
                           },
@@ -1988,33 +1167,15 @@
                             "end": 1052,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 869,
-                                "end": 870,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "if_statement",
                                 "start": 883,
                                 "end": 915,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 883,
-                                    "end": 885,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 886,
                                     "end": 902,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 886,
-                                        "end": 887,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 887,
@@ -2025,12 +1186,6 @@
                                             "start": 887,
                                             "end": 888,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 888,
-                                            "end": 889,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -2044,51 +1199,21 @@
                                             "end": 901,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 895,
-                                                "end": 896,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 896,
                                                 "end": 900,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 896,
-                                                    "end": 897,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 897,
                                                     "end": 899,
                                                     "text": "id"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 899,
-                                                    "end": 900,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 900,
-                                                "end": 901,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 901,
-                                        "end": 902,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -2098,22 +1223,10 @@
                                     "end": 915,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 903,
-                                        "end": 909,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 910,
                                         "end": 914,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 914,
-                                        "end": 915,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -2125,22 +1238,10 @@
                                 "end": 968,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 928,
-                                    "end": 930,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 931,
                                     "end": 955,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 931,
-                                        "end": 932,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 932,
@@ -2151,12 +1252,6 @@
                                             "start": 932,
                                             "end": 933,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 933,
-                                            "end": 934,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -2170,51 +1265,21 @@
                                             "end": 954,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 940,
-                                                "end": 941,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 941,
                                                 "end": 953,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 941,
-                                                    "end": 942,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 942,
                                                     "end": 952,
                                                     "text": "customerId"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 952,
-                                                    "end": 953,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 953,
-                                                "end": 954,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 954,
-                                        "end": 955,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -2224,22 +1289,10 @@
                                     "end": 968,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 956,
-                                        "end": 962,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 963,
                                         "end": 967,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 967,
-                                        "end": 968,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -2251,22 +1304,10 @@
                                 "end": 1016,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 981,
-                                    "end": 983,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 984,
                                     "end": 1003,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 984,
-                                        "end": 985,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 985,
@@ -2277,12 +1318,6 @@
                                             "start": 985,
                                             "end": 986,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 986,
-                                            "end": 987,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -2296,51 +1331,21 @@
                                             "end": 1002,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 993,
-                                                "end": 994,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 994,
                                                 "end": 1001,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 994,
-                                                    "end": 995,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 995,
                                                     "end": 1000,
                                                     "text": "total"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 1000,
-                                                    "end": 1001,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 1001,
-                                                "end": 1002,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 1002,
-                                        "end": 1003,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -2350,22 +1355,10 @@
                                     "end": 1016,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 1004,
-                                        "end": 1010,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 1011,
                                         "end": 1015,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1015,
-                                        "end": 1016,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -2377,40 +1370,16 @@
                                 "end": 1042,
                                 "children": [
                                   {
-                                    "kind": "return",
-                                    "start": 1029,
-                                    "end": 1035,
-                                    "text": "return"
-                                  },
-                                  {
                                     "kind": "false",
                                     "start": 1036,
                                     "end": 1041,
                                     "text": "false"
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 1041,
-                                    "end": 1042,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 1051,
-                                "end": 1052,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "}",
-                        "start": 1057,
-                        "end": 1058,
-                        "text": "}"
                       }
                     ]
                   }
@@ -2425,14 +1394,7 @@
                     "kind": "modifiers",
                     "start": 1064,
                     "end": 1070,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 1064,
-                        "end": 1070,
-                        "text": "static"
-                      }
-                    ]
+                    "text": "static"
                   },
                   {
                     "kind": "generic_type",
@@ -2456,24 +1418,12 @@
                                 "text": "java"
                               },
                               {
-                                "kind": ".",
-                                "start": 1075,
-                                "end": 1076,
-                                "text": "."
-                              },
-                              {
                                 "kind": "type_identifier",
                                 "start": 1076,
                                 "end": 1080,
                                 "text": "util"
                               }
                             ]
-                          },
-                          {
-                            "kind": ".",
-                            "start": 1080,
-                            "end": 1081,
-                            "text": "."
                           },
                           {
                             "kind": "type_identifier",
@@ -2489,22 +1439,10 @@
                         "end": 1094,
                         "children": [
                           {
-                            "kind": "\u003c",
-                            "start": 1085,
-                            "end": 1086,
-                            "text": "\u003c"
-                          },
-                          {
                             "kind": "type_identifier",
                             "start": 1086,
                             "end": 1093,
                             "text": "Result4"
-                          },
-                          {
-                            "kind": "\u003e",
-                            "start": 1093,
-                            "end": 1094,
-                            "text": "\u003e"
                           }
                         ]
                       }
@@ -2522,22 +1460,10 @@
                         "text": "result"
                       },
                       {
-                        "kind": "=",
-                        "start": 1102,
-                        "end": 1103,
-                        "text": "="
-                      },
-                      {
                         "kind": "object_creation_expression",
                         "start": 1104,
                         "end": 1609,
                         "children": [
-                          {
-                            "kind": "new",
-                            "start": 1104,
-                            "end": 1107,
-                            "text": "new"
-                          },
                           {
                             "kind": "generic_type",
                             "start": 1108,
@@ -2560,24 +1486,12 @@
                                         "text": "java"
                                       },
                                       {
-                                        "kind": ".",
-                                        "start": 1112,
-                                        "end": 1113,
-                                        "text": "."
-                                      },
-                                      {
                                         "kind": "type_identifier",
                                         "start": 1113,
                                         "end": 1117,
                                         "text": "util"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ".",
-                                    "start": 1117,
-                                    "end": 1118,
-                                    "text": "."
                                   },
                                   {
                                     "kind": "type_identifier",
@@ -2593,22 +1507,10 @@
                                 "end": 1136,
                                 "children": [
                                   {
-                                    "kind": "\u003c",
-                                    "start": 1127,
-                                    "end": 1128,
-                                    "text": "\u003c"
-                                  },
-                                  {
                                     "kind": "type_identifier",
                                     "start": 1128,
                                     "end": 1135,
                                     "text": "Result4"
-                                  },
-                                  {
-                                    "kind": "\u003e",
-                                    "start": 1135,
-                                    "end": 1136,
-                                    "text": "\u003e"
                                   }
                                 ]
                               }
@@ -2618,20 +1520,7 @@
                             "kind": "argument_list",
                             "start": 1136,
                             "end": 1138,
-                            "children": [
-                              {
-                                "kind": "(",
-                                "start": 1136,
-                                "end": 1137,
-                                "text": "("
-                              },
-                              {
-                                "kind": ")",
-                                "start": 1137,
-                                "end": 1138,
-                                "text": ")"
-                              }
-                            ]
+                            "text": "()"
                           },
                           {
                             "kind": "class_body",
@@ -2639,22 +1528,10 @@
                             "end": 1609,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 1139,
-                                "end": 1140,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "block",
                                 "start": 1140,
                                 "end": 1608,
                                 "children": [
-                                  {
-                                    "kind": "{",
-                                    "start": 1140,
-                                    "end": 1141,
-                                    "text": "{"
-                                  },
                                   {
                                     "kind": "local_variable_declaration",
                                     "start": 1142,
@@ -2682,24 +1559,12 @@
                                                     "text": "java"
                                                   },
                                                   {
-                                                    "kind": ".",
-                                                    "start": 1146,
-                                                    "end": 1147,
-                                                    "text": "."
-                                                  },
-                                                  {
                                                     "kind": "type_identifier",
                                                     "start": 1147,
                                                     "end": 1151,
                                                     "text": "util"
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ".",
-                                                "start": 1151,
-                                                "end": 1152,
-                                                "text": "."
                                               },
                                               {
                                                 "kind": "type_identifier",
@@ -2715,22 +1580,10 @@
                                             "end": 1170,
                                             "children": [
                                               {
-                                                "kind": "\u003c",
-                                                "start": 1161,
-                                                "end": 1162,
-                                                "text": "\u003c"
-                                              },
-                                              {
                                                 "kind": "type_identifier",
                                                 "start": 1162,
                                                 "end": 1169,
                                                 "text": "Result4"
-                                              },
-                                              {
-                                                "kind": "\u003e",
-                                                "start": 1169,
-                                                "end": 1170,
-                                                "text": "\u003e"
                                               }
                                             ]
                                           }
@@ -2748,22 +1601,10 @@
                                             "text": "_tmp"
                                           },
                                           {
-                                            "kind": "=",
-                                            "start": 1176,
-                                            "end": 1177,
-                                            "text": "="
-                                          },
-                                          {
                                             "kind": "object_creation_expression",
                                             "start": 1178,
                                             "end": 1205,
                                             "children": [
-                                              {
-                                                "kind": "new",
-                                                "start": 1178,
-                                                "end": 1181,
-                                                "text": "new"
-                                              },
                                               {
                                                 "kind": "generic_type",
                                                 "start": 1182,
@@ -2786,24 +1627,12 @@
                                                             "text": "java"
                                                           },
                                                           {
-                                                            "kind": ".",
-                                                            "start": 1186,
-                                                            "end": 1187,
-                                                            "text": "."
-                                                          },
-                                                          {
                                                             "kind": "type_identifier",
                                                             "start": 1187,
                                                             "end": 1191,
                                                             "text": "util"
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "kind": ".",
-                                                        "start": 1191,
-                                                        "end": 1192,
-                                                        "text": "."
                                                       },
                                                       {
                                                         "kind": "type_identifier",
@@ -2817,20 +1646,7 @@
                                                     "kind": "type_arguments",
                                                     "start": 1201,
                                                     "end": 1203,
-                                                    "children": [
-                                                      {
-                                                        "kind": "\u003c",
-                                                        "start": 1201,
-                                                        "end": 1202,
-                                                        "text": "\u003c"
-                                                      },
-                                                      {
-                                                        "kind": "\u003e",
-                                                        "start": 1202,
-                                                        "end": 1203,
-                                                        "text": "\u003e"
-                                                      }
-                                                    ]
+                                                    "text": "\u003c\u003e"
                                                   }
                                                 ]
                                               },
@@ -2838,30 +1654,11 @@
                                                 "kind": "argument_list",
                                                 "start": 1203,
                                                 "end": 1205,
-                                                "children": [
-                                                  {
-                                                    "kind": "(",
-                                                    "start": 1203,
-                                                    "end": 1204,
-                                                    "text": "("
-                                                  },
-                                                  {
-                                                    "kind": ")",
-                                                    "start": 1204,
-                                                    "end": 1205,
-                                                    "text": ")"
-                                                  }
-                                                ]
+                                                "text": "()"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1205,
-                                        "end": 1206,
-                                        "text": ";"
                                       }
                                     ]
                                   },
@@ -2870,18 +1667,6 @@
                                     "start": 1207,
                                     "end": 1382,
                                     "children": [
-                                      {
-                                        "kind": "for",
-                                        "start": 1207,
-                                        "end": 1210,
-                                        "text": "for"
-                                      },
-                                      {
-                                        "kind": "(",
-                                        "start": 1211,
-                                        "end": 1212,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "type_identifier",
                                         "start": 1212,
@@ -2895,22 +1680,10 @@
                                         "text": "o"
                                       },
                                       {
-                                        "kind": ":",
-                                        "start": 1218,
-                                        "end": 1219,
-                                        "text": ":"
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 1220,
                                         "end": 1226,
                                         "text": "orders"
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 1226,
-                                        "end": 1227,
-                                        "text": ")"
                                       },
                                       {
                                         "kind": "block",
@@ -2918,28 +1691,10 @@
                                         "end": 1382,
                                         "children": [
                                           {
-                                            "kind": "{",
-                                            "start": 1228,
-                                            "end": 1229,
-                                            "text": "{"
-                                          },
-                                          {
                                             "kind": "enhanced_for_statement",
                                             "start": 1230,
                                             "end": 1380,
                                             "children": [
-                                              {
-                                                "kind": "for",
-                                                "start": 1230,
-                                                "end": 1233,
-                                                "text": "for"
-                                              },
-                                              {
-                                                "kind": "(",
-                                                "start": 1234,
-                                                "end": 1235,
-                                                "text": "("
-                                              },
                                               {
                                                 "kind": "type_identifier",
                                                 "start": 1235,
@@ -2953,34 +1708,16 @@
                                                 "text": "c"
                                               },
                                               {
-                                                "kind": ":",
-                                                "start": 1241,
-                                                "end": 1242,
-                                                "text": ":"
-                                              },
-                                              {
                                                 "kind": "identifier",
                                                 "start": 1243,
                                                 "end": 1252,
                                                 "text": "customers"
                                               },
                                               {
-                                                "kind": ")",
-                                                "start": 1252,
-                                                "end": 1253,
-                                                "text": ")"
-                                              },
-                                              {
                                                 "kind": "block",
                                                 "start": 1254,
                                                 "end": 1380,
                                                 "children": [
-                                                  {
-                                                    "kind": "{",
-                                                    "start": 1254,
-                                                    "end": 1255,
-                                                    "text": "{"
-                                                  },
                                                   {
                                                     "kind": "expression_statement",
                                                     "start": 1256,
@@ -2998,12 +1735,6 @@
                                                             "text": "_tmp"
                                                           },
                                                           {
-                                                            "kind": ".",
-                                                            "start": 1260,
-                                                            "end": 1261,
-                                                            "text": "."
-                                                          },
-                                                          {
                                                             "kind": "identifier",
                                                             "start": 1261,
                                                             "end": 1264,
@@ -3015,22 +1746,10 @@
                                                             "end": 1377,
                                                             "children": [
                                                               {
-                                                                "kind": "(",
-                                                                "start": 1264,
-                                                                "end": 1265,
-                                                                "text": "("
-                                                              },
-                                                              {
                                                                 "kind": "object_creation_expression",
                                                                 "start": 1265,
                                                                 "end": 1376,
                                                                 "children": [
-                                                                  {
-                                                                    "kind": "new",
-                                                                    "start": 1265,
-                                                                    "end": 1268,
-                                                                    "text": "new"
-                                                                  },
                                                                   {
                                                                     "kind": "type_identifier",
                                                                     "start": 1269,
@@ -3043,33 +1762,15 @@
                                                                     "end": 1376,
                                                                     "children": [
                                                                       {
-                                                                        "kind": "(",
-                                                                        "start": 1276,
-                                                                        "end": 1277,
-                                                                        "text": "("
-                                                                      },
-                                                                      {
                                                                         "kind": "parenthesized_expression",
                                                                         "start": 1277,
                                                                         "end": 1302,
                                                                         "children": [
                                                                           {
-                                                                            "kind": "(",
-                                                                            "start": 1277,
-                                                                            "end": 1278,
-                                                                            "text": "("
-                                                                          },
-                                                                          {
                                                                             "kind": "cast_expression",
                                                                             "start": 1278,
                                                                             "end": 1301,
                                                                             "children": [
-                                                                              {
-                                                                                "kind": "(",
-                                                                                "start": 1278,
-                                                                                "end": 1279,
-                                                                                "text": "("
-                                                                              },
                                                                               {
                                                                                 "kind": "type_identifier",
                                                                                 "start": 1279,
@@ -3077,22 +1778,10 @@
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
-                                                                                "kind": ")",
-                                                                                "start": 1286,
-                                                                                "end": 1287,
-                                                                                "text": ")"
-                                                                              },
-                                                                              {
                                                                                 "kind": "parenthesized_expression",
                                                                                 "start": 1288,
                                                                                 "end": 1301,
                                                                                 "children": [
-                                                                                  {
-                                                                                    "kind": "(",
-                                                                                    "start": 1288,
-                                                                                    "end": 1289,
-                                                                                    "text": "("
-                                                                                  },
                                                                                   {
                                                                                     "kind": "method_invocation",
                                                                                     "start": 1289,
@@ -3103,12 +1792,6 @@
                                                                                         "start": 1289,
                                                                                         "end": 1290,
                                                                                         "text": "o"
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": ".",
-                                                                                        "start": 1290,
-                                                                                        "end": 1291,
-                                                                                        "text": "."
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
@@ -3122,69 +1805,27 @@
                                                                                         "end": 1300,
                                                                                         "children": [
                                                                                           {
-                                                                                            "kind": "(",
-                                                                                            "start": 1294,
-                                                                                            "end": 1295,
-                                                                                            "text": "("
-                                                                                          },
-                                                                                          {
                                                                                             "kind": "string_literal",
                                                                                             "start": 1295,
                                                                                             "end": 1299,
                                                                                             "children": [
                                                                                               {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1295,
-                                                                                                "end": 1296,
-                                                                                                "text": "\""
-                                                                                              },
-                                                                                              {
                                                                                                 "kind": "string_fragment",
                                                                                                 "start": 1296,
                                                                                                 "end": 1298,
                                                                                                 "text": "id"
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1298,
-                                                                                                "end": 1299,
-                                                                                                "text": "\""
                                                                                               }
                                                                                             ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": ")",
-                                                                                            "start": 1299,
-                                                                                            "end": 1300,
-                                                                                            "text": ")"
                                                                                           }
                                                                                         ]
                                                                                       }
                                                                                     ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": ")",
-                                                                                    "start": 1300,
-                                                                                    "end": 1301,
-                                                                                    "text": ")"
                                                                                   }
                                                                                 ]
                                                                               }
                                                                             ]
-                                                                          },
-                                                                          {
-                                                                            "kind": ")",
-                                                                            "start": 1301,
-                                                                            "end": 1302,
-                                                                            "text": ")"
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "kind": ",",
-                                                                        "start": 1302,
-                                                                        "end": 1303,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "kind": "parenthesized_expression",
@@ -3192,22 +1833,10 @@
                                                                         "end": 1337,
                                                                         "children": [
                                                                           {
-                                                                            "kind": "(",
-                                                                            "start": 1304,
-                                                                            "end": 1305,
-                                                                            "text": "("
-                                                                          },
-                                                                          {
                                                                             "kind": "cast_expression",
                                                                             "start": 1305,
                                                                             "end": 1336,
                                                                             "children": [
-                                                                              {
-                                                                                "kind": "(",
-                                                                                "start": 1305,
-                                                                                "end": 1306,
-                                                                                "text": "("
-                                                                              },
                                                                               {
                                                                                 "kind": "type_identifier",
                                                                                 "start": 1306,
@@ -3215,22 +1844,10 @@
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
-                                                                                "kind": ")",
-                                                                                "start": 1313,
-                                                                                "end": 1314,
-                                                                                "text": ")"
-                                                                              },
-                                                                              {
                                                                                 "kind": "parenthesized_expression",
                                                                                 "start": 1315,
                                                                                 "end": 1336,
                                                                                 "children": [
-                                                                                  {
-                                                                                    "kind": "(",
-                                                                                    "start": 1315,
-                                                                                    "end": 1316,
-                                                                                    "text": "("
-                                                                                  },
                                                                                   {
                                                                                     "kind": "method_invocation",
                                                                                     "start": 1316,
@@ -3241,12 +1858,6 @@
                                                                                         "start": 1316,
                                                                                         "end": 1317,
                                                                                         "text": "o"
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": ".",
-                                                                                        "start": 1317,
-                                                                                        "end": 1318,
-                                                                                        "text": "."
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
@@ -3260,69 +1871,27 @@
                                                                                         "end": 1335,
                                                                                         "children": [
                                                                                           {
-                                                                                            "kind": "(",
-                                                                                            "start": 1321,
-                                                                                            "end": 1322,
-                                                                                            "text": "("
-                                                                                          },
-                                                                                          {
                                                                                             "kind": "string_literal",
                                                                                             "start": 1322,
                                                                                             "end": 1334,
                                                                                             "children": [
                                                                                               {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1322,
-                                                                                                "end": 1323,
-                                                                                                "text": "\""
-                                                                                              },
-                                                                                              {
                                                                                                 "kind": "string_fragment",
                                                                                                 "start": 1323,
                                                                                                 "end": 1333,
                                                                                                 "text": "customerId"
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1333,
-                                                                                                "end": 1334,
-                                                                                                "text": "\""
                                                                                               }
                                                                                             ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": ")",
-                                                                                            "start": 1334,
-                                                                                            "end": 1335,
-                                                                                            "text": ")"
                                                                                           }
                                                                                         ]
                                                                                       }
                                                                                     ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": ")",
-                                                                                    "start": 1335,
-                                                                                    "end": 1336,
-                                                                                    "text": ")"
                                                                                   }
                                                                                 ]
                                                                               }
                                                                             ]
-                                                                          },
-                                                                          {
-                                                                            "kind": ")",
-                                                                            "start": 1336,
-                                                                            "end": 1337,
-                                                                            "text": ")"
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "kind": ",",
-                                                                        "start": 1337,
-                                                                        "end": 1338,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "kind": "field_access",
@@ -3336,12 +1905,6 @@
                                                                             "text": "c"
                                                                           },
                                                                           {
-                                                                            "kind": ".",
-                                                                            "start": 1340,
-                                                                            "end": 1341,
-                                                                            "text": "."
-                                                                          },
-                                                                          {
                                                                             "kind": "identifier",
                                                                             "start": 1341,
                                                                             "end": 1345,
@@ -3350,33 +1913,15 @@
                                                                         ]
                                                                       },
                                                                       {
-                                                                        "kind": ",",
-                                                                        "start": 1345,
-                                                                        "end": 1346,
-                                                                        "text": ","
-                                                                      },
-                                                                      {
                                                                         "kind": "parenthesized_expression",
                                                                         "start": 1347,
                                                                         "end": 1375,
                                                                         "children": [
                                                                           {
-                                                                            "kind": "(",
-                                                                            "start": 1347,
-                                                                            "end": 1348,
-                                                                            "text": "("
-                                                                          },
-                                                                          {
                                                                             "kind": "cast_expression",
                                                                             "start": 1348,
                                                                             "end": 1374,
                                                                             "children": [
-                                                                              {
-                                                                                "kind": "(",
-                                                                                "start": 1348,
-                                                                                "end": 1349,
-                                                                                "text": "("
-                                                                              },
                                                                               {
                                                                                 "kind": "type_identifier",
                                                                                 "start": 1349,
@@ -3384,22 +1929,10 @@
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
-                                                                                "kind": ")",
-                                                                                "start": 1356,
-                                                                                "end": 1357,
-                                                                                "text": ")"
-                                                                              },
-                                                                              {
                                                                                 "kind": "parenthesized_expression",
                                                                                 "start": 1358,
                                                                                 "end": 1374,
                                                                                 "children": [
-                                                                                  {
-                                                                                    "kind": "(",
-                                                                                    "start": 1358,
-                                                                                    "end": 1359,
-                                                                                    "text": "("
-                                                                                  },
                                                                                   {
                                                                                     "kind": "method_invocation",
                                                                                     "start": 1359,
@@ -3410,12 +1943,6 @@
                                                                                         "start": 1359,
                                                                                         "end": 1360,
                                                                                         "text": "o"
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": ".",
-                                                                                        "start": 1360,
-                                                                                        "end": 1361,
-                                                                                        "text": "."
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
@@ -3429,107 +1956,41 @@
                                                                                         "end": 1373,
                                                                                         "children": [
                                                                                           {
-                                                                                            "kind": "(",
-                                                                                            "start": 1364,
-                                                                                            "end": 1365,
-                                                                                            "text": "("
-                                                                                          },
-                                                                                          {
                                                                                             "kind": "string_literal",
                                                                                             "start": 1365,
                                                                                             "end": 1372,
                                                                                             "children": [
                                                                                               {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1365,
-                                                                                                "end": 1366,
-                                                                                                "text": "\""
-                                                                                              },
-                                                                                              {
                                                                                                 "kind": "string_fragment",
                                                                                                 "start": 1366,
                                                                                                 "end": 1371,
                                                                                                 "text": "total"
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "\"",
-                                                                                                "start": 1371,
-                                                                                                "end": 1372,
-                                                                                                "text": "\""
                                                                                               }
                                                                                             ]
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": ")",
-                                                                                            "start": 1372,
-                                                                                            "end": 1373,
-                                                                                            "text": ")"
                                                                                           }
                                                                                         ]
                                                                                       }
                                                                                     ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": ")",
-                                                                                    "start": 1373,
-                                                                                    "end": 1374,
-                                                                                    "text": ")"
                                                                                   }
                                                                                 ]
                                                                               }
                                                                             ]
-                                                                          },
-                                                                          {
-                                                                            "kind": ")",
-                                                                            "start": 1374,
-                                                                            "end": 1375,
-                                                                            "text": ")"
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "kind": ")",
-                                                                        "start": 1375,
-                                                                        "end": 1376,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
                                                                 ]
-                                                              },
-                                                              {
-                                                                "kind": ")",
-                                                                "start": 1376,
-                                                                "end": 1377,
-                                                                "text": ")"
                                                               }
                                                             ]
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "kind": ";",
-                                                        "start": 1377,
-                                                        "end": 1378,
-                                                        "text": ";"
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": "}",
-                                                    "start": 1379,
-                                                    "end": 1380,
-                                                    "text": "}"
                                                   }
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "kind": "}",
-                                            "start": 1381,
-                                            "end": 1382,
-                                            "text": "}"
                                           }
                                         ]
                                       }
@@ -3562,24 +2023,12 @@
                                                     "text": "java"
                                                   },
                                                   {
-                                                    "kind": ".",
-                                                    "start": 1387,
-                                                    "end": 1388,
-                                                    "text": "."
-                                                  },
-                                                  {
                                                     "kind": "type_identifier",
                                                     "start": 1388,
                                                     "end": 1392,
                                                     "text": "util"
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ".",
-                                                "start": 1392,
-                                                "end": 1393,
-                                                "text": "."
                                               },
                                               {
                                                 "kind": "type_identifier",
@@ -3595,22 +2044,10 @@
                                             "end": 1411,
                                             "children": [
                                               {
-                                                "kind": "\u003c",
-                                                "start": 1402,
-                                                "end": 1403,
-                                                "text": "\u003c"
-                                              },
-                                              {
                                                 "kind": "type_identifier",
                                                 "start": 1403,
                                                 "end": 1410,
                                                 "text": "Result4"
-                                              },
-                                              {
-                                                "kind": "\u003e",
-                                                "start": 1410,
-                                                "end": 1411,
-                                                "text": "\u003e"
                                               }
                                             ]
                                           }
@@ -3628,24 +2065,12 @@
                                             "text": "list"
                                           },
                                           {
-                                            "kind": "=",
-                                            "start": 1417,
-                                            "end": 1418,
-                                            "text": "="
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 1419,
                                             "end": 1423,
                                             "text": "_tmp"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1423,
-                                        "end": 1424,
-                                        "text": ";"
                                       }
                                     ]
                                   },
@@ -3658,14 +2083,7 @@
                                         "kind": "integral_type",
                                         "start": 1425,
                                         "end": 1428,
-                                        "children": [
-                                          {
-                                            "kind": "int",
-                                            "start": 1425,
-                                            "end": 1428,
-                                            "text": "int"
-                                          }
-                                        ]
+                                        "text": "int"
                                       },
                                       {
                                         "kind": "variable_declarator",
@@ -3679,24 +2097,12 @@
                                             "text": "skip"
                                           },
                                           {
-                                            "kind": "=",
-                                            "start": 1434,
-                                            "end": 1435,
-                                            "text": "="
-                                          },
-                                          {
                                             "kind": "decimal_integer_literal",
                                             "start": 1436,
                                             "end": 1437,
                                             "text": "0"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1437,
-                                        "end": 1438,
-                                        "text": ";"
                                       }
                                     ]
                                   },
@@ -3709,14 +2115,7 @@
                                         "kind": "integral_type",
                                         "start": 1439,
                                         "end": 1442,
-                                        "children": [
-                                          {
-                                            "kind": "int",
-                                            "start": 1439,
-                                            "end": 1442,
-                                            "text": "int"
-                                          }
-                                        ]
+                                        "text": "int"
                                       },
                                       {
                                         "kind": "variable_declarator",
@@ -3730,22 +2129,10 @@
                                             "text": "take"
                                           },
                                           {
-                                            "kind": "=",
-                                            "start": 1448,
-                                            "end": 1449,
-                                            "text": "="
-                                          },
-                                          {
                                             "kind": "unary_expression",
                                             "start": 1450,
                                             "end": 1452,
                                             "children": [
-                                              {
-                                                "kind": "-",
-                                                "start": 1450,
-                                                "end": 1451,
-                                                "text": "-"
-                                              },
                                               {
                                                 "kind": "decimal_integer_literal",
                                                 "start": 1451,
@@ -3755,12 +2142,6 @@
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1452,
-                                        "end": 1453,
-                                        "text": ";"
                                       }
                                     ]
                                   },
@@ -3770,18 +2151,6 @@
                                     "end": 1593,
                                     "children": [
                                       {
-                                        "kind": "for",
-                                        "start": 1454,
-                                        "end": 1457,
-                                        "text": "for"
-                                      },
-                                      {
-                                        "kind": "(",
-                                        "start": 1458,
-                                        "end": 1459,
-                                        "text": "("
-                                      },
-                                      {
                                         "kind": "local_variable_declaration",
                                         "start": 1459,
                                         "end": 1469,
@@ -3790,14 +2159,7 @@
                                             "kind": "integral_type",
                                             "start": 1459,
                                             "end": 1462,
-                                            "children": [
-                                              {
-                                                "kind": "int",
-                                                "start": 1459,
-                                                "end": 1462,
-                                                "text": "int"
-                                              }
-                                            ]
+                                            "text": "int"
                                           },
                                           {
                                             "kind": "variable_declarator",
@@ -3811,24 +2173,12 @@
                                                 "text": "i"
                                               },
                                               {
-                                                "kind": "=",
-                                                "start": 1465,
-                                                "end": 1466,
-                                                "text": "="
-                                              },
-                                              {
                                                 "kind": "decimal_integer_literal",
                                                 "start": 1467,
                                                 "end": 1468,
                                                 "text": "0"
                                               }
                                             ]
-                                          },
-                                          {
-                                            "kind": ";",
-                                            "start": 1468,
-                                            "end": 1469,
-                                            "text": ";"
                                           }
                                         ]
                                       },
@@ -3844,12 +2194,6 @@
                                             "text": "i"
                                           },
                                           {
-                                            "kind": "\u003c",
-                                            "start": 1472,
-                                            "end": 1473,
-                                            "text": "\u003c"
-                                          },
-                                          {
                                             "kind": "method_invocation",
                                             "start": 1474,
                                             "end": 1485,
@@ -3861,12 +2205,6 @@
                                                 "text": "list"
                                               },
                                               {
-                                                "kind": ".",
-                                                "start": 1478,
-                                                "end": 1479,
-                                                "text": "."
-                                              },
-                                              {
                                                 "kind": "identifier",
                                                 "start": 1479,
                                                 "end": 1483,
@@ -3876,30 +2214,11 @@
                                                 "kind": "argument_list",
                                                 "start": 1483,
                                                 "end": 1485,
-                                                "children": [
-                                                  {
-                                                    "kind": "(",
-                                                    "start": 1483,
-                                                    "end": 1484,
-                                                    "text": "("
-                                                  },
-                                                  {
-                                                    "kind": ")",
-                                                    "start": 1484,
-                                                    "end": 1485,
-                                                    "text": ")"
-                                                  }
-                                                ]
+                                                "text": "()"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1485,
-                                        "end": 1486,
-                                        "text": ";"
                                       },
                                       {
                                         "kind": "update_expression",
@@ -3911,20 +2230,8 @@
                                             "start": 1487,
                                             "end": 1488,
                                             "text": "i"
-                                          },
-                                          {
-                                            "kind": "++",
-                                            "start": 1488,
-                                            "end": 1490,
-                                            "text": "++"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 1490,
-                                        "end": 1491,
-                                        "text": ")"
                                       },
                                       {
                                         "kind": "block",
@@ -3932,33 +2239,15 @@
                                         "end": 1593,
                                         "children": [
                                           {
-                                            "kind": "{",
-                                            "start": 1492,
-                                            "end": 1493,
-                                            "text": "{"
-                                          },
-                                          {
                                             "kind": "if_statement",
                                             "start": 1494,
                                             "end": 1517,
                                             "children": [
                                               {
-                                                "kind": "if",
-                                                "start": 1494,
-                                                "end": 1496,
-                                                "text": "if"
-                                              },
-                                              {
                                                 "kind": "parenthesized_expression",
                                                 "start": 1497,
                                                 "end": 1507,
                                                 "children": [
-                                                  {
-                                                    "kind": "(",
-                                                    "start": 1497,
-                                                    "end": 1498,
-                                                    "text": "("
-                                                  },
                                                   {
                                                     "kind": "binary_expression",
                                                     "start": 1498,
@@ -3971,24 +2260,12 @@
                                                         "text": "i"
                                                       },
                                                       {
-                                                        "kind": "\u003c",
-                                                        "start": 1500,
-                                                        "end": 1501,
-                                                        "text": "\u003c"
-                                                      },
-                                                      {
                                                         "kind": "identifier",
                                                         "start": 1502,
                                                         "end": 1506,
                                                         "text": "skip"
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": ")",
-                                                    "start": 1506,
-                                                    "end": 1507,
-                                                    "text": ")"
                                                   }
                                                 ]
                                               },
@@ -3996,20 +2273,7 @@
                                                 "kind": "continue_statement",
                                                 "start": 1508,
                                                 "end": 1517,
-                                                "children": [
-                                                  {
-                                                    "kind": "continue",
-                                                    "start": 1508,
-                                                    "end": 1516,
-                                                    "text": "continue"
-                                                  },
-                                                  {
-                                                    "kind": ";",
-                                                    "start": 1516,
-                                                    "end": 1517,
-                                                    "text": ";"
-                                                  }
-                                                ]
+                                                "text": "continue;"
                                               }
                                             ]
                                           },
@@ -4019,22 +2283,10 @@
                                             "end": 1559,
                                             "children": [
                                               {
-                                                "kind": "if",
-                                                "start": 1518,
-                                                "end": 1520,
-                                                "text": "if"
-                                              },
-                                              {
                                                 "kind": "parenthesized_expression",
                                                 "start": 1521,
                                                 "end": 1552,
                                                 "children": [
-                                                  {
-                                                    "kind": "(",
-                                                    "start": 1521,
-                                                    "end": 1522,
-                                                    "text": "("
-                                                  },
                                                   {
                                                     "kind": "binary_expression",
                                                     "start": 1522,
@@ -4052,24 +2304,12 @@
                                                             "text": "take"
                                                           },
                                                           {
-                                                            "kind": "\u003e=",
-                                                            "start": 1527,
-                                                            "end": 1529,
-                                                            "text": "\u003e="
-                                                          },
-                                                          {
                                                             "kind": "decimal_integer_literal",
                                                             "start": 1530,
                                                             "end": 1531,
                                                             "text": "0"
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "kind": "\u0026\u0026",
-                                                        "start": 1532,
-                                                        "end": 1534,
-                                                        "text": "\u0026\u0026"
                                                       },
                                                       {
                                                         "kind": "binary_expression",
@@ -4083,12 +2323,6 @@
                                                             "text": "i"
                                                           },
                                                           {
-                                                            "kind": "\u003e=",
-                                                            "start": 1537,
-                                                            "end": 1539,
-                                                            "text": "\u003e="
-                                                          },
-                                                          {
                                                             "kind": "binary_expression",
                                                             "start": 1540,
                                                             "end": 1551,
@@ -4098,12 +2332,6 @@
                                                                 "start": 1540,
                                                                 "end": 1544,
                                                                 "text": "skip"
-                                                              },
-                                                              {
-                                                                "kind": "+",
-                                                                "start": 1545,
-                                                                "end": 1546,
-                                                                "text": "+"
                                                               },
                                                               {
                                                                 "kind": "identifier",
@@ -4116,12 +2344,6 @@
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": ")",
-                                                    "start": 1551,
-                                                    "end": 1552,
-                                                    "text": ")"
                                                   }
                                                 ]
                                               },
@@ -4129,20 +2351,7 @@
                                                 "kind": "break_statement",
                                                 "start": 1553,
                                                 "end": 1559,
-                                                "children": [
-                                                  {
-                                                    "kind": "break",
-                                                    "start": 1553,
-                                                    "end": 1558,
-                                                    "text": "break"
-                                                  },
-                                                  {
-                                                    "kind": ";",
-                                                    "start": 1558,
-                                                    "end": 1559,
-                                                    "text": ";"
-                                                  }
-                                                ]
+                                                "text": "break;"
                                               }
                                             ]
                                           },
@@ -4163,12 +2372,6 @@
                                                     "text": "_tmp"
                                                   },
                                                   {
-                                                    "kind": ".",
-                                                    "start": 1564,
-                                                    "end": 1565,
-                                                    "text": "."
-                                                  },
-                                                  {
                                                     "kind": "identifier",
                                                     "start": 1565,
                                                     "end": 1568,
@@ -4180,33 +2383,15 @@
                                                     "end": 1590,
                                                     "children": [
                                                       {
-                                                        "kind": "(",
-                                                        "start": 1568,
-                                                        "end": 1569,
-                                                        "text": "("
-                                                      },
-                                                      {
                                                         "kind": "cast_expression",
                                                         "start": 1569,
                                                         "end": 1589,
                                                         "children": [
                                                           {
-                                                            "kind": "(",
-                                                            "start": 1569,
-                                                            "end": 1570,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "kind": "type_identifier",
                                                             "start": 1570,
                                                             "end": 1577,
                                                             "text": "Result4"
-                                                          },
-                                                          {
-                                                            "kind": ")",
-                                                            "start": 1577,
-                                                            "end": 1578,
-                                                            "text": ")"
                                                           },
                                                           {
                                                             "kind": "method_invocation",
@@ -4220,12 +2405,6 @@
                                                                 "text": "list"
                                                               },
                                                               {
-                                                                "kind": ".",
-                                                                "start": 1582,
-                                                                "end": 1583,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "kind": "identifier",
                                                                 "start": 1583,
                                                                 "end": 1586,
@@ -4237,52 +2416,22 @@
                                                                 "end": 1589,
                                                                 "children": [
                                                                   {
-                                                                    "kind": "(",
-                                                                    "start": 1586,
-                                                                    "end": 1587,
-                                                                    "text": "("
-                                                                  },
-                                                                  {
                                                                     "kind": "identifier",
                                                                     "start": 1587,
                                                                     "end": 1588,
                                                                     "text": "i"
-                                                                  },
-                                                                  {
-                                                                    "kind": ")",
-                                                                    "start": 1588,
-                                                                    "end": 1589,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
                                                             ]
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "kind": ")",
-                                                        "start": 1589,
-                                                        "end": 1590,
-                                                        "text": ")"
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ";",
-                                                "start": 1590,
-                                                "end": 1591,
-                                                "text": ";"
                                               }
                                             ]
-                                          },
-                                          {
-                                            "kind": "}",
-                                            "start": 1592,
-                                            "end": 1593,
-                                            "text": "}"
                                           }
                                         ]
                                       }
@@ -4310,60 +2459,24 @@
                                             "end": 1606,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 1600,
-                                                "end": 1601,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "identifier",
                                                 "start": 1601,
                                                 "end": 1605,
                                                 "text": "_tmp"
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 1605,
-                                                "end": 1606,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 1606,
-                                        "end": 1607,
-                                        "text": ";"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": "}",
-                                    "start": 1607,
-                                    "end": 1608,
-                                    "text": "}"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 1608,
-                                "end": 1609,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
                       }
                     ]
-                  },
-                  {
-                    "kind": ";",
-                    "start": 1609,
-                    "end": 1610,
-                    "text": ";"
                   }
                 ]
               },
@@ -4376,20 +2489,7 @@
                     "kind": "modifiers",
                     "start": 1615,
                     "end": 1621,
-                    "children": [
-                      {
-                        "kind": "static",
-                        "start": 1615,
-                        "end": 1621,
-                        "text": "static"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "class",
-                    "start": 1622,
-                    "end": 1627,
-                    "text": "class"
+                    "text": "static"
                   },
                   {
                     "kind": "identifier",
@@ -4403,12 +2503,6 @@
                     "end": 2343,
                     "children": [
                       {
-                        "kind": "{",
-                        "start": 1636,
-                        "end": 1637,
-                        "text": "{"
-                      },
-                      {
                         "kind": "field_declaration",
                         "start": 1646,
                         "end": 1658,
@@ -4417,14 +2511,7 @@
                             "kind": "integral_type",
                             "start": 1646,
                             "end": 1649,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 1646,
-                                "end": 1649,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -4438,12 +2525,6 @@
                                 "text": "orderId"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 1657,
-                            "end": 1658,
-                            "text": ";"
                           }
                         ]
                       },
@@ -4456,14 +2537,7 @@
                             "kind": "integral_type",
                             "start": 1667,
                             "end": 1670,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 1667,
-                                "end": 1670,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -4477,12 +2551,6 @@
                                 "text": "orderCustomerId"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 1686,
-                            "end": 1687,
-                            "text": ";"
                           }
                         ]
                       },
@@ -4509,12 +2577,6 @@
                                 "text": "pairedCustomerName"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 1721,
-                            "end": 1722,
-                            "text": ";"
                           }
                         ]
                       },
@@ -4527,14 +2589,7 @@
                             "kind": "integral_type",
                             "start": 1731,
                             "end": 1734,
-                            "children": [
-                              {
-                                "kind": "int",
-                                "start": 1731,
-                                "end": 1734,
-                                "text": "int"
-                              }
-                            ]
+                            "text": "int"
                           },
                           {
                             "kind": "variable_declarator",
@@ -4548,12 +2603,6 @@
                                 "text": "orderTotal"
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 1745,
-                            "end": 1746,
-                            "text": ";"
                           }
                         ]
                       },
@@ -4574,12 +2623,6 @@
                             "end": 1839,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 1762,
-                                "end": 1763,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 1763,
                                 "end": 1774,
@@ -4588,14 +2631,7 @@
                                     "kind": "integral_type",
                                     "start": 1763,
                                     "end": 1766,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 1763,
-                                        "end": 1766,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -4606,12 +2642,6 @@
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 1774,
-                                "end": 1775,
-                                "text": ","
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 1776,
                                 "end": 1795,
@@ -4620,14 +2650,7 @@
                                     "kind": "integral_type",
                                     "start": 1776,
                                     "end": 1779,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 1776,
-                                        "end": 1779,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -4636,12 +2659,6 @@
                                     "text": "orderCustomerId"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ",",
-                                "start": 1795,
-                                "end": 1796,
-                                "text": ","
                               },
                               {
                                 "kind": "formal_parameter",
@@ -4663,12 +2680,6 @@
                                 ]
                               },
                               {
-                                "kind": ",",
-                                "start": 1822,
-                                "end": 1823,
-                                "text": ","
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 1824,
                                 "end": 1838,
@@ -4677,14 +2688,7 @@
                                     "kind": "integral_type",
                                     "start": 1824,
                                     "end": 1827,
-                                    "children": [
-                                      {
-                                        "kind": "int",
-                                        "start": 1824,
-                                        "end": 1827,
-                                        "text": "int"
-                                      }
-                                    ]
+                                    "text": "int"
                                   },
                                   {
                                     "kind": "identifier",
@@ -4693,12 +2697,6 @@
                                     "text": "orderTotal"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 1838,
-                                "end": 1839,
-                                "text": ")"
                               }
                             ]
                           },
@@ -4707,12 +2705,6 @@
                             "start": 1840,
                             "end": 2039,
                             "children": [
-                              {
-                                "kind": "{",
-                                "start": 1840,
-                                "end": 1841,
-                                "text": "{"
-                              },
                               {
                                 "kind": "expression_statement",
                                 "start": 1854,
@@ -4735,12 +2727,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 1858,
-                                            "end": 1859,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 1859,
                                             "end": 1866,
@@ -4749,24 +2735,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 1867,
-                                        "end": 1868,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 1869,
                                         "end": 1876,
                                         "text": "orderId"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 1876,
-                                    "end": 1877,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -4792,12 +2766,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 1894,
-                                            "end": 1895,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 1895,
                                             "end": 1910,
@@ -4806,24 +2774,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 1911,
-                                        "end": 1912,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 1913,
                                         "end": 1928,
                                         "text": "orderCustomerId"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 1928,
-                                    "end": 1929,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -4849,12 +2805,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 1946,
-                                            "end": 1947,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 1947,
                                             "end": 1965,
@@ -4863,24 +2813,12 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 1966,
-                                        "end": 1967,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 1968,
                                         "end": 1986,
                                         "text": "pairedCustomerName"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 1986,
-                                    "end": 1987,
-                                    "text": ";"
                                   }
                                 ]
                               },
@@ -4906,12 +2844,6 @@
                                             "text": "this"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 2004,
-                                            "end": 2005,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 2005,
                                             "end": 2015,
@@ -4920,32 +2852,14 @@
                                         ]
                                       },
                                       {
-                                        "kind": "=",
-                                        "start": 2016,
-                                        "end": 2017,
-                                        "text": "="
-                                      },
-                                      {
                                         "kind": "identifier",
                                         "start": 2018,
                                         "end": 2028,
                                         "text": "orderTotal"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 2028,
-                                    "end": 2029,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 2038,
-                                "end": 2039,
-                                "text": "}"
                               }
                             ]
                           }
@@ -4974,12 +2888,6 @@
                             "end": 2077,
                             "children": [
                               {
-                                "kind": "(",
-                                "start": 2067,
-                                "end": 2068,
-                                "text": "("
-                              },
-                              {
                                 "kind": "formal_parameter",
                                 "start": 2068,
                                 "end": 2076,
@@ -4997,12 +2905,6 @@
                                     "text": "k"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ")",
-                                "start": 2076,
-                                "end": 2077,
-                                "text": ")"
                               }
                             ]
                           },
@@ -5012,33 +2914,15 @@
                             "end": 2337,
                             "children": [
                               {
-                                "kind": "{",
-                                "start": 2078,
-                                "end": 2079,
-                                "text": "{"
-                              },
-                              {
                                 "kind": "if_statement",
                                 "start": 2092,
                                 "end": 2129,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 2092,
-                                    "end": 2094,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2095,
                                     "end": 2116,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 2095,
-                                        "end": 2096,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 2096,
@@ -5049,12 +2933,6 @@
                                             "start": 2096,
                                             "end": 2097,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 2097,
-                                            "end": 2098,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -5068,51 +2946,21 @@
                                             "end": 2115,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 2104,
-                                                "end": 2105,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 2105,
                                                 "end": 2114,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 2105,
-                                                    "end": 2106,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 2106,
                                                     "end": 2113,
                                                     "text": "orderId"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 2113,
-                                                    "end": 2114,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 2114,
-                                                "end": 2115,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2115,
-                                        "end": 2116,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -5122,22 +2970,10 @@
                                     "end": 2129,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 2117,
-                                        "end": 2123,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 2124,
                                         "end": 2128,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 2128,
-                                        "end": 2129,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -5149,22 +2985,10 @@
                                 "end": 2187,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 2142,
-                                    "end": 2144,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2145,
                                     "end": 2174,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 2145,
-                                        "end": 2146,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 2146,
@@ -5175,12 +2999,6 @@
                                             "start": 2146,
                                             "end": 2147,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 2147,
-                                            "end": 2148,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -5194,51 +3012,21 @@
                                             "end": 2173,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 2154,
-                                                "end": 2155,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 2155,
                                                 "end": 2172,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 2155,
-                                                    "end": 2156,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 2156,
                                                     "end": 2171,
                                                     "text": "orderCustomerId"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 2171,
-                                                    "end": 2172,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 2172,
-                                                "end": 2173,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2173,
-                                        "end": 2174,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -5248,22 +3036,10 @@
                                     "end": 2187,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 2175,
-                                        "end": 2181,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 2182,
                                         "end": 2186,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 2186,
-                                        "end": 2187,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -5275,22 +3051,10 @@
                                 "end": 2248,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 2200,
-                                    "end": 2202,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2203,
                                     "end": 2235,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 2203,
-                                        "end": 2204,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 2204,
@@ -5301,12 +3065,6 @@
                                             "start": 2204,
                                             "end": 2205,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 2205,
-                                            "end": 2206,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -5320,51 +3078,21 @@
                                             "end": 2234,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 2212,
-                                                "end": 2213,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 2213,
                                                 "end": 2233,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 2213,
-                                                    "end": 2214,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 2214,
                                                     "end": 2232,
                                                     "text": "pairedCustomerName"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 2232,
-                                                    "end": 2233,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 2233,
-                                                "end": 2234,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2234,
-                                        "end": 2235,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -5374,22 +3102,10 @@
                                     "end": 2248,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 2236,
-                                        "end": 2242,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 2243,
                                         "end": 2247,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 2247,
-                                        "end": 2248,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -5401,22 +3117,10 @@
                                 "end": 2301,
                                 "children": [
                                   {
-                                    "kind": "if",
-                                    "start": 2261,
-                                    "end": 2263,
-                                    "text": "if"
-                                  },
-                                  {
                                     "kind": "parenthesized_expression",
                                     "start": 2264,
                                     "end": 2288,
                                     "children": [
-                                      {
-                                        "kind": "(",
-                                        "start": 2264,
-                                        "end": 2265,
-                                        "text": "("
-                                      },
                                       {
                                         "kind": "method_invocation",
                                         "start": 2265,
@@ -5427,12 +3131,6 @@
                                             "start": 2265,
                                             "end": 2266,
                                             "text": "k"
-                                          },
-                                          {
-                                            "kind": ".",
-                                            "start": 2266,
-                                            "end": 2267,
-                                            "text": "."
                                           },
                                           {
                                             "kind": "identifier",
@@ -5446,51 +3144,21 @@
                                             "end": 2287,
                                             "children": [
                                               {
-                                                "kind": "(",
-                                                "start": 2273,
-                                                "end": 2274,
-                                                "text": "("
-                                              },
-                                              {
                                                 "kind": "string_literal",
                                                 "start": 2274,
                                                 "end": 2286,
                                                 "children": [
                                                   {
-                                                    "kind": "\"",
-                                                    "start": 2274,
-                                                    "end": 2275,
-                                                    "text": "\""
-                                                  },
-                                                  {
                                                     "kind": "string_fragment",
                                                     "start": 2275,
                                                     "end": 2285,
                                                     "text": "orderTotal"
-                                                  },
-                                                  {
-                                                    "kind": "\"",
-                                                    "start": 2285,
-                                                    "end": 2286,
-                                                    "text": "\""
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": ")",
-                                                "start": 2286,
-                                                "end": 2287,
-                                                "text": ")"
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ")",
-                                        "start": 2287,
-                                        "end": 2288,
-                                        "text": ")"
                                       }
                                     ]
                                   },
@@ -5500,22 +3168,10 @@
                                     "end": 2301,
                                     "children": [
                                       {
-                                        "kind": "return",
-                                        "start": 2289,
-                                        "end": 2295,
-                                        "text": "return"
-                                      },
-                                      {
                                         "kind": "true",
                                         "start": 2296,
                                         "end": 2300,
                                         "text": "true"
-                                      },
-                                      {
-                                        "kind": ";",
-                                        "start": 2300,
-                                        "end": 2301,
-                                        "text": ";"
                                       }
                                     ]
                                   }
@@ -5527,40 +3183,16 @@
                                 "end": 2327,
                                 "children": [
                                   {
-                                    "kind": "return",
-                                    "start": 2314,
-                                    "end": 2320,
-                                    "text": "return"
-                                  },
-                                  {
                                     "kind": "false",
                                     "start": 2321,
                                     "end": 2326,
                                     "text": "false"
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 2326,
-                                    "end": 2327,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 2336,
-                                "end": 2337,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "}",
-                        "start": 2342,
-                        "end": 2343,
-                        "text": "}"
                       }
                     ]
                   }
@@ -5575,20 +3207,7 @@
                     "kind": "modifiers",
                     "start": 2350,
                     "end": 2363,
-                    "children": [
-                      {
-                        "kind": "public",
-                        "start": 2350,
-                        "end": 2356,
-                        "text": "public"
-                      },
-                      {
-                        "kind": "static",
-                        "start": 2357,
-                        "end": 2363,
-                        "text": "static"
-                      }
-                    ]
+                    "text": "public static"
                   },
                   {
                     "kind": "void_type",
@@ -5607,12 +3226,6 @@
                     "start": 2373,
                     "end": 2388,
                     "children": [
-                      {
-                        "kind": "(",
-                        "start": 2373,
-                        "end": 2374,
-                        "text": "("
-                      },
                       {
                         "kind": "formal_parameter",
                         "start": 2374,
@@ -5633,20 +3246,7 @@
                                 "kind": "dimensions",
                                 "start": 2380,
                                 "end": 2382,
-                                "children": [
-                                  {
-                                    "kind": "[",
-                                    "start": 2380,
-                                    "end": 2381,
-                                    "text": "["
-                                  },
-                                  {
-                                    "kind": "]",
-                                    "start": 2381,
-                                    "end": 2382,
-                                    "text": "]"
-                                  }
-                                ]
+                                "text": "[]"
                               }
                             ]
                           },
@@ -5657,12 +3257,6 @@
                             "text": "args"
                           }
                         ]
-                      },
-                      {
-                        "kind": ")",
-                        "start": 2387,
-                        "end": 2388,
-                        "text": ")"
                       }
                     ]
                   },
@@ -5671,12 +3265,6 @@
                     "start": 2389,
                     "end": 2736,
                     "children": [
-                      {
-                        "kind": "{",
-                        "start": 2389,
-                        "end": 2390,
-                        "text": "{"
-                      },
                       {
                         "kind": "expression_statement",
                         "start": 2399,
@@ -5699,24 +3287,12 @@
                                     "text": "System"
                                   },
                                   {
-                                    "kind": ".",
-                                    "start": 2405,
-                                    "end": 2406,
-                                    "text": "."
-                                  },
-                                  {
                                     "kind": "identifier",
                                     "start": 2406,
                                     "end": 2409,
                                     "text": "out"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": ".",
-                                "start": 2409,
-                                "end": 2410,
-                                "text": "."
                               },
                               {
                                 "kind": "identifier",
@@ -5730,51 +3306,21 @@
                                 "end": 2465,
                                 "children": [
                                   {
-                                    "kind": "(",
-                                    "start": 2417,
-                                    "end": 2418,
-                                    "text": "("
-                                  },
-                                  {
                                     "kind": "string_literal",
                                     "start": 2418,
                                     "end": 2464,
                                     "children": [
                                       {
-                                        "kind": "\"",
-                                        "start": 2418,
-                                        "end": 2419,
-                                        "text": "\""
-                                      },
-                                      {
                                         "kind": "string_fragment",
                                         "start": 2419,
                                         "end": 2463,
                                         "text": "--- Cross Join: All order-customer pairs ---"
-                                      },
-                                      {
-                                        "kind": "\"",
-                                        "start": 2463,
-                                        "end": 2464,
-                                        "text": "\""
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ")",
-                                    "start": 2464,
-                                    "end": 2465,
-                                    "text": ")"
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "kind": ";",
-                            "start": 2465,
-                            "end": 2466,
-                            "text": ";"
                           }
                         ]
                       },
@@ -5783,18 +3329,6 @@
                         "start": 2475,
                         "end": 2730,
                         "children": [
-                          {
-                            "kind": "for",
-                            "start": 2475,
-                            "end": 2478,
-                            "text": "for"
-                          },
-                          {
-                            "kind": "(",
-                            "start": 2479,
-                            "end": 2480,
-                            "text": "("
-                          },
                           {
                             "kind": "type_identifier",
                             "start": 2480,
@@ -5808,34 +3342,16 @@
                             "text": "entry"
                           },
                           {
-                            "kind": ":",
-                            "start": 2490,
-                            "end": 2491,
-                            "text": ":"
-                          },
-                          {
                             "kind": "identifier",
                             "start": 2492,
                             "end": 2498,
                             "text": "result"
                           },
                           {
-                            "kind": ")",
-                            "start": 2498,
-                            "end": 2499,
-                            "text": ")"
-                          },
-                          {
                             "kind": "block",
                             "start": 2500,
                             "end": 2730,
                             "children": [
-                              {
-                                "kind": "{",
-                                "start": 2500,
-                                "end": 2501,
-                                "text": "{"
-                              },
                               {
                                 "kind": "expression_statement",
                                 "start": 2514,
@@ -5858,24 +3374,12 @@
                                             "text": "System"
                                           },
                                           {
-                                            "kind": ".",
-                                            "start": 2520,
-                                            "end": 2521,
-                                            "text": "."
-                                          },
-                                          {
                                             "kind": "identifier",
                                             "start": 2521,
                                             "end": 2524,
                                             "text": "out"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "kind": ".",
-                                        "start": 2524,
-                                        "end": 2525,
-                                        "text": "."
                                       },
                                       {
                                         "kind": "identifier",
@@ -5888,12 +3392,6 @@
                                         "start": 2532,
                                         "end": 2719,
                                         "children": [
-                                          {
-                                            "kind": "(",
-                                            "start": 2532,
-                                            "end": 2533,
-                                            "text": "("
-                                          },
                                           {
                                             "kind": "binary_expression",
                                             "start": 2533,
@@ -5970,30 +3468,12 @@
                                                                                                     "end": 2540,
                                                                                                     "children": [
                                                                                                       {
-                                                                                                        "kind": "\"",
-                                                                                                        "start": 2533,
-                                                                                                        "end": 2534,
-                                                                                                        "text": "\""
-                                                                                                      },
-                                                                                                      {
                                                                                                         "kind": "string_fragment",
                                                                                                         "start": 2534,
                                                                                                         "end": 2539,
                                                                                                         "text": "Order"
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "\"",
-                                                                                                        "start": 2539,
-                                                                                                        "end": 2540,
-                                                                                                        "text": "\""
                                                                                                       }
                                                                                                     ]
-                                                                                                  },
-                                                                                                  {
-                                                                                                    "kind": "+",
-                                                                                                    "start": 2541,
-                                                                                                    "end": 2542,
-                                                                                                    "text": "+"
                                                                                                   },
                                                                                                   {
                                                                                                     "kind": "string_literal",
@@ -6001,32 +3481,14 @@
                                                                                                     "end": 2546,
                                                                                                     "children": [
                                                                                                       {
-                                                                                                        "kind": "\"",
-                                                                                                        "start": 2543,
-                                                                                                        "end": 2544,
-                                                                                                        "text": "\""
-                                                                                                      },
-                                                                                                      {
                                                                                                         "kind": "string_fragment",
                                                                                                         "start": 2544,
                                                                                                         "end": 2545,
                                                                                                         "text": " "
-                                                                                                      },
-                                                                                                      {
-                                                                                                        "kind": "\"",
-                                                                                                        "start": 2545,
-                                                                                                        "end": 2546,
-                                                                                                        "text": "\""
                                                                                                       }
                                                                                                     ]
                                                                                                   }
                                                                                                 ]
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "+",
-                                                                                                "start": 2547,
-                                                                                                "end": 2548,
-                                                                                                "text": "+"
                                                                                               },
                                                                                               {
                                                                                                 "kind": "field_access",
@@ -6040,12 +3502,6 @@
                                                                                                     "text": "entry"
                                                                                                   },
                                                                                                   {
-                                                                                                    "kind": ".",
-                                                                                                    "start": 2554,
-                                                                                                    "end": 2555,
-                                                                                                    "text": "."
-                                                                                                  },
-                                                                                                  {
                                                                                                     "kind": "identifier",
                                                                                                     "start": 2555,
                                                                                                     "end": 2562,
@@ -6056,43 +3512,19 @@
                                                                                             ]
                                                                                           },
                                                                                           {
-                                                                                            "kind": "+",
-                                                                                            "start": 2563,
-                                                                                            "end": 2564,
-                                                                                            "text": "+"
-                                                                                          },
-                                                                                          {
                                                                                             "kind": "string_literal",
                                                                                             "start": 2565,
                                                                                             "end": 2568,
                                                                                             "children": [
                                                                                               {
-                                                                                                "kind": "\"",
-                                                                                                "start": 2565,
-                                                                                                "end": 2566,
-                                                                                                "text": "\""
-                                                                                              },
-                                                                                              {
                                                                                                 "kind": "string_fragment",
                                                                                                 "start": 2566,
                                                                                                 "end": 2567,
                                                                                                 "text": " "
-                                                                                              },
-                                                                                              {
-                                                                                                "kind": "\"",
-                                                                                                "start": 2567,
-                                                                                                "end": 2568,
-                                                                                                "text": "\""
                                                                                               }
                                                                                             ]
                                                                                           }
                                                                                         ]
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": "+",
-                                                                                        "start": 2569,
-                                                                                        "end": 2570,
-                                                                                        "text": "+"
                                                                                       },
                                                                                       {
                                                                                         "kind": "string_literal",
@@ -6100,32 +3532,14 @@
                                                                                         "end": 2585,
                                                                                         "children": [
                                                                                           {
-                                                                                            "kind": "\"",
-                                                                                            "start": 2571,
-                                                                                            "end": 2572,
-                                                                                            "text": "\""
-                                                                                          },
-                                                                                          {
                                                                                             "kind": "string_fragment",
                                                                                             "start": 2572,
                                                                                             "end": 2584,
                                                                                             "text": "(customerId:"
-                                                                                          },
-                                                                                          {
-                                                                                            "kind": "\"",
-                                                                                            "start": 2584,
-                                                                                            "end": 2585,
-                                                                                            "text": "\""
                                                                                           }
                                                                                         ]
                                                                                       }
                                                                                     ]
-                                                                                  },
-                                                                                  {
-                                                                                    "kind": "+",
-                                                                                    "start": 2586,
-                                                                                    "end": 2587,
-                                                                                    "text": "+"
                                                                                   },
                                                                                   {
                                                                                     "kind": "string_literal",
@@ -6133,32 +3547,14 @@
                                                                                     "end": 2591,
                                                                                     "children": [
                                                                                       {
-                                                                                        "kind": "\"",
-                                                                                        "start": 2588,
-                                                                                        "end": 2589,
-                                                                                        "text": "\""
-                                                                                      },
-                                                                                      {
                                                                                         "kind": "string_fragment",
                                                                                         "start": 2589,
                                                                                         "end": 2590,
                                                                                         "text": " "
-                                                                                      },
-                                                                                      {
-                                                                                        "kind": "\"",
-                                                                                        "start": 2590,
-                                                                                        "end": 2591,
-                                                                                        "text": "\""
                                                                                       }
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "kind": "+",
-                                                                                "start": 2592,
-                                                                                "end": 2593,
-                                                                                "text": "+"
                                                                               },
                                                                               {
                                                                                 "kind": "field_access",
@@ -6172,12 +3568,6 @@
                                                                                     "text": "entry"
                                                                                   },
                                                                                   {
-                                                                                    "kind": ".",
-                                                                                    "start": 2599,
-                                                                                    "end": 2600,
-                                                                                    "text": "."
-                                                                                  },
-                                                                                  {
                                                                                     "kind": "identifier",
                                                                                     "start": 2600,
                                                                                     "end": 2615,
@@ -6188,43 +3578,19 @@
                                                                             ]
                                                                           },
                                                                           {
-                                                                            "kind": "+",
-                                                                            "start": 2616,
-                                                                            "end": 2617,
-                                                                            "text": "+"
-                                                                          },
-                                                                          {
                                                                             "kind": "string_literal",
                                                                             "start": 2618,
                                                                             "end": 2621,
                                                                             "children": [
                                                                               {
-                                                                                "kind": "\"",
-                                                                                "start": 2618,
-                                                                                "end": 2619,
-                                                                                "text": "\""
-                                                                              },
-                                                                              {
                                                                                 "kind": "string_fragment",
                                                                                 "start": 2619,
                                                                                 "end": 2620,
                                                                                 "text": " "
-                                                                              },
-                                                                              {
-                                                                                "kind": "\"",
-                                                                                "start": 2620,
-                                                                                "end": 2621,
-                                                                                "text": "\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "kind": "+",
-                                                                        "start": 2622,
-                                                                        "end": 2623,
-                                                                        "text": "+"
                                                                       },
                                                                       {
                                                                         "kind": "string_literal",
@@ -6232,32 +3598,14 @@
                                                                         "end": 2636,
                                                                         "children": [
                                                                           {
-                                                                            "kind": "\"",
-                                                                            "start": 2624,
-                                                                            "end": 2625,
-                                                                            "text": "\""
-                                                                          },
-                                                                          {
                                                                             "kind": "string_fragment",
                                                                             "start": 2625,
                                                                             "end": 2635,
                                                                             "text": ", total: $"
-                                                                          },
-                                                                          {
-                                                                            "kind": "\"",
-                                                                            "start": 2635,
-                                                                            "end": 2636,
-                                                                            "text": "\""
                                                                           }
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "kind": "+",
-                                                                    "start": 2637,
-                                                                    "end": 2638,
-                                                                    "text": "+"
                                                                   },
                                                                   {
                                                                     "kind": "string_literal",
@@ -6265,32 +3613,14 @@
                                                                     "end": 2642,
                                                                     "children": [
                                                                       {
-                                                                        "kind": "\"",
-                                                                        "start": 2639,
-                                                                        "end": 2640,
-                                                                        "text": "\""
-                                                                      },
-                                                                      {
                                                                         "kind": "string_fragment",
                                                                         "start": 2640,
                                                                         "end": 2641,
                                                                         "text": " "
-                                                                      },
-                                                                      {
-                                                                        "kind": "\"",
-                                                                        "start": 2641,
-                                                                        "end": 2642,
-                                                                        "text": "\""
                                                                       }
                                                                     ]
                                                                   }
                                                                 ]
-                                                              },
-                                                              {
-                                                                "kind": "+",
-                                                                "start": 2643,
-                                                                "end": 2644,
-                                                                "text": "+"
                                                               },
                                                               {
                                                                 "kind": "field_access",
@@ -6304,12 +3634,6 @@
                                                                     "text": "entry"
                                                                   },
                                                                   {
-                                                                    "kind": ".",
-                                                                    "start": 2650,
-                                                                    "end": 2651,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "kind": "identifier",
                                                                     "start": 2651,
                                                                     "end": 2661,
@@ -6320,43 +3644,19 @@
                                                             ]
                                                           },
                                                           {
-                                                            "kind": "+",
-                                                            "start": 2662,
-                                                            "end": 2663,
-                                                            "text": "+"
-                                                          },
-                                                          {
                                                             "kind": "string_literal",
                                                             "start": 2664,
                                                             "end": 2667,
                                                             "children": [
                                                               {
-                                                                "kind": "\"",
-                                                                "start": 2664,
-                                                                "end": 2665,
-                                                                "text": "\""
-                                                              },
-                                                              {
                                                                 "kind": "string_fragment",
                                                                 "start": 2665,
                                                                 "end": 2666,
                                                                 "text": " "
-                                                              },
-                                                              {
-                                                                "kind": "\"",
-                                                                "start": 2666,
-                                                                "end": 2667,
-                                                                "text": "\""
                                                               }
                                                             ]
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "kind": "+",
-                                                        "start": 2668,
-                                                        "end": 2669,
-                                                        "text": "+"
                                                       },
                                                       {
                                                         "kind": "string_literal",
@@ -6364,32 +3664,14 @@
                                                         "end": 2685,
                                                         "children": [
                                                           {
-                                                            "kind": "\"",
-                                                            "start": 2670,
-                                                            "end": 2671,
-                                                            "text": "\""
-                                                          },
-                                                          {
                                                             "kind": "string_fragment",
                                                             "start": 2671,
                                                             "end": 2684,
                                                             "text": ") paired with"
-                                                          },
-                                                          {
-                                                            "kind": "\"",
-                                                            "start": 2684,
-                                                            "end": 2685,
-                                                            "text": "\""
                                                           }
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": "+",
-                                                    "start": 2686,
-                                                    "end": 2687,
-                                                    "text": "+"
                                                   },
                                                   {
                                                     "kind": "string_literal",
@@ -6397,32 +3679,14 @@
                                                     "end": 2691,
                                                     "children": [
                                                       {
-                                                        "kind": "\"",
-                                                        "start": 2688,
-                                                        "end": 2689,
-                                                        "text": "\""
-                                                      },
-                                                      {
                                                         "kind": "string_fragment",
                                                         "start": 2689,
                                                         "end": 2690,
                                                         "text": " "
-                                                      },
-                                                      {
-                                                        "kind": "\"",
-                                                        "start": 2690,
-                                                        "end": 2691,
-                                                        "text": "\""
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": "+",
-                                                "start": 2692,
-                                                "end": 2693,
-                                                "text": "+"
                                               },
                                               {
                                                 "kind": "field_access",
@@ -6436,12 +3700,6 @@
                                                     "text": "entry"
                                                   },
                                                   {
-                                                    "kind": ".",
-                                                    "start": 2699,
-                                                    "end": 2700,
-                                                    "text": "."
-                                                  },
-                                                  {
                                                     "kind": "identifier",
                                                     "start": 2700,
                                                     "end": 2718,
@@ -6450,50 +3708,20 @@
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "kind": ")",
-                                            "start": 2718,
-                                            "end": 2719,
-                                            "text": ")"
                                           }
                                         ]
                                       }
                                     ]
-                                  },
-                                  {
-                                    "kind": ";",
-                                    "start": 2719,
-                                    "end": 2720,
-                                    "text": ";"
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "}",
-                                "start": 2729,
-                                "end": 2730,
-                                "text": "}"
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "kind": "}",
-                        "start": 2735,
-                        "end": 2736,
-                        "text": "}"
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "kind": "}",
-                "start": 2737,
-                "end": 2738,
-                "text": "}"
               }
             ]
           }

--- a/tools/json-ast/x/java/ast.go
+++ b/tools/json-ast/x/java/ast.go
@@ -2,7 +2,9 @@ package java
 
 import sitter "github.com/smacker/go-tree-sitter"
 
-// Node models a tree-sitter node for Java source.
+// Node represents a minimal JSON-serialisable AST node.  Only named
+// tree-sitter nodes are kept to reduce noise.  Leaf nodes store the raw
+// source text in Text.
 type Node struct {
 	Kind     string `json:"kind"`
 	Start    int    `json:"start"`
@@ -18,11 +20,14 @@ func convert(n *sitter.Node, src []byte) Node {
 		Start: int(n.StartByte()),
 		End:   int(n.EndByte()),
 	}
-	if n.ChildCount() == 0 {
+
+	if n.NamedChildCount() == 0 {
 		node.Text = n.Content(src)
+		return node
 	}
-	for i := 0; i < int(n.ChildCount()); i++ {
-		child := n.Child(i)
+
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
 		if child == nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- clean up Java JSON AST generation
- convert only named tree-sitter nodes and store leaf text
- update cross_join.java.json with the new structure

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889cc46ab58832099e36d568f4a17a8