### PR TITLE
Refine Zig AST json output

### DIFF
--- a/tests/json-ast/x/zig/cross_join.zig.json
+++ b/tests/json-ast/x/zig/cross_join.zig.json
@@ -21,22 +21,10 @@
             "end": 90,
             "children": [
               {
-                "type": "const",
-                "start": 63,
-                "end": 68,
-                "text": "const"
-              },
-              {
                 "type": "IDENTIFIER",
                 "start": 69,
                 "end": 72,
                 "text": "std"
-              },
-              {
-                "type": "=",
-                "start": 73,
-                "end": 74,
-                "text": "="
               },
               {
                 "type": "ErrorUnionExpr",
@@ -52,26 +40,13 @@
                         "type": "BUILTINIDENTIFIER",
                         "start": 75,
                         "end": 82,
-                        "children": [
-                          {
-                            "type": "@",
-                            "start": 75,
-                            "end": 76,
-                            "text": "@"
-                          }
-                        ]
+                        "text": "@import"
                       },
                       {
                         "type": "FnCallArguments",
                         "start": 82,
                         "end": 89,
                         "children": [
-                          {
-                            "type": "(",
-                            "start": 82,
-                            "end": 83,
-                            "text": "("
-                          },
                           {
                             "type": "ErrorUnionExpr",
                             "start": 83,
@@ -86,42 +61,17 @@
                                     "type": "STRINGLITERALSINGLE",
                                     "start": 83,
                                     "end": 88,
-                                    "children": [
-                                      {
-                                        "type": "\"",
-                                        "start": 83,
-                                        "end": 84,
-                                        "text": "\""
-                                      },
-                                      {
-                                        "type": "\"",
-                                        "start": 87,
-                                        "end": 88,
-                                        "text": "\""
-                                      }
-                                    ]
+                                    "text": "\"std\""
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ")",
-                            "start": 88,
-                            "end": 89,
-                            "text": ")"
                           }
                         ]
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "type": ";",
-                "start": 89,
-                "end": 90,
-                "text": ";"
               }
             ]
           }
@@ -138,22 +88,10 @@
             "end": 155,
             "children": [
               {
-                "type": "const",
-                "start": 92,
-                "end": 97,
-                "text": "const"
-              },
-              {
                 "type": "IDENTIFIER",
                 "start": 98,
                 "end": 106,
                 "text": "Customer"
-              },
-              {
-                "type": "=",
-                "start": 107,
-                "end": 108,
-                "text": "="
               },
               {
                 "type": "ErrorUnionExpr",
@@ -174,20 +112,7 @@
                             "type": "ContainerDeclType",
                             "start": 109,
                             "end": 115,
-                            "children": [
-                              {
-                                "type": "struct",
-                                "start": 109,
-                                "end": 115,
-                                "text": "struct"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "{",
-                            "start": 116,
-                            "end": 117,
-                            "text": "{"
+                            "text": "struct"
                           },
                           {
                             "type": "ContainerField",
@@ -199,12 +124,6 @@
                                 "start": 122,
                                 "end": 124,
                                 "text": "id"
-                              },
-                              {
-                                "type": ":",
-                                "start": 124,
-                                "end": 125,
-                                "text": ":"
                               },
                               {
                                 "type": "ErrorUnionExpr",
@@ -229,12 +148,6 @@
                             ]
                           },
                           {
-                            "type": ",",
-                            "start": 129,
-                            "end": 130,
-                            "text": ","
-                          },
-                          {
                             "type": "ContainerField",
                             "start": 135,
                             "end": 151,
@@ -246,12 +159,6 @@
                                 "text": "name"
                               },
                               {
-                                "type": ":",
-                                "start": 139,
-                                "end": 140,
-                                "text": ":"
-                              },
-                              {
                                 "type": "PrefixTypeOp",
                                 "start": 141,
                                 "end": 148,
@@ -260,26 +167,7 @@
                                     "type": "SliceTypeStart",
                                     "start": 141,
                                     "end": 143,
-                                    "children": [
-                                      {
-                                        "type": "[",
-                                        "start": 141,
-                                        "end": 142,
-                                        "text": "["
-                                      },
-                                      {
-                                        "type": "]",
-                                        "start": 142,
-                                        "end": 143,
-                                        "text": "]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "const",
-                                    "start": 143,
-                                    "end": 148,
-                                    "text": "const"
+                                    "text": "[]"
                                   }
                                 ]
                               },
@@ -304,30 +192,12 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 151,
-                            "end": 152,
-                            "text": ","
-                          },
-                          {
-                            "type": "}",
-                            "start": 153,
-                            "end": 154,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "type": ";",
-                "start": 154,
-                "end": 155,
-                "text": ";"
               }
             ]
           }
@@ -344,22 +214,10 @@
             "end": 289,
             "children": [
               {
-                "type": "const",
-                "start": 157,
-                "end": 162,
-                "text": "const"
-              },
-              {
                 "type": "IDENTIFIER",
                 "start": 163,
                 "end": 168,
                 "text": "Entry"
-              },
-              {
-                "type": "=",
-                "start": 169,
-                "end": 170,
-                "text": "="
               },
               {
                 "type": "ErrorUnionExpr",
@@ -380,20 +238,7 @@
                             "type": "ContainerDeclType",
                             "start": 171,
                             "end": 177,
-                            "children": [
-                              {
-                                "type": "struct",
-                                "start": 171,
-                                "end": 177,
-                                "text": "struct"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "{",
-                            "start": 178,
-                            "end": 179,
-                            "text": "{"
+                            "text": "struct"
                           },
                           {
                             "type": "ContainerField",
@@ -405,12 +250,6 @@
                                 "start": 184,
                                 "end": 192,
                                 "text": "order_id"
-                              },
-                              {
-                                "type": ":",
-                                "start": 192,
-                                "end": 193,
-                                "text": ":"
                               },
                               {
                                 "type": "ErrorUnionExpr",
@@ -435,12 +274,6 @@
                             ]
                           },
                           {
-                            "type": ",",
-                            "start": 197,
-                            "end": 198,
-                            "text": ","
-                          },
-                          {
                             "type": "ContainerField",
                             "start": 203,
                             "end": 225,
@@ -450,12 +283,6 @@
                                 "start": 203,
                                 "end": 220,
                                 "text": "order_customer_id"
-                              },
-                              {
-                                "type": ":",
-                                "start": 220,
-                                "end": 221,
-                                "text": ":"
                               },
                               {
                                 "type": "ErrorUnionExpr",
@@ -480,12 +307,6 @@
                             ]
                           },
                           {
-                            "type": ",",
-                            "start": 225,
-                            "end": 226,
-                            "text": ","
-                          },
-                          {
                             "type": "ContainerField",
                             "start": 231,
                             "end": 263,
@@ -497,12 +318,6 @@
                                 "text": "paired_customer_name"
                               },
                               {
-                                "type": ":",
-                                "start": 251,
-                                "end": 252,
-                                "text": ":"
-                              },
-                              {
                                 "type": "PrefixTypeOp",
                                 "start": 253,
                                 "end": 260,
@@ -511,26 +326,7 @@
                                     "type": "SliceTypeStart",
                                     "start": 253,
                                     "end": 255,
-                                    "children": [
-                                      {
-                                        "type": "[",
-                                        "start": 253,
-                                        "end": 254,
-                                        "text": "["
-                                      },
-                                      {
-                                        "type": "]",
-                                        "start": 254,
-                                        "end": 255,
-                                        "text": "]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "const",
-                                    "start": 255,
-                                    "end": 260,
-                                    "text": "const"
+                                    "text": "[]"
                                   }
                                 ]
                               },
@@ -557,12 +353,6 @@
                             ]
                           },
                           {
-                            "type": ",",
-                            "start": 263,
-                            "end": 264,
-                            "text": ","
-                          },
-                          {
                             "type": "ContainerField",
                             "start": 269,
                             "end": 285,
@@ -572,12 +362,6 @@
                                 "start": 269,
                                 "end": 280,
                                 "text": "order_total"
-                              },
-                              {
-                                "type": ":",
-                                "start": 280,
-                                "end": 281,
-                                "text": ":"
                               },
                               {
                                 "type": "ErrorUnionExpr",
@@ -600,40 +384,16 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 285,
-                            "end": 286,
-                            "text": ","
-                          },
-                          {
-                            "type": "}",
-                            "start": 287,
-                            "end": 288,
-                            "text": "}"
                           }
                         ]
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "type": ";",
-                "start": 288,
-                "end": 289,
-                "text": ";"
               }
             ]
           }
         ]
-      },
-      {
-        "type": "pub",
-        "start": 291,
-        "end": 294,
-        "text": "pub"
       },
       {
         "type": "TopLevelDecl",
@@ -646,12 +406,6 @@
             "end": 309,
             "children": [
               {
-                "type": "fn",
-                "start": 295,
-                "end": 297,
-                "text": "fn"
-              },
-              {
                 "type": "IDENTIFIER",
                 "start": 298,
                 "end": 302,
@@ -661,20 +415,7 @@
                 "type": "ParamDeclList",
                 "start": 302,
                 "end": 304,
-                "children": [
-                  {
-                    "type": "(",
-                    "start": 302,
-                    "end": 303,
-                    "text": "("
-                  },
-                  {
-                    "type": ")",
-                    "start": 303,
-                    "end": 304,
-                    "text": ")"
-                  }
-                ]
+                "text": "()"
               },
               {
                 "type": "ErrorUnionExpr",
@@ -704,12 +445,6 @@
             "end": 1886,
             "children": [
               {
-                "type": "{",
-                "start": 310,
-                "end": 311,
-                "text": "{"
-              },
-              {
                 "type": "Statement",
                 "start": 316,
                 "end": 452,
@@ -720,22 +455,10 @@
                     "end": 452,
                     "children": [
                       {
-                        "type": "const",
-                        "start": 316,
-                        "end": 321,
-                        "text": "const"
-                      },
-                      {
                         "type": "IDENTIFIER",
                         "start": 322,
                         "end": 331,
                         "text": "customers"
-                      },
-                      {
-                        "type": ":",
-                        "start": 331,
-                        "end": 332,
-                        "text": ":"
                       },
                       {
                         "type": "PrefixTypeOp",
@@ -747,12 +470,6 @@
                             "start": 333,
                             "end": 336,
                             "children": [
-                              {
-                                "type": "[",
-                                "start": 333,
-                                "end": 334,
-                                "text": "["
-                              },
                               {
                                 "type": "ErrorUnionExpr",
                                 "start": 334,
@@ -772,12 +489,6 @@
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "type": "]",
-                                "start": 335,
-                                "end": 336,
-                                "text": "]"
                               }
                             ]
                           }
@@ -804,12 +515,6 @@
                         ]
                       },
                       {
-                        "type": "=",
-                        "start": 345,
-                        "end": 346,
-                        "text": "="
-                      },
-                      {
                         "type": "PrefixTypeOp",
                         "start": 347,
                         "end": 350,
@@ -819,12 +524,6 @@
                             "start": 347,
                             "end": 350,
                             "children": [
-                              {
-                                "type": "[",
-                                "start": 347,
-                                "end": 348,
-                                "text": "["
-                              },
                               {
                                 "type": "ErrorUnionExpr",
                                 "start": 348,
@@ -844,12 +543,6 @@
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "type": "]",
-                                "start": 349,
-                                "end": 350,
-                                "text": "]"
                               }
                             ]
                           }
@@ -881,12 +574,6 @@
                         "end": 451,
                         "children": [
                           {
-                            "type": "{",
-                            "start": 358,
-                            "end": 359,
-                            "text": "{"
-                          },
-                          {
                             "type": "ErrorUnionExpr",
                             "start": 359,
                             "end": 388,
@@ -897,44 +584,20 @@
                                 "end": 388,
                                 "children": [
                                   {
-                                    "type": ".",
-                                    "start": 359,
-                                    "end": 360,
-                                    "text": "."
-                                  },
-                                  {
                                     "type": "InitList",
                                     "start": 360,
                                     "end": 388,
                                     "children": [
-                                      {
-                                        "type": "{",
-                                        "start": 360,
-                                        "end": 361,
-                                        "text": "{"
-                                      },
                                       {
                                         "type": "FieldInit",
                                         "start": 362,
                                         "end": 369,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 362,
-                                            "end": 363,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 363,
                                             "end": 365,
                                             "text": "id"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 366,
-                                            "end": 367,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -959,33 +622,15 @@
                                         ]
                                       },
                                       {
-                                        "type": ",",
-                                        "start": 369,
-                                        "end": 370,
-                                        "text": ","
-                                      },
-                                      {
                                         "type": "FieldInit",
                                         "start": 371,
                                         "end": 386,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 371,
-                                            "end": 372,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 372,
                                             "end": 376,
                                             "text": "name"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 377,
-                                            "end": 378,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -1001,44 +646,19 @@
                                                     "type": "STRINGLITERALSINGLE",
                                                     "start": 379,
                                                     "end": 386,
-                                                    "children": [
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 379,
-                                                        "end": 380,
-                                                        "text": "\""
-                                                      },
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 385,
-                                                        "end": 386,
-                                                        "text": "\""
-                                                      }
-                                                    ]
+                                                    "text": "\"Alice\""
                                                   }
                                                 ]
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "}",
-                                        "start": 387,
-                                        "end": 388,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 388,
-                            "end": 389,
-                            "text": ","
                           },
                           {
                             "type": "ErrorUnionExpr",
@@ -1051,44 +671,20 @@
                                 "end": 417,
                                 "children": [
                                   {
-                                    "type": ".",
-                                    "start": 390,
-                                    "end": 391,
-                                    "text": "."
-                                  },
-                                  {
                                     "type": "InitList",
                                     "start": 391,
                                     "end": 417,
                                     "children": [
-                                      {
-                                        "type": "{",
-                                        "start": 391,
-                                        "end": 392,
-                                        "text": "{"
-                                      },
                                       {
                                         "type": "FieldInit",
                                         "start": 393,
                                         "end": 400,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 393,
-                                            "end": 394,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 394,
                                             "end": 396,
                                             "text": "id"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 397,
-                                            "end": 398,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -1113,33 +709,15 @@
                                         ]
                                       },
                                       {
-                                        "type": ",",
-                                        "start": 400,
-                                        "end": 401,
-                                        "text": ","
-                                      },
-                                      {
                                         "type": "FieldInit",
                                         "start": 402,
                                         "end": 415,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 402,
-                                            "end": 403,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 403,
                                             "end": 407,
                                             "text": "name"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 408,
-                                            "end": 409,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -1155,44 +733,19 @@
                                                     "type": "STRINGLITERALSINGLE",
                                                     "start": 410,
                                                     "end": 415,
-                                                    "children": [
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 410,
-                                                        "end": 411,
-                                                        "text": "\""
-                                                      },
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 414,
-                                                        "end": 415,
-                                                        "text": "\""
-                                                      }
-                                                    ]
+                                                    "text": "\"Bob\""
                                                   }
                                                 ]
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "}",
-                                        "start": 416,
-                                        "end": 417,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 417,
-                            "end": 418,
-                            "text": ","
                           },
                           {
                             "type": "ErrorUnionExpr",
@@ -1205,44 +758,20 @@
                                 "end": 450,
                                 "children": [
                                   {
-                                    "type": ".",
-                                    "start": 419,
-                                    "end": 420,
-                                    "text": "."
-                                  },
-                                  {
                                     "type": "InitList",
                                     "start": 420,
                                     "end": 450,
                                     "children": [
-                                      {
-                                        "type": "{",
-                                        "start": 420,
-                                        "end": 421,
-                                        "text": "{"
-                                      },
                                       {
                                         "type": "FieldInit",
                                         "start": 422,
                                         "end": 429,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 422,
-                                            "end": 423,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 423,
                                             "end": 425,
                                             "text": "id"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 426,
-                                            "end": 427,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -1267,33 +796,15 @@
                                         ]
                                       },
                                       {
-                                        "type": ",",
-                                        "start": 429,
-                                        "end": 430,
-                                        "text": ","
-                                      },
-                                      {
                                         "type": "FieldInit",
                                         "start": 431,
                                         "end": 448,
                                         "children": [
                                           {
-                                            "type": ".",
-                                            "start": 431,
-                                            "end": 432,
-                                            "text": "."
-                                          },
-                                          {
                                             "type": "IDENTIFIER",
                                             "start": 432,
                                             "end": 436,
                                             "text": "name"
-                                          },
-                                          {
-                                            "type": "=",
-                                            "start": 437,
-                                            "end": 438,
-                                            "text": "="
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -1309,52 +820,21 @@
                                                     "type": "STRINGLITERALSINGLE",
                                                     "start": 439,
                                                     "end": 448,
-                                                    "children": [
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 439,
-                                                        "end": 440,
-                                                        "text": "\""
-                                                      },
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 447,
-                                                        "end": 448,
-                                                        "text": "\""
-                                                      }
-                                                    ]
+                                                    "text": "\"Charlie\""
                                                   }
                                                 ]
                                               }
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "}",
-                                        "start": 449,
-                                        "end": 450,
-                                        "text": "}"
                                       }
                                     ]
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": "}",
-                            "start": 450,
-                            "end": 451,
-                            "text": "}"
                           }
                         ]
-                      },
-                      {
-                        "type": ";",
-                        "start": 451,
-                        "end": 452,
-                        "text": ";"
                       }
                     ]
                   }
@@ -1371,22 +851,10 @@
                     "end": 1107,
                     "children": [
                       {
-                        "type": "const",
-                        "start": 457,
-                        "end": 462,
-                        "text": "const"
-                      },
-                      {
                         "type": "IDENTIFIER",
                         "start": 463,
                         "end": 469,
                         "text": "orders"
-                      },
-                      {
-                        "type": "=",
-                        "start": 470,
-                        "end": 471,
-                        "text": "="
                       },
                       {
                         "type": "PrefixTypeOp",
@@ -1398,12 +866,6 @@
                             "start": 472,
                             "end": 475,
                             "children": [
-                              {
-                                "type": "[",
-                                "start": 472,
-                                "end": 473,
-                                "text": "["
-                              },
                               {
                                 "type": "ErrorUnionExpr",
                                 "start": 473,
@@ -1423,12 +885,6 @@
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "type": "]",
-                                "start": 474,
-                                "end": 475,
-                                "text": "]"
                               }
                             ]
                           }
@@ -1456,12 +912,6 @@
                                 "end": 497,
                                 "children": [
                                   {
-                                    "type": ".",
-                                    "start": 478,
-                                    "end": 479,
-                                    "text": "."
-                                  },
-                                  {
                                     "type": "IDENTIFIER",
                                     "start": 479,
                                     "end": 492,
@@ -1472,12 +922,6 @@
                                     "start": 492,
                                     "end": 497,
                                     "children": [
-                                      {
-                                        "type": "(",
-                                        "start": 492,
-                                        "end": 493,
-                                        "text": "("
-                                      },
                                       {
                                         "type": "ErrorUnionExpr",
                                         "start": 493,
@@ -1497,12 +941,6 @@
                                             ]
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": ")",
-                                        "start": 496,
-                                        "end": 497,
-                                        "text": ")"
                                       }
                                     ]
                                   }
@@ -1517,12 +955,6 @@
                         "start": 497,
                         "end": 1106,
                         "children": [
-                          {
-                            "type": "{",
-                            "start": 497,
-                            "end": 498,
-                            "text": "{"
-                          },
                           {
                             "type": "ErrorUnionExpr",
                             "start": 498,
@@ -1548,12 +980,6 @@
                                             "start": 498,
                                             "end": 501,
                                             "text": "blk"
-                                          },
-                                          {
-                                            "type": ":",
-                                            "start": 501,
-                                            "end": 502,
-                                            "text": ":"
                                           }
                                         ]
                                       },
@@ -1562,12 +988,6 @@
                                         "start": 503,
                                         "end": 699,
                                         "children": [
-                                          {
-                                            "type": "{",
-                                            "start": 503,
-                                            "end": 504,
-                                            "text": "{"
-                                          },
                                           {
                                             "type": "Statement",
                                             "start": 505,
@@ -1579,22 +999,10 @@
                                                 "end": 566,
                                                 "children": [
                                                   {
-                                                    "type": "var",
-                                                    "start": 505,
-                                                    "end": 508,
-                                                    "text": "var"
-                                                  },
-                                                  {
                                                     "type": "IDENTIFIER",
                                                     "start": 509,
                                                     "end": 510,
                                                     "text": "m"
-                                                  },
-                                                  {
-                                                    "type": "=",
-                                                    "start": 511,
-                                                    "end": 512,
-                                                    "text": "="
                                                   },
                                                   {
                                                     "type": "ErrorUnionExpr",
@@ -1618,12 +1026,6 @@
                                                             "end": 535,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 516,
-                                                                "end": 517,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 517,
                                                                 "end": 530,
@@ -1634,12 +1036,6 @@
                                                                 "start": 530,
                                                                 "end": 535,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 530,
-                                                                    "end": 531,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 531,
@@ -1659,12 +1055,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 534,
-                                                                    "end": 535,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -1676,12 +1066,6 @@
                                                             "end": 565,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 535,
-                                                                "end": 536,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 536,
                                                                 "end": 540,
@@ -1692,12 +1076,6 @@
                                                                 "start": 540,
                                                                 "end": 565,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 540,
-                                                                    "end": 541,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 541,
@@ -1720,12 +1098,6 @@
                                                                             "end": 549,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 544,
-                                                                                "end": 545,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 545,
                                                                                 "end": 549,
@@ -1739,12 +1111,6 @@
                                                                             "end": 564,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 549,
-                                                                                "end": 550,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 550,
                                                                                 "end": 564,
@@ -1755,12 +1121,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 564,
-                                                                    "end": 565,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -1769,12 +1129,6 @@
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "type": ";",
-                                                    "start": 565,
-                                                    "end": 566,
-                                                    "text": ";"
                                                   }
                                                 ]
                                               }
@@ -1817,12 +1171,6 @@
                                                                 "end": 583,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 568,
-                                                                    "end": 569,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 569,
                                                                     "end": 572,
@@ -1833,12 +1181,6 @@
                                                                     "start": 572,
                                                                     "end": 583,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 572,
-                                                                        "end": 573,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 573,
@@ -1853,30 +1195,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 573,
                                                                                 "end": 577,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 573,
-                                                                                    "end": 574,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 576,
-                                                                                    "end": 577,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"id\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 577,
-                                                                        "end": 578,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -1897,12 +1220,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 582,
-                                                                        "end": 583,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -1916,14 +1233,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 584,
                                                         "end": 589,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 584,
-                                                            "end": 589,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -1934,26 +1244,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 590,
                                                             "end": 601,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 590,
-                                                                "end": 601,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 601,
-                                                "end": 602,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -1994,12 +1291,6 @@
                                                                 "end": 625,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 604,
-                                                                    "end": 605,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 605,
                                                                     "end": 608,
@@ -2010,12 +1301,6 @@
                                                                     "start": 608,
                                                                     "end": 625,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 608,
-                                                                        "end": 609,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 609,
@@ -2030,30 +1315,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 609,
                                                                                 "end": 621,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 609,
-                                                                                    "end": 610,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 620,
-                                                                                    "end": 621,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"customerId\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 621,
-                                                                        "end": 622,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -2074,12 +1340,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 624,
-                                                                        "end": 625,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -2093,14 +1353,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 626,
                                                         "end": 631,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 626,
-                                                            "end": 631,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -2111,26 +1364,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 632,
                                                             "end": 643,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 632,
-                                                                "end": 643,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 643,
-                                                "end": 644,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -2171,12 +1411,6 @@
                                                                 "end": 664,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 646,
-                                                                    "end": 647,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 647,
                                                                     "end": 650,
@@ -2187,12 +1421,6 @@
                                                                     "start": 650,
                                                                     "end": 664,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 650,
-                                                                        "end": 651,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 651,
@@ -2207,30 +1435,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 651,
                                                                                 "end": 658,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 651,
-                                                                                    "end": 652,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 657,
-                                                                                    "end": 658,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"total\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 658,
-                                                                        "end": 659,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -2251,12 +1460,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 663,
-                                                                        "end": 664,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -2270,14 +1473,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 665,
                                                         "end": 670,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 665,
-                                                            "end": 670,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -2288,26 +1484,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 671,
                                                             "end": 682,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 671,
-                                                                "end": 682,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 682,
-                                                "end": 683,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -2322,22 +1505,10 @@
                                                 "end": 696,
                                                 "children": [
                                                   {
-                                                    "type": "break",
-                                                    "start": 684,
-                                                    "end": 689,
-                                                    "text": "break"
-                                                  },
-                                                  {
                                                     "type": "BreakLabel",
                                                     "start": 690,
                                                     "end": 694,
                                                     "children": [
-                                                      {
-                                                        "type": ":",
-                                                        "start": 690,
-                                                        "end": 691,
-                                                        "text": ":"
-                                                      },
                                                       {
                                                         "type": "IDENTIFIER",
                                                         "start": 691,
@@ -2367,20 +1538,8 @@
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 696,
-                                                "end": 697,
-                                                "text": ";"
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": "}",
-                                            "start": 698,
-                                            "end": 699,
-                                            "text": "}"
                                           }
                                         ]
                                       }
@@ -2389,12 +1548,6 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 699,
-                            "end": 700,
-                            "text": ","
                           },
                           {
                             "type": "ErrorUnionExpr",
@@ -2421,12 +1574,6 @@
                                             "start": 701,
                                             "end": 704,
                                             "text": "blk"
-                                          },
-                                          {
-                                            "type": ":",
-                                            "start": 704,
-                                            "end": 705,
-                                            "text": ":"
                                           }
                                         ]
                                       },
@@ -2435,12 +1582,6 @@
                                         "start": 706,
                                         "end": 902,
                                         "children": [
-                                          {
-                                            "type": "{",
-                                            "start": 706,
-                                            "end": 707,
-                                            "text": "{"
-                                          },
                                           {
                                             "type": "Statement",
                                             "start": 708,
@@ -2452,22 +1593,10 @@
                                                 "end": 769,
                                                 "children": [
                                                   {
-                                                    "type": "var",
-                                                    "start": 708,
-                                                    "end": 711,
-                                                    "text": "var"
-                                                  },
-                                                  {
                                                     "type": "IDENTIFIER",
                                                     "start": 712,
                                                     "end": 713,
                                                     "text": "m"
-                                                  },
-                                                  {
-                                                    "type": "=",
-                                                    "start": 714,
-                                                    "end": 715,
-                                                    "text": "="
                                                   },
                                                   {
                                                     "type": "ErrorUnionExpr",
@@ -2491,12 +1620,6 @@
                                                             "end": 738,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 719,
-                                                                "end": 720,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 720,
                                                                 "end": 733,
@@ -2507,12 +1630,6 @@
                                                                 "start": 733,
                                                                 "end": 738,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 733,
-                                                                    "end": 734,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 734,
@@ -2532,12 +1649,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 737,
-                                                                    "end": 738,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -2549,12 +1660,6 @@
                                                             "end": 768,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 738,
-                                                                "end": 739,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 739,
                                                                 "end": 743,
@@ -2565,12 +1670,6 @@
                                                                 "start": 743,
                                                                 "end": 768,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 743,
-                                                                    "end": 744,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 744,
@@ -2593,12 +1692,6 @@
                                                                             "end": 752,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 747,
-                                                                                "end": 748,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 748,
                                                                                 "end": 752,
@@ -2612,12 +1705,6 @@
                                                                             "end": 767,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 752,
-                                                                                "end": 753,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 753,
                                                                                 "end": 767,
@@ -2628,12 +1715,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 767,
-                                                                    "end": 768,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -2642,12 +1723,6 @@
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "type": ";",
-                                                    "start": 768,
-                                                    "end": 769,
-                                                    "text": ";"
                                                   }
                                                 ]
                                               }
@@ -2690,12 +1765,6 @@
                                                                 "end": 786,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 771,
-                                                                    "end": 772,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 772,
                                                                     "end": 775,
@@ -2706,12 +1775,6 @@
                                                                     "start": 775,
                                                                     "end": 786,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 775,
-                                                                        "end": 776,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 776,
@@ -2726,30 +1789,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 776,
                                                                                 "end": 780,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 776,
-                                                                                    "end": 777,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 779,
-                                                                                    "end": 780,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"id\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 780,
-                                                                        "end": 781,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -2770,12 +1814,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 785,
-                                                                        "end": 786,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -2789,14 +1827,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 787,
                                                         "end": 792,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 787,
-                                                            "end": 792,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -2807,26 +1838,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 793,
                                                             "end": 804,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 793,
-                                                                "end": 804,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 804,
-                                                "end": 805,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -2867,12 +1885,6 @@
                                                                 "end": 828,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 807,
-                                                                    "end": 808,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 808,
                                                                     "end": 811,
@@ -2883,12 +1895,6 @@
                                                                     "start": 811,
                                                                     "end": 828,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 811,
-                                                                        "end": 812,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 812,
@@ -2903,30 +1909,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 812,
                                                                                 "end": 824,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 812,
-                                                                                    "end": 813,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 823,
-                                                                                    "end": 824,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"customerId\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 824,
-                                                                        "end": 825,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -2947,12 +1934,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 827,
-                                                                        "end": 828,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -2966,14 +1947,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 829,
                                                         "end": 834,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 829,
-                                                            "end": 834,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -2984,26 +1958,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 835,
                                                             "end": 846,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 835,
-                                                                "end": 846,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 846,
-                                                "end": 847,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -3044,12 +2005,6 @@
                                                                 "end": 867,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 849,
-                                                                    "end": 850,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 850,
                                                                     "end": 853,
@@ -3060,12 +2015,6 @@
                                                                     "start": 853,
                                                                     "end": 867,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 853,
-                                                                        "end": 854,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 854,
@@ -3080,30 +2029,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 854,
                                                                                 "end": 861,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 854,
-                                                                                    "end": 855,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 860,
-                                                                                    "end": 861,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"total\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 861,
-                                                                        "end": 862,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -3124,12 +2054,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 866,
-                                                                        "end": 867,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -3143,14 +2067,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 868,
                                                         "end": 873,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 868,
-                                                            "end": 873,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -3161,26 +2078,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 874,
                                                             "end": 885,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 874,
-                                                                "end": 885,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 885,
-                                                "end": 886,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -3195,22 +2099,10 @@
                                                 "end": 899,
                                                 "children": [
                                                   {
-                                                    "type": "break",
-                                                    "start": 887,
-                                                    "end": 892,
-                                                    "text": "break"
-                                                  },
-                                                  {
                                                     "type": "BreakLabel",
                                                     "start": 893,
                                                     "end": 897,
                                                     "children": [
-                                                      {
-                                                        "type": ":",
-                                                        "start": 893,
-                                                        "end": 894,
-                                                        "text": ":"
-                                                      },
                                                       {
                                                         "type": "IDENTIFIER",
                                                         "start": 894,
@@ -3240,20 +2132,8 @@
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 899,
-                                                "end": 900,
-                                                "text": ";"
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": "}",
-                                            "start": 901,
-                                            "end": 902,
-                                            "text": "}"
                                           }
                                         ]
                                       }
@@ -3262,12 +2142,6 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": ",",
-                            "start": 902,
-                            "end": 903,
-                            "text": ","
                           },
                           {
                             "type": "ErrorUnionExpr",
@@ -3294,12 +2168,6 @@
                                             "start": 904,
                                             "end": 907,
                                             "text": "blk"
-                                          },
-                                          {
-                                            "type": ":",
-                                            "start": 907,
-                                            "end": 908,
-                                            "text": ":"
                                           }
                                         ]
                                       },
@@ -3308,12 +2176,6 @@
                                         "start": 909,
                                         "end": 1105,
                                         "children": [
-                                          {
-                                            "type": "{",
-                                            "start": 909,
-                                            "end": 910,
-                                            "text": "{"
-                                          },
                                           {
                                             "type": "Statement",
                                             "start": 911,
@@ -3325,22 +2187,10 @@
                                                 "end": 972,
                                                 "children": [
                                                   {
-                                                    "type": "var",
-                                                    "start": 911,
-                                                    "end": 914,
-                                                    "text": "var"
-                                                  },
-                                                  {
                                                     "type": "IDENTIFIER",
                                                     "start": 915,
                                                     "end": 916,
                                                     "text": "m"
-                                                  },
-                                                  {
-                                                    "type": "=",
-                                                    "start": 917,
-                                                    "end": 918,
-                                                    "text": "="
                                                   },
                                                   {
                                                     "type": "ErrorUnionExpr",
@@ -3364,12 +2214,6 @@
                                                             "end": 941,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 922,
-                                                                "end": 923,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 923,
                                                                 "end": 936,
@@ -3380,12 +2224,6 @@
                                                                 "start": 936,
                                                                 "end": 941,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 936,
-                                                                    "end": 937,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 937,
@@ -3405,12 +2243,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 940,
-                                                                    "end": 941,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -3422,12 +2254,6 @@
                                                             "end": 971,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 941,
-                                                                "end": 942,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 942,
                                                                 "end": 946,
@@ -3438,12 +2264,6 @@
                                                                 "start": 946,
                                                                 "end": 971,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 946,
-                                                                    "end": 947,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 947,
@@ -3466,12 +2286,6 @@
                                                                             "end": 955,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 950,
-                                                                                "end": 951,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 951,
                                                                                 "end": 955,
@@ -3485,12 +2299,6 @@
                                                                             "end": 970,
                                                                             "children": [
                                                                               {
-                                                                                "type": ".",
-                                                                                "start": 955,
-                                                                                "end": 956,
-                                                                                "text": "."
-                                                                              },
-                                                                              {
                                                                                 "type": "IDENTIFIER",
                                                                                 "start": 956,
                                                                                 "end": 970,
@@ -3501,12 +2309,6 @@
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 970,
-                                                                    "end": 971,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -3515,12 +2317,6 @@
                                                         ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "type": ";",
-                                                    "start": 971,
-                                                    "end": 972,
-                                                    "text": ";"
                                                   }
                                                 ]
                                               }
@@ -3563,12 +2359,6 @@
                                                                 "end": 989,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 974,
-                                                                    "end": 975,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 975,
                                                                     "end": 978,
@@ -3579,12 +2369,6 @@
                                                                     "start": 978,
                                                                     "end": 989,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 978,
-                                                                        "end": 979,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 979,
@@ -3599,30 +2383,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 979,
                                                                                 "end": 983,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 979,
-                                                                                    "end": 980,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 982,
-                                                                                    "end": 983,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"id\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 983,
-                                                                        "end": 984,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -3643,12 +2408,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 988,
-                                                                        "end": 989,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -3662,14 +2421,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 990,
                                                         "end": 995,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 990,
-                                                            "end": 995,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -3680,26 +2432,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 996,
                                                             "end": 1007,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 996,
-                                                                "end": 1007,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1007,
-                                                "end": 1008,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -3740,12 +2479,6 @@
                                                                 "end": 1031,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 1010,
-                                                                    "end": 1011,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 1011,
                                                                     "end": 1014,
@@ -3756,12 +2489,6 @@
                                                                     "start": 1014,
                                                                     "end": 1031,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 1014,
-                                                                        "end": 1015,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 1015,
@@ -3776,30 +2503,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 1015,
                                                                                 "end": 1027,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 1015,
-                                                                                    "end": 1016,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 1026,
-                                                                                    "end": 1027,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"customerId\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 1027,
-                                                                        "end": 1028,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -3820,12 +2528,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 1030,
-                                                                        "end": 1031,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -3839,14 +2541,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 1032,
                                                         "end": 1037,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 1032,
-                                                            "end": 1037,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -3857,26 +2552,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 1038,
                                                             "end": 1049,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 1038,
-                                                                "end": 1049,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1049,
-                                                "end": 1050,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -3917,12 +2599,6 @@
                                                                 "end": 1070,
                                                                 "children": [
                                                                   {
-                                                                    "type": ".",
-                                                                    "start": 1052,
-                                                                    "end": 1053,
-                                                                    "text": "."
-                                                                  },
-                                                                  {
                                                                     "type": "IDENTIFIER",
                                                                     "start": 1053,
                                                                     "end": 1056,
@@ -3933,12 +2609,6 @@
                                                                     "start": 1056,
                                                                     "end": 1070,
                                                                     "children": [
-                                                                      {
-                                                                        "type": "(",
-                                                                        "start": 1056,
-                                                                        "end": 1057,
-                                                                        "text": "("
-                                                                      },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
                                                                         "start": 1057,
@@ -3953,30 +2623,11 @@
                                                                                 "type": "STRINGLITERALSINGLE",
                                                                                 "start": 1057,
                                                                                 "end": 1064,
-                                                                                "children": [
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 1057,
-                                                                                    "end": 1058,
-                                                                                    "text": "\""
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "\"",
-                                                                                    "start": 1063,
-                                                                                    "end": 1064,
-                                                                                    "text": "\""
-                                                                                  }
-                                                                                ]
+                                                                                "text": "\"total\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ",",
-                                                                        "start": 1064,
-                                                                        "end": 1065,
-                                                                        "text": ","
                                                                       },
                                                                       {
                                                                         "type": "ErrorUnionExpr",
@@ -3997,12 +2648,6 @@
                                                                             ]
                                                                           }
                                                                         ]
-                                                                      },
-                                                                      {
-                                                                        "type": ")",
-                                                                        "start": 1069,
-                                                                        "end": 1070,
-                                                                        "text": ")"
                                                                       }
                                                                     ]
                                                                   }
@@ -4016,14 +2661,7 @@
                                                         "type": "BitwiseOp",
                                                         "start": 1071,
                                                         "end": 1076,
-                                                        "children": [
-                                                          {
-                                                            "type": "catch",
-                                                            "start": 1071,
-                                                            "end": 1076,
-                                                            "text": "catch"
-                                                          }
-                                                        ]
+                                                        "text": "catch"
                                                       },
                                                       {
                                                         "type": "ErrorUnionExpr",
@@ -4034,26 +2672,13 @@
                                                             "type": "SuffixExpr",
                                                             "start": 1077,
                                                             "end": 1088,
-                                                            "children": [
-                                                              {
-                                                                "type": "unreachable",
-                                                                "start": 1077,
-                                                                "end": 1088,
-                                                                "text": "unreachable"
-                                                              }
-                                                            ]
+                                                            "text": "unreachable"
                                                           }
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1088,
-                                                "end": 1089,
-                                                "text": ";"
                                               }
                                             ]
                                           },
@@ -4068,22 +2693,10 @@
                                                 "end": 1102,
                                                 "children": [
                                                   {
-                                                    "type": "break",
-                                                    "start": 1090,
-                                                    "end": 1095,
-                                                    "text": "break"
-                                                  },
-                                                  {
                                                     "type": "BreakLabel",
                                                     "start": 1096,
                                                     "end": 1100,
                                                     "children": [
-                                                      {
-                                                        "type": ":",
-                                                        "start": 1096,
-                                                        "end": 1097,
-                                                        "text": ":"
-                                                      },
                                                       {
                                                         "type": "IDENTIFIER",
                                                         "start": 1097,
@@ -4113,20 +2726,8 @@
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1102,
-                                                "end": 1103,
-                                                "text": ";"
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": "}",
-                                            "start": 1104,
-                                            "end": 1105,
-                                            "text": "}"
                                           }
                                         ]
                                       }
@@ -4135,20 +2736,8 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "type": "}",
-                            "start": 1105,
-                            "end": 1106,
-                            "text": "}"
                           }
                         ]
-                      },
-                      {
-                        "type": ";",
-                        "start": 1106,
-                        "end": 1107,
-                        "text": ";"
                       }
                     ]
                   }
@@ -4165,22 +2754,10 @@
                     "end": 1509,
                     "children": [
                       {
-                        "type": "const",
-                        "start": 1112,
-                        "end": 1117,
-                        "text": "const"
-                      },
-                      {
                         "type": "IDENTIFIER",
                         "start": 1118,
                         "end": 1124,
                         "text": "result"
-                      },
-                      {
-                        "type": ":",
-                        "start": 1124,
-                        "end": 1125,
-                        "text": ":"
                       },
                       {
                         "type": "PrefixTypeOp",
@@ -4191,20 +2768,7 @@
                             "type": "SliceTypeStart",
                             "start": 1126,
                             "end": 1128,
-                            "children": [
-                              {
-                                "type": "[",
-                                "start": 1126,
-                                "end": 1127,
-                                "text": "["
-                              },
-                              {
-                                "type": "]",
-                                "start": 1127,
-                                "end": 1128,
-                                "text": "]"
-                              }
-                            ]
+                            "text": "[]"
                           }
                         ]
                       },
@@ -4227,12 +2791,6 @@
                             ]
                           }
                         ]
-                      },
-                      {
-                        "type": "=",
-                        "start": 1134,
-                        "end": 1135,
-                        "text": "="
                       },
                       {
                         "type": "ErrorUnionExpr",
@@ -4259,12 +2817,6 @@
                                         "start": 1136,
                                         "end": 1139,
                                         "text": "blk"
-                                      },
-                                      {
-                                        "type": ":",
-                                        "start": 1139,
-                                        "end": 1140,
-                                        "text": ":"
                                       }
                                     ]
                                   },
@@ -4273,12 +2825,6 @@
                                     "start": 1141,
                                     "end": 1508,
                                     "children": [
-                                      {
-                                        "type": "{",
-                                        "start": 1141,
-                                        "end": 1142,
-                                        "text": "{"
-                                      },
                                       {
                                         "type": "Statement",
                                         "start": 1147,
@@ -4290,22 +2836,10 @@
                                             "end": 1208,
                                             "children": [
                                               {
-                                                "type": "var",
-                                                "start": 1147,
-                                                "end": 1150,
-                                                "text": "var"
-                                              },
-                                              {
                                                 "type": "IDENTIFIER",
                                                 "start": 1151,
                                                 "end": 1154,
                                                 "text": "arr"
-                                              },
-                                              {
-                                                "type": "=",
-                                                "start": 1155,
-                                                "end": 1156,
-                                                "text": "="
                                               },
                                               {
                                                 "type": "ErrorUnionExpr",
@@ -4329,12 +2863,6 @@
                                                         "end": 1177,
                                                         "children": [
                                                           {
-                                                            "type": ".",
-                                                            "start": 1160,
-                                                            "end": 1161,
-                                                            "text": "."
-                                                          },
-                                                          {
                                                             "type": "IDENTIFIER",
                                                             "start": 1161,
                                                             "end": 1170,
@@ -4345,12 +2873,6 @@
                                                             "start": 1170,
                                                             "end": 1177,
                                                             "children": [
-                                                              {
-                                                                "type": "(",
-                                                                "start": 1170,
-                                                                "end": 1171,
-                                                                "text": "("
-                                                              },
                                                               {
                                                                 "type": "ErrorUnionExpr",
                                                                 "start": 1171,
@@ -4370,12 +2892,6 @@
                                                                     ]
                                                                   }
                                                                 ]
-                                                              },
-                                                              {
-                                                                "type": ")",
-                                                                "start": 1176,
-                                                                "end": 1177,
-                                                                "text": ")"
                                                               }
                                                             ]
                                                           }
@@ -4387,12 +2903,6 @@
                                                         "end": 1207,
                                                         "children": [
                                                           {
-                                                            "type": ".",
-                                                            "start": 1177,
-                                                            "end": 1178,
-                                                            "text": "."
-                                                          },
-                                                          {
                                                             "type": "IDENTIFIER",
                                                             "start": 1178,
                                                             "end": 1182,
@@ -4403,12 +2913,6 @@
                                                             "start": 1182,
                                                             "end": 1207,
                                                             "children": [
-                                                              {
-                                                                "type": "(",
-                                                                "start": 1182,
-                                                                "end": 1183,
-                                                                "text": "("
-                                                              },
                                                               {
                                                                 "type": "ErrorUnionExpr",
                                                                 "start": 1183,
@@ -4431,12 +2935,6 @@
                                                                         "end": 1191,
                                                                         "children": [
                                                                           {
-                                                                            "type": ".",
-                                                                            "start": 1186,
-                                                                            "end": 1187,
-                                                                            "text": "."
-                                                                          },
-                                                                          {
                                                                             "type": "IDENTIFIER",
                                                                             "start": 1187,
                                                                             "end": 1191,
@@ -4450,12 +2948,6 @@
                                                                         "end": 1206,
                                                                         "children": [
                                                                           {
-                                                                            "type": ".",
-                                                                            "start": 1191,
-                                                                            "end": 1192,
-                                                                            "text": "."
-                                                                          },
-                                                                          {
                                                                             "type": "IDENTIFIER",
                                                                             "start": 1192,
                                                                             "end": 1206,
@@ -4466,12 +2958,6 @@
                                                                     ]
                                                                   }
                                                                 ]
-                                                              },
-                                                              {
-                                                                "type": ")",
-                                                                "start": 1206,
-                                                                "end": 1207,
-                                                                "text": ")"
                                                               }
                                                             ]
                                                           }
@@ -4480,12 +2966,6 @@
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1207,
-                                                "end": 1208,
-                                                "text": ";"
                                               }
                                             ]
                                           }
@@ -4517,18 +2997,6 @@
                                                         "end": 1229,
                                                         "children": [
                                                           {
-                                                            "type": "for",
-                                                            "start": 1213,
-                                                            "end": 1216,
-                                                            "text": "for"
-                                                          },
-                                                          {
-                                                            "type": "(",
-                                                            "start": 1217,
-                                                            "end": 1218,
-                                                            "text": "("
-                                                          },
-                                                          {
                                                             "type": "ErrorUnionExpr",
                                                             "start": 1218,
                                                             "end": 1224,
@@ -4549,33 +3017,15 @@
                                                             ]
                                                           },
                                                           {
-                                                            "type": ")",
-                                                            "start": 1224,
-                                                            "end": 1225,
-                                                            "text": ")"
-                                                          },
-                                                          {
                                                             "type": "PtrIndexPayload",
                                                             "start": 1226,
                                                             "end": 1229,
                                                             "children": [
                                                               {
-                                                                "type": "|",
-                                                                "start": 1226,
-                                                                "end": 1227,
-                                                                "text": "|"
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1227,
                                                                 "end": 1228,
                                                                 "text": "o"
-                                                              },
-                                                              {
-                                                                "type": "|",
-                                                                "start": 1228,
-                                                                "end": 1229,
-                                                                "text": "|"
                                                               }
                                                             ]
                                                           }
@@ -4591,12 +3041,6 @@
                                                             "start": 1230,
                                                             "end": 1434,
                                                             "children": [
-                                                              {
-                                                                "type": "{",
-                                                                "start": 1230,
-                                                                "end": 1231,
-                                                                "text": "{"
-                                                              },
                                                               {
                                                                 "type": "Statement",
                                                                 "start": 1240,
@@ -4623,18 +3067,6 @@
                                                                                 "end": 1259,
                                                                                 "children": [
                                                                                   {
-                                                                                    "type": "for",
-                                                                                    "start": 1240,
-                                                                                    "end": 1243,
-                                                                                    "text": "for"
-                                                                                  },
-                                                                                  {
-                                                                                    "type": "(",
-                                                                                    "start": 1244,
-                                                                                    "end": 1245,
-                                                                                    "text": "("
-                                                                                  },
-                                                                                  {
                                                                                     "type": "ErrorUnionExpr",
                                                                                     "start": 1245,
                                                                                     "end": 1254,
@@ -4655,33 +3087,15 @@
                                                                                     ]
                                                                                   },
                                                                                   {
-                                                                                    "type": ")",
-                                                                                    "start": 1254,
-                                                                                    "end": 1255,
-                                                                                    "text": ")"
-                                                                                  },
-                                                                                  {
                                                                                     "type": "PtrIndexPayload",
                                                                                     "start": 1256,
                                                                                     "end": 1259,
                                                                                     "children": [
                                                                                       {
-                                                                                        "type": "|",
-                                                                                        "start": 1256,
-                                                                                        "end": 1257,
-                                                                                        "text": "|"
-                                                                                      },
-                                                                                      {
                                                                                         "type": "IDENTIFIER",
                                                                                         "start": 1257,
                                                                                         "end": 1258,
                                                                                         "text": "c"
-                                                                                      },
-                                                                                      {
-                                                                                        "type": "|",
-                                                                                        "start": 1258,
-                                                                                        "end": 1259,
-                                                                                        "text": "|"
                                                                                       }
                                                                                     ]
                                                                                   }
@@ -4697,12 +3111,6 @@
                                                                                     "start": 1260,
                                                                                     "end": 1428,
                                                                                     "children": [
-                                                                                      {
-                                                                                        "type": "{",
-                                                                                        "start": 1260,
-                                                                                        "end": 1261,
-                                                                                        "text": "{"
-                                                                                      },
                                                                                       {
                                                                                         "type": "Statement",
                                                                                         "start": 1274,
@@ -4740,12 +3148,6 @@
                                                                                                             "end": 1399,
                                                                                                             "children": [
                                                                                                               {
-                                                                                                                "type": ".",
-                                                                                                                "start": 1277,
-                                                                                                                "end": 1278,
-                                                                                                                "text": "."
-                                                                                                              },
-                                                                                                              {
                                                                                                                 "type": "IDENTIFIER",
                                                                                                                 "start": 1278,
                                                                                                                 "end": 1284,
@@ -4757,12 +3159,6 @@
                                                                                                                 "end": 1399,
                                                                                                                 "children": [
                                                                                                                   {
-                                                                                                                    "type": "(",
-                                                                                                                    "start": 1284,
-                                                                                                                    "end": 1285,
-                                                                                                                    "text": "("
-                                                                                                                  },
-                                                                                                                  {
                                                                                                                     "type": "ErrorUnionExpr",
                                                                                                                     "start": 1285,
                                                                                                                     "end": 1398,
@@ -4773,44 +3169,20 @@
                                                                                                                         "end": 1398,
                                                                                                                         "children": [
                                                                                                                           {
-                                                                                                                            "type": ".",
-                                                                                                                            "start": 1285,
-                                                                                                                            "end": 1286,
-                                                                                                                            "text": "."
-                                                                                                                          },
-                                                                                                                          {
                                                                                                                             "type": "InitList",
                                                                                                                             "start": 1286,
                                                                                                                             "end": 1398,
                                                                                                                             "children": [
-                                                                                                                              {
-                                                                                                                                "type": "{",
-                                                                                                                                "start": 1286,
-                                                                                                                                "end": 1287,
-                                                                                                                                "text": "{"
-                                                                                                                              },
                                                                                                                               {
                                                                                                                                 "type": "FieldInit",
                                                                                                                                 "start": 1288,
                                                                                                                                 "end": 1304,
                                                                                                                                 "children": [
                                                                                                                                   {
-                                                                                                                                    "type": ".",
-                                                                                                                                    "start": 1288,
-                                                                                                                                    "end": 1289,
-                                                                                                                                    "text": "."
-                                                                                                                                  },
-                                                                                                                                  {
                                                                                                                                     "type": "IDENTIFIER",
                                                                                                                                     "start": 1289,
                                                                                                                                     "end": 1297,
                                                                                                                                     "text": "order_id"
-                                                                                                                                  },
-                                                                                                                                  {
-                                                                                                                                    "type": "=",
-                                                                                                                                    "start": 1298,
-                                                                                                                                    "end": 1299,
-                                                                                                                                    "text": "="
                                                                                                                                   },
                                                                                                                                   {
                                                                                                                                     "type": "ErrorUnionExpr",
@@ -4834,12 +3206,6 @@
                                                                                                                                             "end": 1304,
                                                                                                                                             "children": [
                                                                                                                                               {
-                                                                                                                                                "type": ".",
-                                                                                                                                                "start": 1301,
-                                                                                                                                                "end": 1302,
-                                                                                                                                                "text": "."
-                                                                                                                                              },
-                                                                                                                                              {
                                                                                                                                                 "type": "IDENTIFIER",
                                                                                                                                                 "start": 1302,
                                                                                                                                                 "end": 1304,
@@ -4854,33 +3220,15 @@
                                                                                                                                 ]
                                                                                                                               },
                                                                                                                               {
-                                                                                                                                "type": ",",
-                                                                                                                                "start": 1304,
-                                                                                                                                "end": 1305,
-                                                                                                                                "text": ","
-                                                                                                                              },
-                                                                                                                              {
                                                                                                                                 "type": "FieldInit",
                                                                                                                                 "start": 1306,
                                                                                                                                 "end": 1340,
                                                                                                                                 "children": [
                                                                                                                                   {
-                                                                                                                                    "type": ".",
-                                                                                                                                    "start": 1306,
-                                                                                                                                    "end": 1307,
-                                                                                                                                    "text": "."
-                                                                                                                                  },
-                                                                                                                                  {
                                                                                                                                     "type": "IDENTIFIER",
                                                                                                                                     "start": 1307,
                                                                                                                                     "end": 1324,
                                                                                                                                     "text": "order_customer_id"
-                                                                                                                                  },
-                                                                                                                                  {
-                                                                                                                                    "type": "=",
-                                                                                                                                    "start": 1325,
-                                                                                                                                    "end": 1326,
-                                                                                                                                    "text": "="
                                                                                                                                   },
                                                                                                                                   {
                                                                                                                                     "type": "ErrorUnionExpr",
@@ -4904,12 +3252,6 @@
                                                                                                                                             "end": 1340,
                                                                                                                                             "children": [
                                                                                                                                               {
-                                                                                                                                                "type": ".",
-                                                                                                                                                "start": 1328,
-                                                                                                                                                "end": 1329,
-                                                                                                                                                "text": "."
-                                                                                                                                              },
-                                                                                                                                              {
                                                                                                                                                 "type": "IDENTIFIER",
                                                                                                                                                 "start": 1329,
                                                                                                                                                 "end": 1340,
@@ -4924,33 +3266,15 @@
                                                                                                                                 ]
                                                                                                                               },
                                                                                                                               {
-                                                                                                                                "type": ",",
-                                                                                                                                "start": 1340,
-                                                                                                                                "end": 1341,
-                                                                                                                                "text": ","
-                                                                                                                              },
-                                                                                                                              {
                                                                                                                                 "type": "FieldInit",
                                                                                                                                 "start": 1342,
                                                                                                                                 "end": 1372,
                                                                                                                                 "children": [
                                                                                                                                   {
-                                                                                                                                    "type": ".",
-                                                                                                                                    "start": 1342,
-                                                                                                                                    "end": 1343,
-                                                                                                                                    "text": "."
-                                                                                                                                  },
-                                                                                                                                  {
                                                                                                                                     "type": "IDENTIFIER",
                                                                                                                                     "start": 1343,
                                                                                                                                     "end": 1363,
                                                                                                                                     "text": "paired_customer_name"
-                                                                                                                                  },
-                                                                                                                                  {
-                                                                                                                                    "type": "=",
-                                                                                                                                    "start": 1364,
-                                                                                                                                    "end": 1365,
-                                                                                                                                    "text": "="
                                                                                                                                   },
                                                                                                                                   {
                                                                                                                                     "type": "ErrorUnionExpr",
@@ -4974,12 +3298,6 @@
                                                                                                                                             "end": 1372,
                                                                                                                                             "children": [
                                                                                                                                               {
-                                                                                                                                                "type": ".",
-                                                                                                                                                "start": 1367,
-                                                                                                                                                "end": 1368,
-                                                                                                                                                "text": "."
-                                                                                                                                              },
-                                                                                                                                              {
                                                                                                                                                 "type": "IDENTIFIER",
                                                                                                                                                 "start": 1368,
                                                                                                                                                 "end": 1372,
@@ -4994,33 +3312,15 @@
                                                                                                                                 ]
                                                                                                                               },
                                                                                                                               {
-                                                                                                                                "type": ",",
-                                                                                                                                "start": 1372,
-                                                                                                                                "end": 1373,
-                                                                                                                                "text": ","
-                                                                                                                              },
-                                                                                                                              {
                                                                                                                                 "type": "FieldInit",
                                                                                                                                 "start": 1374,
                                                                                                                                 "end": 1396,
                                                                                                                                 "children": [
                                                                                                                                   {
-                                                                                                                                    "type": ".",
-                                                                                                                                    "start": 1374,
-                                                                                                                                    "end": 1375,
-                                                                                                                                    "text": "."
-                                                                                                                                  },
-                                                                                                                                  {
                                                                                                                                     "type": "IDENTIFIER",
                                                                                                                                     "start": 1375,
                                                                                                                                     "end": 1386,
                                                                                                                                     "text": "order_total"
-                                                                                                                                  },
-                                                                                                                                  {
-                                                                                                                                    "type": "=",
-                                                                                                                                    "start": 1387,
-                                                                                                                                    "end": 1388,
-                                                                                                                                    "text": "="
                                                                                                                                   },
                                                                                                                                   {
                                                                                                                                     "type": "ErrorUnionExpr",
@@ -5044,12 +3344,6 @@
                                                                                                                                             "end": 1396,
                                                                                                                                             "children": [
                                                                                                                                               {
-                                                                                                                                                "type": ".",
-                                                                                                                                                "start": 1390,
-                                                                                                                                                "end": 1391,
-                                                                                                                                                "text": "."
-                                                                                                                                              },
-                                                                                                                                              {
                                                                                                                                                 "type": "IDENTIFIER",
                                                                                                                                                 "start": 1391,
                                                                                                                                                 "end": 1396,
@@ -5062,24 +3356,12 @@
                                                                                                                                     ]
                                                                                                                                   }
                                                                                                                                 ]
-                                                                                                                              },
-                                                                                                                              {
-                                                                                                                                "type": "}",
-                                                                                                                                "start": 1397,
-                                                                                                                                "end": 1398,
-                                                                                                                                "text": "}"
                                                                                                                               }
                                                                                                                             ]
                                                                                                                           }
                                                                                                                         ]
                                                                                                                       }
                                                                                                                     ]
-                                                                                                                  },
-                                                                                                                  {
-                                                                                                                    "type": ")",
-                                                                                                                    "start": 1398,
-                                                                                                                    "end": 1399,
-                                                                                                                    "text": ")"
                                                                                                                   }
                                                                                                                 ]
                                                                                                               }
@@ -5093,14 +3375,7 @@
                                                                                                     "type": "BitwiseOp",
                                                                                                     "start": 1400,
                                                                                                     "end": 1405,
-                                                                                                    "children": [
-                                                                                                      {
-                                                                                                        "type": "catch",
-                                                                                                        "start": 1400,
-                                                                                                        "end": 1405,
-                                                                                                        "text": "catch"
-                                                                                                      }
-                                                                                                    ]
+                                                                                                    "text": "catch"
                                                                                                   },
                                                                                                   {
                                                                                                     "type": "ErrorUnionExpr",
@@ -5111,34 +3386,15 @@
                                                                                                         "type": "SuffixExpr",
                                                                                                         "start": 1406,
                                                                                                         "end": 1417,
-                                                                                                        "children": [
-                                                                                                          {
-                                                                                                            "type": "unreachable",
-                                                                                                            "start": 1406,
-                                                                                                            "end": 1417,
-                                                                                                            "text": "unreachable"
-                                                                                                          }
-                                                                                                        ]
+                                                                                                        "text": "unreachable"
                                                                                                       }
                                                                                                     ]
                                                                                                   }
                                                                                                 ]
                                                                                               }
                                                                                             ]
-                                                                                          },
-                                                                                          {
-                                                                                            "type": ";",
-                                                                                            "start": 1417,
-                                                                                            "end": 1418,
-                                                                                            "text": ";"
                                                                                           }
                                                                                         ]
-                                                                                      },
-                                                                                      {
-                                                                                        "type": "}",
-                                                                                        "start": 1427,
-                                                                                        "end": 1428,
-                                                                                        "text": "}"
                                                                                       }
                                                                                     ]
                                                                                   }
@@ -5151,12 +3407,6 @@
                                                                     ]
                                                                   }
                                                                 ]
-                                                              },
-                                                              {
-                                                                "type": "}",
-                                                                "start": 1433,
-                                                                "end": 1434,
-                                                                "text": "}"
                                                               }
                                                             ]
                                                           }
@@ -5181,22 +3431,10 @@
                                             "end": 1486,
                                             "children": [
                                               {
-                                                "type": "var",
-                                                "start": 1439,
-                                                "end": 1442,
-                                                "text": "var"
-                                              },
-                                              {
                                                 "type": "IDENTIFIER",
                                                 "start": 1443,
                                                 "end": 1446,
                                                 "text": "tmp"
-                                              },
-                                              {
-                                                "type": "=",
-                                                "start": 1447,
-                                                "end": 1448,
-                                                "text": "="
                                               },
                                               {
                                                 "type": "BinaryExpr",
@@ -5225,12 +3463,6 @@
                                                             "end": 1467,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 1452,
-                                                                "end": 1453,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1453,
                                                                 "end": 1465,
@@ -5240,20 +3472,7 @@
                                                                 "type": "FnCallArguments",
                                                                 "start": 1465,
                                                                 "end": 1467,
-                                                                "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 1465,
-                                                                    "end": 1466,
-                                                                    "text": "("
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 1466,
-                                                                    "end": 1467,
-                                                                    "text": ")"
-                                                                  }
-                                                                ]
+                                                                "text": "()"
                                                               }
                                                             ]
                                                           }
@@ -5265,14 +3484,7 @@
                                                     "type": "BitwiseOp",
                                                     "start": 1468,
                                                     "end": 1473,
-                                                    "children": [
-                                                      {
-                                                        "type": "catch",
-                                                        "start": 1468,
-                                                        "end": 1473,
-                                                        "text": "catch"
-                                                      }
-                                                    ]
+                                                    "text": "catch"
                                                   },
                                                   {
                                                     "type": "ErrorUnionExpr",
@@ -5283,24 +3495,11 @@
                                                         "type": "SuffixExpr",
                                                         "start": 1474,
                                                         "end": 1485,
-                                                        "children": [
-                                                          {
-                                                            "type": "unreachable",
-                                                            "start": 1474,
-                                                            "end": 1485,
-                                                            "text": "unreachable"
-                                                          }
-                                                        ]
+                                                        "text": "unreachable"
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "type": ";",
-                                                "start": 1485,
-                                                "end": 1486,
-                                                "text": ";"
                                               }
                                             ]
                                           }
@@ -5317,22 +3516,10 @@
                                             "end": 1505,
                                             "children": [
                                               {
-                                                "type": "break",
-                                                "start": 1491,
-                                                "end": 1496,
-                                                "text": "break"
-                                              },
-                                              {
                                                 "type": "BreakLabel",
                                                 "start": 1497,
                                                 "end": 1501,
                                                 "children": [
-                                                  {
-                                                    "type": ":",
-                                                    "start": 1497,
-                                                    "end": 1498,
-                                                    "text": ":"
-                                                  },
                                                   {
                                                     "type": "IDENTIFIER",
                                                     "start": 1498,
@@ -5362,20 +3549,8 @@
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": ";",
-                                            "start": 1505,
-                                            "end": 1506,
-                                            "text": ";"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "}",
-                                        "start": 1507,
-                                        "end": 1508,
-                                        "text": "}"
                                       }
                                     ]
                                   }
@@ -5384,12 +3559,6 @@
                             ]
                           }
                         ]
-                      },
-                      {
-                        "type": ";",
-                        "start": 1508,
-                        "end": 1509,
-                        "text": ";"
                       }
                     ]
                   }
@@ -5414,14 +3583,7 @@
                             "type": "PrefixOp",
                             "start": 1514,
                             "end": 1517,
-                            "children": [
-                              {
-                                "type": "try",
-                                "start": 1514,
-                                "end": 1517,
-                                "text": "try"
-                              }
-                            ]
+                            "text": "try"
                           },
                           {
                             "type": "ErrorUnionExpr",
@@ -5445,12 +3607,6 @@
                                     "end": 1524,
                                     "children": [
                                       {
-                                        "type": ".",
-                                        "start": 1521,
-                                        "end": 1522,
-                                        "text": "."
-                                      },
-                                      {
                                         "type": "IDENTIFIER",
                                         "start": 1522,
                                         "end": 1524,
@@ -5464,12 +3620,6 @@
                                     "end": 1536,
                                     "children": [
                                       {
-                                        "type": ".",
-                                        "start": 1524,
-                                        "end": 1525,
-                                        "text": "."
-                                      },
-                                      {
                                         "type": "IDENTIFIER",
                                         "start": 1525,
                                         "end": 1534,
@@ -5479,20 +3629,7 @@
                                         "type": "FnCallArguments",
                                         "start": 1534,
                                         "end": 1536,
-                                        "children": [
-                                          {
-                                            "type": "(",
-                                            "start": 1534,
-                                            "end": 1535,
-                                            "text": "("
-                                          },
-                                          {
-                                            "type": ")",
-                                            "start": 1535,
-                                            "end": 1536,
-                                            "text": ")"
-                                          }
-                                        ]
+                                        "text": "()"
                                       }
                                     ]
                                   },
@@ -5501,12 +3638,6 @@
                                     "start": 1536,
                                     "end": 1545,
                                     "children": [
-                                      {
-                                        "type": ".",
-                                        "start": 1536,
-                                        "end": 1537,
-                                        "text": "."
-                                      },
                                       {
                                         "type": "IDENTIFIER",
                                         "start": 1537,
@@ -5517,20 +3648,7 @@
                                         "type": "FnCallArguments",
                                         "start": 1543,
                                         "end": 1545,
-                                        "children": [
-                                          {
-                                            "type": "(",
-                                            "start": 1543,
-                                            "end": 1544,
-                                            "text": "("
-                                          },
-                                          {
-                                            "type": ")",
-                                            "start": 1544,
-                                            "end": 1545,
-                                            "text": ")"
-                                          }
-                                        ]
+                                        "text": "()"
                                       }
                                     ]
                                   },
@@ -5539,12 +3657,6 @@
                                     "start": 1545,
                                     "end": 1611,
                                     "children": [
-                                      {
-                                        "type": ".",
-                                        "start": 1545,
-                                        "end": 1546,
-                                        "text": "."
-                                      },
                                       {
                                         "type": "IDENTIFIER",
                                         "start": 1546,
@@ -5556,12 +3668,6 @@
                                         "start": 1551,
                                         "end": 1611,
                                         "children": [
-                                          {
-                                            "type": "(",
-                                            "start": 1551,
-                                            "end": 1552,
-                                            "text": "("
-                                          },
                                           {
                                             "type": "ErrorUnionExpr",
                                             "start": 1552,
@@ -5578,12 +3684,6 @@
                                                     "end": 1559,
                                                     "children": [
                                                       {
-                                                        "type": "\"",
-                                                        "start": 1552,
-                                                        "end": 1553,
-                                                        "text": "\""
-                                                      },
-                                                      {
                                                         "type": "FormatSequence",
                                                         "start": 1553,
                                                         "end": 1556,
@@ -5594,24 +3694,12 @@
                                                         "start": 1556,
                                                         "end": 1558,
                                                         "text": "\\n"
-                                                      },
-                                                      {
-                                                        "type": "\"",
-                                                        "start": 1558,
-                                                        "end": 1559,
-                                                        "text": "\""
                                                       }
                                                     ]
                                                   }
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": ",",
-                                            "start": 1559,
-                                            "end": 1560,
-                                            "text": ","
                                           },
                                           {
                                             "type": "ErrorUnionExpr",
@@ -5624,22 +3712,10 @@
                                                 "end": 1610,
                                                 "children": [
                                                   {
-                                                    "type": ".",
-                                                    "start": 1561,
-                                                    "end": 1562,
-                                                    "text": "."
-                                                  },
-                                                  {
                                                     "type": "InitList",
                                                     "start": 1562,
                                                     "end": 1610,
                                                     "children": [
-                                                      {
-                                                        "type": "{",
-                                                        "start": 1562,
-                                                        "end": 1563,
-                                                        "text": "{"
-                                                      },
                                                       {
                                                         "type": "ErrorUnionExpr",
                                                         "start": 1563,
@@ -5654,42 +3730,17 @@
                                                                 "type": "STRINGLITERALSINGLE",
                                                                 "start": 1563,
                                                                 "end": 1609,
-                                                                "children": [
-                                                                  {
-                                                                    "type": "\"",
-                                                                    "start": 1563,
-                                                                    "end": 1564,
-                                                                    "text": "\""
-                                                                  },
-                                                                  {
-                                                                    "type": "\"",
-                                                                    "start": 1608,
-                                                                    "end": 1609,
-                                                                    "text": "\""
-                                                                  }
-                                                                ]
+                                                                "text": "\"--- Cross Join: All order-customer pairs ---\""
                                                               }
                                                             ]
                                                           }
                                                         ]
-                                                      },
-                                                      {
-                                                        "type": "}",
-                                                        "start": 1609,
-                                                        "end": 1610,
-                                                        "text": "}"
                                                       }
                                                     ]
                                                   }
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": ")",
-                                            "start": 1610,
-                                            "end": 1611,
-                                            "text": ")"
                                           }
                                         ]
                                       }
@@ -5702,12 +3753,6 @@
                         ]
                       }
                     ]
-                  },
-                  {
-                    "type": ";",
-                    "start": 1611,
-                    "end": 1612,
-                    "text": ";"
                   }
                 ]
               },
@@ -5737,18 +3782,6 @@
                                 "end": 1637,
                                 "children": [
                                   {
-                                    "type": "for",
-                                    "start": 1617,
-                                    "end": 1620,
-                                    "text": "for"
-                                  },
-                                  {
-                                    "type": "(",
-                                    "start": 1621,
-                                    "end": 1622,
-                                    "text": "("
-                                  },
-                                  {
                                     "type": "ErrorUnionExpr",
                                     "start": 1622,
                                     "end": 1628,
@@ -5769,33 +3802,15 @@
                                     ]
                                   },
                                   {
-                                    "type": ")",
-                                    "start": 1628,
-                                    "end": 1629,
-                                    "text": ")"
-                                  },
-                                  {
                                     "type": "PtrIndexPayload",
                                     "start": 1630,
                                     "end": 1637,
                                     "children": [
                                       {
-                                        "type": "|",
-                                        "start": 1630,
-                                        "end": 1631,
-                                        "text": "|"
-                                      },
-                                      {
                                         "type": "IDENTIFIER",
                                         "start": 1631,
                                         "end": 1636,
                                         "text": "entry"
-                                      },
-                                      {
-                                        "type": "|",
-                                        "start": 1636,
-                                        "end": 1637,
-                                        "text": "|"
                                       }
                                     ]
                                   }
@@ -5811,12 +3826,6 @@
                                     "start": 1638,
                                     "end": 1884,
                                     "children": [
-                                      {
-                                        "type": "{",
-                                        "start": 1638,
-                                        "end": 1639,
-                                        "text": "{"
-                                      },
                                       {
                                         "type": "Statement",
                                         "start": 1648,
@@ -5836,14 +3845,7 @@
                                                     "type": "PrefixOp",
                                                     "start": 1648,
                                                     "end": 1651,
-                                                    "children": [
-                                                      {
-                                                        "type": "try",
-                                                        "start": 1648,
-                                                        "end": 1651,
-                                                        "text": "try"
-                                                      }
-                                                    ]
+                                                    "text": "try"
                                                   },
                                                   {
                                                     "type": "ErrorUnionExpr",
@@ -5867,12 +3869,6 @@
                                                             "end": 1658,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 1655,
-                                                                "end": 1656,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1656,
                                                                 "end": 1658,
@@ -5886,12 +3882,6 @@
                                                             "end": 1670,
                                                             "children": [
                                                               {
-                                                                "type": ".",
-                                                                "start": 1658,
-                                                                "end": 1659,
-                                                                "text": "."
-                                                              },
-                                                              {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1659,
                                                                 "end": 1668,
@@ -5901,20 +3891,7 @@
                                                                 "type": "FnCallArguments",
                                                                 "start": 1668,
                                                                 "end": 1670,
-                                                                "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 1668,
-                                                                    "end": 1669,
-                                                                    "text": "("
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 1669,
-                                                                    "end": 1670,
-                                                                    "text": ")"
-                                                                  }
-                                                                ]
+                                                                "text": "()"
                                                               }
                                                             ]
                                                           },
@@ -5923,12 +3900,6 @@
                                                             "start": 1670,
                                                             "end": 1679,
                                                             "children": [
-                                                              {
-                                                                "type": ".",
-                                                                "start": 1670,
-                                                                "end": 1671,
-                                                                "text": "."
-                                                              },
                                                               {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1671,
@@ -5939,20 +3910,7 @@
                                                                 "type": "FnCallArguments",
                                                                 "start": 1677,
                                                                 "end": 1679,
-                                                                "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 1677,
-                                                                    "end": 1678,
-                                                                    "text": "("
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 1678,
-                                                                    "end": 1679,
-                                                                    "text": ")"
-                                                                  }
-                                                                ]
+                                                                "text": "()"
                                                               }
                                                             ]
                                                           },
@@ -5961,12 +3919,6 @@
                                                             "start": 1679,
                                                             "end": 1877,
                                                             "children": [
-                                                              {
-                                                                "type": ".",
-                                                                "start": 1679,
-                                                                "end": 1680,
-                                                                "text": "."
-                                                              },
                                                               {
                                                                 "type": "IDENTIFIER",
                                                                 "start": 1680,
@@ -5978,12 +3930,6 @@
                                                                 "start": 1685,
                                                                 "end": 1877,
                                                                 "children": [
-                                                                  {
-                                                                    "type": "(",
-                                                                    "start": 1685,
-                                                                    "end": 1686,
-                                                                    "text": "("
-                                                                  },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
                                                                     "start": 1686,
@@ -5999,12 +3945,6 @@
                                                                             "start": 1686,
                                                                             "end": 1729,
                                                                             "children": [
-                                                                              {
-                                                                                "type": "\"",
-                                                                                "start": 1686,
-                                                                                "end": 1687,
-                                                                                "text": "\""
-                                                                              },
                                                                               {
                                                                                 "type": "FormatSequence",
                                                                                 "start": 1687,
@@ -6058,24 +3998,12 @@
                                                                                 "start": 1726,
                                                                                 "end": 1728,
                                                                                 "text": "\\n"
-                                                                              },
-                                                                              {
-                                                                                "type": "\"",
-                                                                                "start": 1728,
-                                                                                "end": 1729,
-                                                                                "text": "\""
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ",",
-                                                                    "start": 1729,
-                                                                    "end": 1730,
-                                                                    "text": ","
                                                                   },
                                                                   {
                                                                     "type": "ErrorUnionExpr",
@@ -6088,22 +4016,10 @@
                                                                         "end": 1876,
                                                                         "children": [
                                                                           {
-                                                                            "type": ".",
-                                                                            "start": 1731,
-                                                                            "end": 1732,
-                                                                            "text": "."
-                                                                          },
-                                                                          {
                                                                             "type": "InitList",
                                                                             "start": 1732,
                                                                             "end": 1876,
                                                                             "children": [
-                                                                              {
-                                                                                "type": "{",
-                                                                                "start": 1732,
-                                                                                "end": 1733,
-                                                                                "text": "{"
-                                                                              },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
                                                                                 "start": 1733,
@@ -6118,30 +4034,11 @@
                                                                                         "type": "STRINGLITERALSINGLE",
                                                                                         "start": 1733,
                                                                                         "end": 1740,
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1733,
-                                                                                            "end": 1734,
-                                                                                            "text": "\""
-                                                                                          },
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1739,
-                                                                                            "end": 1740,
-                                                                                            "text": "\""
-                                                                                          }
-                                                                                        ]
+                                                                                        "text": "\"Order\""
                                                                                       }
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1740,
-                                                                                "end": 1741,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6165,12 +4062,6 @@
                                                                                         "end": 1756,
                                                                                         "children": [
                                                                                           {
-                                                                                            "type": ".",
-                                                                                            "start": 1747,
-                                                                                            "end": 1748,
-                                                                                            "text": "."
-                                                                                          },
-                                                                                          {
                                                                                             "type": "IDENTIFIER",
                                                                                             "start": 1748,
                                                                                             "end": 1756,
@@ -6181,12 +4072,6 @@
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1756,
-                                                                                "end": 1757,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6202,30 +4087,11 @@
                                                                                         "type": "STRINGLITERALSINGLE",
                                                                                         "start": 1758,
                                                                                         "end": 1772,
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1758,
-                                                                                            "end": 1759,
-                                                                                            "text": "\""
-                                                                                          },
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1771,
-                                                                                            "end": 1772,
-                                                                                            "text": "\""
-                                                                                          }
-                                                                                        ]
+                                                                                        "text": "\"(customerId:\""
                                                                                       }
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1772,
-                                                                                "end": 1773,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6249,12 +4115,6 @@
                                                                                         "end": 1797,
                                                                                         "children": [
                                                                                           {
-                                                                                            "type": ".",
-                                                                                            "start": 1779,
-                                                                                            "end": 1780,
-                                                                                            "text": "."
-                                                                                          },
-                                                                                          {
                                                                                             "type": "IDENTIFIER",
                                                                                             "start": 1780,
                                                                                             "end": 1797,
@@ -6265,12 +4125,6 @@
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1797,
-                                                                                "end": 1798,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6286,30 +4140,11 @@
                                                                                         "type": "STRINGLITERALSINGLE",
                                                                                         "start": 1799,
                                                                                         "end": 1811,
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1799,
-                                                                                            "end": 1800,
-                                                                                            "text": "\""
-                                                                                          },
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1810,
-                                                                                            "end": 1811,
-                                                                                            "text": "\""
-                                                                                          }
-                                                                                        ]
+                                                                                        "text": "\", total: $\""
                                                                                       }
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1811,
-                                                                                "end": 1812,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6333,12 +4168,6 @@
                                                                                         "end": 1830,
                                                                                         "children": [
                                                                                           {
-                                                                                            "type": ".",
-                                                                                            "start": 1818,
-                                                                                            "end": 1819,
-                                                                                            "text": "."
-                                                                                          },
-                                                                                          {
                                                                                             "type": "IDENTIFIER",
                                                                                             "start": 1819,
                                                                                             "end": 1830,
@@ -6349,12 +4178,6 @@
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1830,
-                                                                                "end": 1831,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6370,30 +4193,11 @@
                                                                                         "type": "STRINGLITERALSINGLE",
                                                                                         "start": 1832,
                                                                                         "end": 1847,
-                                                                                        "children": [
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1832,
-                                                                                            "end": 1833,
-                                                                                            "text": "\""
-                                                                                          },
-                                                                                          {
-                                                                                            "type": "\"",
-                                                                                            "start": 1846,
-                                                                                            "end": 1847,
-                                                                                            "text": "\""
-                                                                                          }
-                                                                                        ]
+                                                                                        "text": "\") paired with\""
                                                                                       }
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": ",",
-                                                                                "start": 1847,
-                                                                                "end": 1848,
-                                                                                "text": ","
                                                                               },
                                                                               {
                                                                                 "type": "ErrorUnionExpr",
@@ -6417,12 +4221,6 @@
                                                                                         "end": 1875,
                                                                                         "children": [
                                                                                           {
-                                                                                            "type": ".",
-                                                                                            "start": 1854,
-                                                                                            "end": 1855,
-                                                                                            "text": "."
-                                                                                          },
-                                                                                          {
                                                                                             "type": "IDENTIFIER",
                                                                                             "start": 1855,
                                                                                             "end": 1875,
@@ -6433,24 +4231,12 @@
                                                                                     ]
                                                                                   }
                                                                                 ]
-                                                                              },
-                                                                              {
-                                                                                "type": "}",
-                                                                                "start": 1875,
-                                                                                "end": 1876,
-                                                                                "text": "}"
                                                                               }
                                                                             ]
                                                                           }
                                                                         ]
                                                                       }
                                                                     ]
-                                                                  },
-                                                                  {
-                                                                    "type": ")",
-                                                                    "start": 1876,
-                                                                    "end": 1877,
-                                                                    "text": ")"
                                                                   }
                                                                 ]
                                                               }
@@ -6463,20 +4249,8 @@
                                                 ]
                                               }
                                             ]
-                                          },
-                                          {
-                                            "type": ";",
-                                            "start": 1877,
-                                            "end": 1878,
-                                            "text": ";"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "}",
-                                        "start": 1883,
-                                        "end": 1884,
-                                        "text": "}"
                                       }
                                     ]
                                   }
@@ -6489,12 +4263,6 @@
                     ]
                   }
                 ]
-              },
-              {
-                "type": "}",
-                "start": 1885,
-                "end": 1886,
-                "text": "}"
               }
             ]
           }

--- a/tools/json-ast/x/zig/ast.go
+++ b/tools/json-ast/x/zig/ast.go
@@ -2,7 +2,9 @@ package zig
 
 import sitter "github.com/smacker/go-tree-sitter"
 
-// Node represents a tree-sitter node in Zig's syntax tree.
+// Node represents a tree-sitter node in Zig's syntax tree. Only named nodes are
+// included so that punctuation tokens are omitted from the output. Leaf nodes
+// carry their textual content in the Text field.
 type Node struct {
 	Type     string `json:"type"`
 	Start    int    `json:"start"`
@@ -18,11 +20,11 @@ func convertNode(n *sitter.Node, src []byte) Node {
 		Start: int(n.StartByte()),
 		End:   int(n.EndByte()),
 	}
-	if n.ChildCount() == 0 {
+	if n.NamedChildCount() == 0 {
 		node.Text = n.Content(src)
 	}
-	for i := 0; i < int(n.ChildCount()); i++ {
-		child := n.Child(i)
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
 		if child == nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- filter out unnamed tokens when converting tree-sitter Zig nodes
- regenerate Zig golden file with reduced output

## Testing
- `go run -tags slow /tmp/gen.go`
- `go test ./tools/json-ast/x/zig -tags slow` *(fails: missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_6889ccc88a34832093091122d3d7bd4b