### PR TITLE
Refine Go JSON AST

### DIFF
--- a/tests/json-ast/x/go/cross_join.go.json
+++ b/tests/json-ast/x/go/cross_join.go.json
@@ -90,7 +90,7 @@
             "children": [
               {
                 "kind": "identifier",
-                "name": "customers",
+                "text": "customers",
                 "start": 10,
                 "startCol": 4,
                 "end": 10,
@@ -196,7 +196,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 11,
                                                 "startCol": 1,
                                                 "end": 11,
@@ -239,7 +239,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Name",
+                                                "text": "Name",
                                                 "start": 12,
                                                 "startCol": 1,
                                                 "end": 12,
@@ -317,7 +317,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 14,
                                                 "startCol": 1,
                                                 "end": 14,
@@ -360,7 +360,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Name",
+                                                "text": "Name",
                                                 "start": 15,
                                                 "startCol": 1,
                                                 "end": 15,
@@ -438,7 +438,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 17,
                                                 "startCol": 1,
                                                 "end": 17,
@@ -481,7 +481,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Name",
+                                                "text": "Name",
                                                 "start": 18,
                                                 "startCol": 1,
                                                 "end": 18,
@@ -650,7 +650,7 @@
             "children": [
               {
                 "kind": "identifier",
-                "name": "orders",
+                "text": "orders",
                 "start": 26,
                 "startCol": 4,
                 "end": 26,
@@ -756,7 +756,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 27,
                                                 "startCol": 1,
                                                 "end": 27,
@@ -799,7 +799,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "CustomerID",
+                                                "text": "CustomerID",
                                                 "start": 28,
                                                 "startCol": 1,
                                                 "end": 28,
@@ -842,7 +842,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Total",
+                                                "text": "Total",
                                                 "start": 29,
                                                 "startCol": 1,
                                                 "end": 29,
@@ -920,7 +920,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 31,
                                                 "startCol": 1,
                                                 "end": 31,
@@ -963,7 +963,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "CustomerID",
+                                                "text": "CustomerID",
                                                 "start": 32,
                                                 "startCol": 1,
                                                 "end": 32,
@@ -1006,7 +1006,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Total",
+                                                "text": "Total",
                                                 "start": 33,
                                                 "startCol": 1,
                                                 "end": 33,
@@ -1084,7 +1084,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "ID",
+                                                "text": "ID",
                                                 "start": 35,
                                                 "startCol": 1,
                                                 "end": 35,
@@ -1127,7 +1127,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "CustomerID",
+                                                "text": "CustomerID",
                                                 "start": 36,
                                                 "startCol": 1,
                                                 "end": 36,
@@ -1170,7 +1170,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "Total",
+                                                "text": "Total",
                                                 "start": 37,
                                                 "startCol": 1,
                                                 "end": 37,
@@ -1541,19 +1541,11 @@
         "children": [
           {
             "kind": "identifier",
-            "name": "main",
+            "text": "main",
             "start": 53,
             "startCol": 5,
             "end": 53,
             "endCol": 9
-          },
-          {
-            "kind": "parameter_list",
-            "text": "()",
-            "start": 53,
-            "startCol": 9,
-            "end": 53,
-            "endCol": 11
           },
           {
             "kind": "block",
@@ -1578,7 +1570,7 @@
                     "children": [
                       {
                         "kind": "identifier",
-                        "name": "result",
+                        "text": "result",
                         "start": 54,
                         "startCol": 5,
                         "end": 54,
@@ -1623,14 +1615,6 @@
                                 "endCol": 2,
                                 "children": [
                                   {
-                                    "kind": "parameter_list",
-                                    "text": "()",
-                                    "start": 54,
-                                    "startCol": 27,
-                                    "end": 54,
-                                    "endCol": 29
-                                  },
-                                  {
                                     "kind": "slice_type",
                                     "start": 54,
                                     "startCol": 30,
@@ -1670,7 +1654,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "res",
+                                                "text": "res",
                                                 "start": 55,
                                                 "startCol": 2,
                                                 "end": 55,
@@ -1708,14 +1692,6 @@
                                                         "endCol": 17
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": "literal_value",
-                                                    "text": "{}",
-                                                    "start": 55,
-                                                    "startCol": 17,
-                                                    "end": 55,
-                                                    "endCol": 19
                                                   }
                                                 ]
                                               }
@@ -1746,7 +1722,7 @@
                                                 "children": [
                                                   {
                                                     "kind": "identifier",
-                                                    "name": "_",
+                                                    "text": "_",
                                                     "start": 56,
                                                     "startCol": 6,
                                                     "end": 56,
@@ -1754,7 +1730,7 @@
                                                   },
                                                   {
                                                     "kind": "identifier",
-                                                    "name": "o",
+                                                    "text": "o",
                                                     "start": 56,
                                                     "startCol": 9,
                                                     "end": 56,
@@ -1764,7 +1740,7 @@
                                               },
                                               {
                                                 "kind": "identifier",
-                                                "name": "orders",
+                                                "text": "orders",
                                                 "start": 56,
                                                 "startCol": 20,
                                                 "end": 56,
@@ -1802,7 +1778,7 @@
                                                         "children": [
                                                           {
                                                             "kind": "identifier",
-                                                            "name": "_",
+                                                            "text": "_",
                                                             "start": 57,
                                                             "startCol": 7,
                                                             "end": 57,
@@ -1810,7 +1786,7 @@
                                                           },
                                                           {
                                                             "kind": "identifier",
-                                                            "name": "c",
+                                                            "text": "c",
                                                             "start": 57,
                                                             "startCol": 10,
                                                             "end": 57,
@@ -1820,7 +1796,7 @@
                                                       },
                                                       {
                                                         "kind": "identifier",
-                                                        "name": "customers",
+                                                        "text": "customers",
                                                         "start": 57,
                                                         "startCol": 21,
                                                         "end": 57,
@@ -1851,7 +1827,7 @@
                                                             "children": [
                                                               {
                                                                 "kind": "identifier",
-                                                                "name": "res",
+                                                                "text": "res",
                                                                 "start": 58,
                                                                 "startCol": 4,
                                                                 "end": 58,
@@ -1875,7 +1851,7 @@
                                                                 "children": [
                                                                   {
                                                                     "kind": "identifier",
-                                                                    "name": "append",
+                                                                    "text": "append",
                                                                     "start": 58,
                                                                     "startCol": 10,
                                                                     "end": 58,
@@ -1890,7 +1866,7 @@
                                                                     "children": [
                                                                       {
                                                                         "kind": "identifier",
-                                                                        "name": "res",
+                                                                        "text": "res",
                                                                         "start": 58,
                                                                         "startCol": 17,
                                                                         "end": 58,
@@ -1934,7 +1910,7 @@
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "name": "OrderID",
+                                                                                        "text": "OrderID",
                                                                                         "start": 59,
                                                                                         "startCol": 5,
                                                                                         "end": 59,
@@ -1958,7 +1934,7 @@
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "identifier",
-                                                                                            "name": "o",
+                                                                                            "text": "o",
                                                                                             "start": 59,
                                                                                             "startCol": 25,
                                                                                             "end": 59,
@@ -1994,7 +1970,7 @@
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "name": "OrderCustomerID",
+                                                                                        "text": "OrderCustomerID",
                                                                                         "start": 60,
                                                                                         "startCol": 5,
                                                                                         "end": 60,
@@ -2018,7 +1994,7 @@
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "identifier",
-                                                                                            "name": "o",
+                                                                                            "text": "o",
                                                                                             "start": 60,
                                                                                             "startCol": 25,
                                                                                             "end": 60,
@@ -2054,7 +2030,7 @@
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "name": "PairedCustomerName",
+                                                                                        "text": "PairedCustomerName",
                                                                                         "start": 61,
                                                                                         "startCol": 5,
                                                                                         "end": 61,
@@ -2078,7 +2054,7 @@
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "identifier",
-                                                                                            "name": "c",
+                                                                                            "text": "c",
                                                                                             "start": 61,
                                                                                             "startCol": 25,
                                                                                             "end": 61,
@@ -2114,7 +2090,7 @@
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "name": "OrderTotal",
+                                                                                        "text": "OrderTotal",
                                                                                         "start": 62,
                                                                                         "startCol": 5,
                                                                                         "end": 62,
@@ -2138,7 +2114,7 @@
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "identifier",
-                                                                                            "name": "o",
+                                                                                            "text": "o",
                                                                                             "start": 62,
                                                                                             "startCol": 25,
                                                                                             "end": 62,
@@ -2194,7 +2170,7 @@
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "name": "res",
+                                                "text": "res",
                                                 "start": 66,
                                                 "startCol": 9,
                                                 "end": 66,
@@ -2207,14 +2183,6 @@
                                     ]
                                   }
                                 ]
-                              },
-                              {
-                                "kind": "argument_list",
-                                "text": "()",
-                                "start": 67,
-                                "startCol": 2,
-                                "end": 67,
-                                "endCol": 4
                               }
                             ]
                           }
@@ -2247,7 +2215,7 @@
                         "children": [
                           {
                             "kind": "identifier",
-                            "name": "fmt",
+                            "text": "fmt",
                             "start": 68,
                             "startCol": 1,
                             "end": 68,
@@ -2307,7 +2275,7 @@
                         "children": [
                           {
                             "kind": "identifier",
-                            "name": "_",
+                            "text": "_",
                             "start": 69,
                             "startCol": 5,
                             "end": 69,
@@ -2315,7 +2283,7 @@
                           },
                           {
                             "kind": "identifier",
-                            "name": "entry",
+                            "text": "entry",
                             "start": 69,
                             "startCol": 8,
                             "end": 69,
@@ -2325,7 +2293,7 @@
                       },
                       {
                         "kind": "identifier",
-                        "name": "result",
+                        "text": "result",
                         "start": 69,
                         "startCol": 23,
                         "end": 69,
@@ -2363,7 +2331,7 @@
                                 "children": [
                                   {
                                     "kind": "identifier",
-                                    "name": "fmt",
+                                    "text": "fmt",
                                     "start": 70,
                                     "startCol": 2,
                                     "end": 70,
@@ -2403,7 +2371,7 @@
                                     "children": [
                                       {
                                         "kind": "identifier",
-                                        "name": "entry",
+                                        "text": "entry",
                                         "start": 70,
                                         "startCol": 23,
                                         "end": 70,
@@ -2436,7 +2404,7 @@
                                     "children": [
                                       {
                                         "kind": "identifier",
-                                        "name": "entry",
+                                        "text": "entry",
                                         "start": 70,
                                         "startCol": 54,
                                         "end": 70,
@@ -2469,7 +2437,7 @@
                                     "children": [
                                       {
                                         "kind": "identifier",
-                                        "name": "entry",
+                                        "text": "entry",
                                         "start": 70,
                                         "startCol": 91,
                                         "end": 70,
@@ -2502,7 +2470,7 @@
                                     "children": [
                                       {
                                         "kind": "identifier",
-                                        "name": "entry",
+                                        "text": "entry",
                                         "start": 70,
                                         "startCol": 126,
                                         "end": 70,

--- a/tools/json-ast/x/go/inspect.go
+++ b/tools/json-ast/x/go/inspect.go
@@ -11,7 +11,7 @@ import (
 
 // Program represents a parsed Go source file.
 type Program struct {
-	Root Node `json:"root"`
+	Root *Node `json:"root"`
 }
 
 // Inspect parses Go source code using tree-sitter and returns its Program


### PR DESCRIPTION
## Summary
- simplify Go AST nodes and skip non-value leaves
- update Go JSON AST generator
- refresh cross_join.go.json output

## Testing
- `go test -tags=slow ./tools/json-ast/x/go -run TestInspect_Golden -update`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889ce645aa883208a391cff5b632eb0