### PR TITLE
Improve Java JSON AST

### DIFF
--- a/tests/json-ast/x/java/cross_join.java.json
+++ b/tests/json-ast/x/java/cross_join.java.json
@@ -1,169 +1,65 @@
 {
   "root": {
     "kind": "program",
-    "start": 1,
-    "startCol": 0,
-    "end": 64,
-    "endCol": 0,
     "children": [
       {
         "kind": "class_declaration",
-        "start": 1,
-        "startCol": 0,
-        "end": 63,
-        "endCol": 1,
         "children": [
           {
-            "kind": "modifiers",
-            "start": 1,
-            "startCol": 0,
-            "end": 1,
-            "endCol": 6,
-            "text": "public"
-          },
-          {
             "kind": "identifier",
-            "start": 1,
-            "startCol": 13,
-            "end": 1,
-            "endCol": 17,
             "text": "Main"
           },
           {
             "kind": "class_body",
-            "start": 1,
-            "startCol": 18,
-            "end": 63,
-            "endCol": 1,
             "children": [
               {
                 "kind": "field_declaration",
-                "start": 2,
-                "startCol": 4,
-                "end": 2,
-                "endCol": 112,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 2,
-                    "startCol": 4,
-                    "end": 2,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "array_type",
-                    "start": 2,
-                    "startCol": 11,
-                    "end": 2,
-                    "endCol": 18,
                     "children": [
                       {
                         "kind": "type_identifier",
-                        "start": 2,
-                        "startCol": 11,
-                        "end": 2,
-                        "endCol": 16,
                         "text": "Data1"
-                      },
-                      {
-                        "kind": "dimensions",
-                        "start": 2,
-                        "startCol": 16,
-                        "end": 2,
-                        "endCol": 18,
-                        "text": "[]"
                       }
                     ]
                   },
                   {
                     "kind": "variable_declarator",
-                    "start": 2,
-                    "startCol": 19,
-                    "end": 2,
-                    "endCol": 111,
                     "children": [
                       {
                         "kind": "identifier",
-                        "start": 2,
-                        "startCol": 19,
-                        "end": 2,
-                        "endCol": 28,
                         "text": "customers"
                       },
                       {
                         "kind": "array_creation_expression",
-                        "start": 2,
-                        "startCol": 31,
-                        "end": 2,
-                        "endCol": 111,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 2,
-                            "startCol": 35,
-                            "end": 2,
-                            "endCol": 40,
                             "text": "Data1"
                           },
                           {
-                            "kind": "dimensions",
-                            "start": 2,
-                            "startCol": 40,
-                            "end": 2,
-                            "endCol": 42,
-                            "text": "[]"
-                          },
-                          {
                             "kind": "array_initializer",
-                            "start": 2,
-                            "startCol": 42,
-                            "end": 2,
-                            "endCol": 111,
                             "children": [
                               {
                                 "kind": "object_creation_expression",
-                                "start": 2,
-                                "startCol": 43,
-                                "end": 2,
-                                "endCol": 64,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 2,
-                                    "startCol": 47,
-                                    "end": 2,
-                                    "endCol": 52,
                                     "text": "Data1"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 2,
-                                    "startCol": 52,
-                                    "end": 2,
-                                    "endCol": 64,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 2,
-                                        "startCol": 53,
-                                        "end": 2,
-                                        "endCol": 54,
                                         "text": "1"
                                       },
                                       {
                                         "kind": "string_literal",
-                                        "start": 2,
-                                        "startCol": 56,
-                                        "end": 2,
-                                        "endCol": 63,
                                         "children": [
                                           {
                                             "kind": "string_fragment",
-                                            "start": 2,
-                                            "startCol": 57,
-                                            "end": 2,
-                                            "endCol": 62,
                                             "text": "Alice"
                                           }
                                         ]
@@ -174,47 +70,23 @@
                               },
                               {
                                 "kind": "object_creation_expression",
-                                "start": 2,
-                                "startCol": 66,
-                                "end": 2,
-                                "endCol": 85,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 2,
-                                    "startCol": 70,
-                                    "end": 2,
-                                    "endCol": 75,
                                     "text": "Data1"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 2,
-                                    "startCol": 75,
-                                    "end": 2,
-                                    "endCol": 85,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 2,
-                                        "startCol": 76,
-                                        "end": 2,
-                                        "endCol": 77,
                                         "text": "2"
                                       },
                                       {
                                         "kind": "string_literal",
-                                        "start": 2,
-                                        "startCol": 79,
-                                        "end": 2,
-                                        "endCol": 84,
                                         "children": [
                                           {
                                             "kind": "string_fragment",
-                                            "start": 2,
-                                            "startCol": 80,
-                                            "end": 2,
-                                            "endCol": 83,
                                             "text": "Bob"
                                           }
                                         ]
@@ -225,47 +97,23 @@
                               },
                               {
                                 "kind": "object_creation_expression",
-                                "start": 2,
-                                "startCol": 87,
-                                "end": 2,
-                                "endCol": 110,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 2,
-                                    "startCol": 91,
-                                    "end": 2,
-                                    "endCol": 96,
                                     "text": "Data1"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 2,
-                                    "startCol": 96,
-                                    "end": 2,
-                                    "endCol": 110,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 2,
-                                        "startCol": 97,
-                                        "end": 2,
-                                        "endCol": 98,
                                         "text": "3"
                                       },
                                       {
                                         "kind": "string_literal",
-                                        "start": 2,
-                                        "startCol": 100,
-                                        "end": 2,
-                                        "endCol": 109,
                                         "children": [
                                           {
                                             "kind": "string_fragment",
-                                            "start": 2,
-                                            "startCol": 101,
-                                            "end": 2,
-                                            "endCol": 108,
                                             "text": "Charlie"
                                           }
                                         ]
@@ -284,62 +132,22 @@
               },
               {
                 "kind": "class_declaration",
-                "start": 3,
-                "startCol": 4,
-                "end": 15,
-                "endCol": 5,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 3,
-                    "startCol": 4,
-                    "end": 3,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "identifier",
-                    "start": 3,
-                    "startCol": 17,
-                    "end": 3,
-                    "endCol": 22,
                     "text": "Data1"
                   },
                   {
                     "kind": "class_body",
-                    "start": 3,
-                    "startCol": 23,
-                    "end": 15,
-                    "endCol": 5,
                     "children": [
                       {
                         "kind": "field_declaration",
-                        "start": 4,
-                        "startCol": 8,
-                        "end": 4,
-                        "endCol": 15,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 4,
-                            "startCol": 8,
-                            "end": 4,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 4,
-                            "startCol": 12,
-                            "end": 4,
-                            "endCol": 14,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 4,
-                                "startCol": 12,
-                                "end": 4,
-                                "endCol": 14,
                                 "text": "id"
                               }
                             ]
@@ -348,32 +156,16 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 5,
-                        "startCol": 8,
-                        "end": 5,
-                        "endCol": 20,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 5,
-                            "startCol": 8,
-                            "end": 5,
-                            "endCol": 14,
                             "text": "String"
                           },
                           {
                             "kind": "variable_declarator",
-                            "start": 5,
-                            "startCol": 15,
-                            "end": 5,
-                            "endCol": 19,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 5,
-                                "startCol": 15,
-                                "end": 5,
-                                "endCol": 19,
                                 "text": "name"
                               }
                             ]
@@ -382,72 +174,32 @@
                       },
                       {
                         "kind": "constructor_declaration",
-                        "start": 6,
-                        "startCol": 8,
-                        "end": 9,
-                        "endCol": 9,
                         "children": [
                           {
                             "kind": "identifier",
-                            "start": 6,
-                            "startCol": 8,
-                            "end": 6,
-                            "endCol": 13,
                             "text": "Data1"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 6,
-                            "startCol": 13,
-                            "end": 6,
-                            "endCol": 34,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 6,
-                                "startCol": 14,
-                                "end": 6,
-                                "endCol": 20,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 6,
-                                    "startCol": 14,
-                                    "end": 6,
-                                    "endCol": 17,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 6,
-                                    "startCol": 18,
-                                    "end": 6,
-                                    "endCol": 20,
                                     "text": "id"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 6,
-                                "startCol": 22,
-                                "end": 6,
-                                "endCol": 33,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 6,
-                                    "startCol": 22,
-                                    "end": 6,
-                                    "endCol": 28,
                                     "text": "String"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 6,
-                                    "startCol": 29,
-                                    "end": 6,
-                                    "endCol": 33,
                                     "text": "name"
                                   }
                                 ]
@@ -456,56 +208,28 @@
                           },
                           {
                             "kind": "constructor_body",
-                            "start": 6,
-                            "startCol": 35,
-                            "end": 9,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "expression_statement",
-                                "start": 7,
-                                "startCol": 12,
-                                "end": 7,
-                                "endCol": 25,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 7,
-                                    "startCol": 12,
-                                    "end": 7,
-                                    "endCol": 24,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 7,
-                                        "startCol": 12,
-                                        "end": 7,
-                                        "endCol": 19,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 7,
-                                            "startCol": 12,
-                                            "end": 7,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 7,
-                                            "startCol": 17,
-                                            "end": 7,
-                                            "endCol": 19,
                                             "text": "id"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 7,
-                                        "startCol": 22,
-                                        "end": 7,
-                                        "endCol": 24,
                                         "text": "id"
                                       }
                                     ]
@@ -514,49 +238,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 8,
-                                "startCol": 12,
-                                "end": 8,
-                                "endCol": 29,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 8,
-                                    "startCol": 12,
-                                    "end": 8,
-                                    "endCol": 28,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 8,
-                                        "startCol": 12,
-                                        "end": 8,
-                                        "endCol": 21,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 8,
-                                            "startCol": 12,
-                                            "end": 8,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 8,
-                                            "startCol": 17,
-                                            "end": 8,
-                                            "endCol": 21,
                                             "text": "name"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 8,
-                                        "startCol": 24,
-                                        "end": 8,
-                                        "endCol": 28,
                                         "text": "name"
                                       }
                                     ]
@@ -569,55 +269,23 @@
                       },
                       {
                         "kind": "method_declaration",
-                        "start": 10,
-                        "startCol": 8,
-                        "end": 14,
-                        "endCol": 9,
                         "children": [
                           {
-                            "kind": "boolean_type",
-                            "start": 10,
-                            "startCol": 8,
-                            "end": 10,
-                            "endCol": 15,
-                            "text": "boolean"
-                          },
-                          {
                             "kind": "identifier",
-                            "start": 10,
-                            "startCol": 16,
-                            "end": 10,
-                            "endCol": 27,
                             "text": "containsKey"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 10,
-                            "startCol": 27,
-                            "end": 10,
-                            "endCol": 37,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 10,
-                                "startCol": 28,
-                                "end": 10,
-                                "endCol": 36,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 10,
-                                    "startCol": 28,
-                                    "end": 10,
-                                    "endCol": 34,
                                     "text": "String"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 10,
-                                    "startCol": 35,
-                                    "end": 10,
-                                    "endCol": 36,
                                     "text": "k"
                                   }
                                 ]
@@ -626,68 +294,32 @@
                           },
                           {
                             "kind": "block",
-                            "start": 10,
-                            "startCol": 38,
-                            "end": 14,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "if_statement",
-                                "start": 11,
-                                "startCol": 12,
-                                "end": 11,
-                                "endCol": 44,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 11,
-                                    "startCol": 15,
-                                    "end": 11,
-                                    "endCol": 31,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 11,
-                                        "startCol": 16,
-                                        "end": 11,
-                                        "endCol": 30,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 11,
-                                            "startCol": 16,
-                                            "end": 11,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 11,
-                                            "startCol": 18,
-                                            "end": 11,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 11,
-                                            "startCol": 24,
-                                            "end": 11,
-                                            "endCol": 30,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 11,
-                                                "startCol": 25,
-                                                "end": 11,
-                                                "endCol": 29,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 11,
-                                                    "startCol": 26,
-                                                    "end": 11,
-                                                    "endCol": 28,
                                                     "text": "id"
                                                   }
                                                 ]
@@ -700,17 +332,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 11,
-                                    "startCol": 32,
-                                    "end": 11,
-                                    "endCol": 44,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 11,
-                                        "startCol": 39,
-                                        "end": 11,
-                                        "endCol": 43,
                                         "text": "true"
                                       }
                                     ]
@@ -719,61 +343,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 12,
-                                "startCol": 12,
-                                "end": 12,
-                                "endCol": 46,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 12,
-                                    "startCol": 15,
-                                    "end": 12,
-                                    "endCol": 33,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 12,
-                                        "startCol": 16,
-                                        "end": 12,
-                                        "endCol": 32,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 12,
-                                            "startCol": 16,
-                                            "end": 12,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 12,
-                                            "startCol": 18,
-                                            "end": 12,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 12,
-                                            "startCol": 24,
-                                            "end": 12,
-                                            "endCol": 32,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 12,
-                                                "startCol": 25,
-                                                "end": 12,
-                                                "endCol": 31,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 12,
-                                                    "startCol": 26,
-                                                    "end": 12,
-                                                    "endCol": 30,
                                                     "text": "name"
                                                   }
                                                 ]
@@ -786,17 +378,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 12,
-                                    "startCol": 34,
-                                    "end": 12,
-                                    "endCol": 46,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 12,
-                                        "startCol": 41,
-                                        "end": 12,
-                                        "endCol": 45,
                                         "text": "true"
                                       }
                                     ]
@@ -805,17 +389,9 @@
                               },
                               {
                                 "kind": "return_statement",
-                                "start": 13,
-                                "startCol": 12,
-                                "end": 13,
-                                "endCol": 25,
                                 "children": [
                                   {
                                     "kind": "false",
-                                    "start": 13,
-                                    "startCol": 19,
-                                    "end": 13,
-                                    "endCol": 24,
                                     "text": "false"
                                   }
                                 ]
@@ -830,133 +406,53 @@
               },
               {
                 "kind": "field_declaration",
-                "start": 17,
-                "startCol": 4,
-                "end": 17,
-                "endCol": 112,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 17,
-                    "startCol": 4,
-                    "end": 17,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "array_type",
-                    "start": 17,
-                    "startCol": 11,
-                    "end": 17,
-                    "endCol": 18,
                     "children": [
                       {
                         "kind": "type_identifier",
-                        "start": 17,
-                        "startCol": 11,
-                        "end": 17,
-                        "endCol": 16,
                         "text": "Data2"
-                      },
-                      {
-                        "kind": "dimensions",
-                        "start": 17,
-                        "startCol": 16,
-                        "end": 17,
-                        "endCol": 18,
-                        "text": "[]"
                       }
                     ]
                   },
                   {
                     "kind": "variable_declarator",
-                    "start": 17,
-                    "startCol": 19,
-                    "end": 17,
-                    "endCol": 111,
                     "children": [
                       {
                         "kind": "identifier",
-                        "start": 17,
-                        "startCol": 19,
-                        "end": 17,
-                        "endCol": 25,
                         "text": "orders"
                       },
                       {
                         "kind": "array_creation_expression",
-                        "start": 17,
-                        "startCol": 28,
-                        "end": 17,
-                        "endCol": 111,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 17,
-                            "startCol": 32,
-                            "end": 17,
-                            "endCol": 37,
                             "text": "Data2"
                           },
                           {
-                            "kind": "dimensions",
-                            "start": 17,
-                            "startCol": 37,
-                            "end": 17,
-                            "endCol": 39,
-                            "text": "[]"
-                          },
-                          {
                             "kind": "array_initializer",
-                            "start": 17,
-                            "startCol": 39,
-                            "end": 17,
-                            "endCol": 111,
                             "children": [
                               {
                                 "kind": "object_creation_expression",
-                                "start": 17,
-                                "startCol": 40,
-                                "end": 17,
-                                "endCol": 62,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 17,
-                                    "startCol": 44,
-                                    "end": 17,
-                                    "endCol": 49,
                                     "text": "Data2"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 17,
-                                    "startCol": 49,
-                                    "end": 17,
-                                    "endCol": 62,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 50,
-                                        "end": 17,
-                                        "endCol": 53,
                                         "text": "100"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 55,
-                                        "end": 17,
-                                        "endCol": 56,
                                         "text": "1"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 58,
-                                        "end": 17,
-                                        "endCol": 61,
                                         "text": "250"
                                       }
                                     ]
@@ -965,48 +461,24 @@
                               },
                               {
                                 "kind": "object_creation_expression",
-                                "start": 17,
-                                "startCol": 64,
-                                "end": 17,
-                                "endCol": 86,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 17,
-                                    "startCol": 68,
-                                    "end": 17,
-                                    "endCol": 73,
                                     "text": "Data2"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 17,
-                                    "startCol": 73,
-                                    "end": 17,
-                                    "endCol": 86,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 74,
-                                        "end": 17,
-                                        "endCol": 77,
                                         "text": "101"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 79,
-                                        "end": 17,
-                                        "endCol": 80,
                                         "text": "2"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 82,
-                                        "end": 17,
-                                        "endCol": 85,
                                         "text": "125"
                                       }
                                     ]
@@ -1015,48 +487,24 @@
                               },
                               {
                                 "kind": "object_creation_expression",
-                                "start": 17,
-                                "startCol": 88,
-                                "end": 17,
-                                "endCol": 110,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 17,
-                                    "startCol": 92,
-                                    "end": 17,
-                                    "endCol": 97,
                                     "text": "Data2"
                                   },
                                   {
                                     "kind": "argument_list",
-                                    "start": 17,
-                                    "startCol": 97,
-                                    "end": 17,
-                                    "endCol": 110,
                                     "children": [
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 98,
-                                        "end": 17,
-                                        "endCol": 101,
                                         "text": "102"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 103,
-                                        "end": 17,
-                                        "endCol": 104,
                                         "text": "1"
                                       },
                                       {
                                         "kind": "decimal_integer_literal",
-                                        "start": 17,
-                                        "startCol": 106,
-                                        "end": 17,
-                                        "endCol": 109,
                                         "text": "300"
                                       }
                                     ]
@@ -1073,62 +521,22 @@
               },
               {
                 "kind": "class_declaration",
-                "start": 18,
-                "startCol": 4,
-                "end": 33,
-                "endCol": 5,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 18,
-                    "startCol": 4,
-                    "end": 18,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "identifier",
-                    "start": 18,
-                    "startCol": 17,
-                    "end": 18,
-                    "endCol": 22,
                     "text": "Data2"
                   },
                   {
                     "kind": "class_body",
-                    "start": 18,
-                    "startCol": 23,
-                    "end": 33,
-                    "endCol": 5,
                     "children": [
                       {
                         "kind": "field_declaration",
-                        "start": 19,
-                        "startCol": 8,
-                        "end": 19,
-                        "endCol": 15,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 19,
-                            "startCol": 8,
-                            "end": 19,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 19,
-                            "startCol": 12,
-                            "end": 19,
-                            "endCol": 14,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 19,
-                                "startCol": 12,
-                                "end": 19,
-                                "endCol": 14,
                                 "text": "id"
                               }
                             ]
@@ -1137,32 +545,12 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 20,
-                        "startCol": 8,
-                        "end": 20,
-                        "endCol": 23,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 20,
-                            "startCol": 8,
-                            "end": 20,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 20,
-                            "startCol": 12,
-                            "end": 20,
-                            "endCol": 22,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 20,
-                                "startCol": 12,
-                                "end": 20,
-                                "endCol": 22,
                                 "text": "customerId"
                               }
                             ]
@@ -1171,32 +559,12 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 21,
-                        "startCol": 8,
-                        "end": 21,
-                        "endCol": 18,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 21,
-                            "startCol": 8,
-                            "end": 21,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 21,
-                            "startCol": 12,
-                            "end": 21,
-                            "endCol": 17,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 21,
-                                "startCol": 12,
-                                "end": 21,
-                                "endCol": 17,
                                 "text": "total"
                               }
                             ]
@@ -1205,97 +573,37 @@
                       },
                       {
                         "kind": "constructor_declaration",
-                        "start": 22,
-                        "startCol": 8,
-                        "end": 26,
-                        "endCol": 9,
                         "children": [
                           {
                             "kind": "identifier",
-                            "start": 22,
-                            "startCol": 8,
-                            "end": 22,
-                            "endCol": 13,
                             "text": "Data2"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 22,
-                            "startCol": 13,
-                            "end": 22,
-                            "endCol": 48,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 22,
-                                "startCol": 14,
-                                "end": 22,
-                                "endCol": 20,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 22,
-                                    "startCol": 14,
-                                    "end": 22,
-                                    "endCol": 17,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 22,
-                                    "startCol": 18,
-                                    "end": 22,
-                                    "endCol": 20,
                                     "text": "id"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 22,
-                                "startCol": 22,
-                                "end": 22,
-                                "endCol": 36,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 22,
-                                    "startCol": 22,
-                                    "end": 22,
-                                    "endCol": 25,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 22,
-                                    "startCol": 26,
-                                    "end": 22,
-                                    "endCol": 36,
                                     "text": "customerId"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 22,
-                                "startCol": 38,
-                                "end": 22,
-                                "endCol": 47,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 22,
-                                    "startCol": 38,
-                                    "end": 22,
-                                    "endCol": 41,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 22,
-                                    "startCol": 42,
-                                    "end": 22,
-                                    "endCol": 47,
                                     "text": "total"
                                   }
                                 ]
@@ -1304,56 +612,28 @@
                           },
                           {
                             "kind": "constructor_body",
-                            "start": 22,
-                            "startCol": 49,
-                            "end": 26,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "expression_statement",
-                                "start": 23,
-                                "startCol": 12,
-                                "end": 23,
-                                "endCol": 25,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 23,
-                                    "startCol": 12,
-                                    "end": 23,
-                                    "endCol": 24,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 23,
-                                        "startCol": 12,
-                                        "end": 23,
-                                        "endCol": 19,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 23,
-                                            "startCol": 12,
-                                            "end": 23,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 23,
-                                            "startCol": 17,
-                                            "end": 23,
-                                            "endCol": 19,
                                             "text": "id"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 23,
-                                        "startCol": 22,
-                                        "end": 23,
-                                        "endCol": 24,
                                         "text": "id"
                                       }
                                     ]
@@ -1362,49 +642,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 24,
-                                "startCol": 12,
-                                "end": 24,
-                                "endCol": 41,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 24,
-                                    "startCol": 12,
-                                    "end": 24,
-                                    "endCol": 40,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 24,
-                                        "startCol": 12,
-                                        "end": 24,
-                                        "endCol": 27,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 24,
-                                            "startCol": 12,
-                                            "end": 24,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 24,
-                                            "startCol": 17,
-                                            "end": 24,
-                                            "endCol": 27,
                                             "text": "customerId"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 24,
-                                        "startCol": 30,
-                                        "end": 24,
-                                        "endCol": 40,
                                         "text": "customerId"
                                       }
                                     ]
@@ -1413,49 +669,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 25,
-                                "startCol": 12,
-                                "end": 25,
-                                "endCol": 31,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 25,
-                                    "startCol": 12,
-                                    "end": 25,
-                                    "endCol": 30,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 25,
-                                        "startCol": 12,
-                                        "end": 25,
-                                        "endCol": 22,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 25,
-                                            "startCol": 12,
-                                            "end": 25,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 25,
-                                            "startCol": 17,
-                                            "end": 25,
-                                            "endCol": 22,
                                             "text": "total"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 25,
-                                        "startCol": 25,
-                                        "end": 25,
-                                        "endCol": 30,
                                         "text": "total"
                                       }
                                     ]
@@ -1468,55 +700,23 @@
                       },
                       {
                         "kind": "method_declaration",
-                        "start": 27,
-                        "startCol": 8,
-                        "end": 32,
-                        "endCol": 9,
                         "children": [
                           {
-                            "kind": "boolean_type",
-                            "start": 27,
-                            "startCol": 8,
-                            "end": 27,
-                            "endCol": 15,
-                            "text": "boolean"
-                          },
-                          {
                             "kind": "identifier",
-                            "start": 27,
-                            "startCol": 16,
-                            "end": 27,
-                            "endCol": 27,
                             "text": "containsKey"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 27,
-                            "startCol": 27,
-                            "end": 27,
-                            "endCol": 37,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 27,
-                                "startCol": 28,
-                                "end": 27,
-                                "endCol": 36,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 27,
-                                    "startCol": 28,
-                                    "end": 27,
-                                    "endCol": 34,
                                     "text": "String"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 27,
-                                    "startCol": 35,
-                                    "end": 27,
-                                    "endCol": 36,
                                     "text": "k"
                                   }
                                 ]
@@ -1525,68 +725,32 @@
                           },
                           {
                             "kind": "block",
-                            "start": 27,
-                            "startCol": 38,
-                            "end": 32,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "if_statement",
-                                "start": 28,
-                                "startCol": 12,
-                                "end": 28,
-                                "endCol": 44,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 28,
-                                    "startCol": 15,
-                                    "end": 28,
-                                    "endCol": 31,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 28,
-                                        "startCol": 16,
-                                        "end": 28,
-                                        "endCol": 30,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 28,
-                                            "startCol": 16,
-                                            "end": 28,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 28,
-                                            "startCol": 18,
-                                            "end": 28,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 28,
-                                            "startCol": 24,
-                                            "end": 28,
-                                            "endCol": 30,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 28,
-                                                "startCol": 25,
-                                                "end": 28,
-                                                "endCol": 29,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 28,
-                                                    "startCol": 26,
-                                                    "end": 28,
-                                                    "endCol": 28,
                                                     "text": "id"
                                                   }
                                                 ]
@@ -1599,17 +763,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 28,
-                                    "startCol": 32,
-                                    "end": 28,
-                                    "endCol": 44,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 28,
-                                        "startCol": 39,
-                                        "end": 28,
-                                        "endCol": 43,
                                         "text": "true"
                                       }
                                     ]
@@ -1618,61 +774,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 29,
-                                "startCol": 12,
-                                "end": 29,
-                                "endCol": 52,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 29,
-                                    "startCol": 15,
-                                    "end": 29,
-                                    "endCol": 39,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 29,
-                                        "startCol": 16,
-                                        "end": 29,
-                                        "endCol": 38,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 29,
-                                            "startCol": 16,
-                                            "end": 29,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 29,
-                                            "startCol": 18,
-                                            "end": 29,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 29,
-                                            "startCol": 24,
-                                            "end": 29,
-                                            "endCol": 38,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 29,
-                                                "startCol": 25,
-                                                "end": 29,
-                                                "endCol": 37,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 29,
-                                                    "startCol": 26,
-                                                    "end": 29,
-                                                    "endCol": 36,
                                                     "text": "customerId"
                                                   }
                                                 ]
@@ -1685,17 +809,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 29,
-                                    "startCol": 40,
-                                    "end": 29,
-                                    "endCol": 52,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 29,
-                                        "startCol": 47,
-                                        "end": 29,
-                                        "endCol": 51,
                                         "text": "true"
                                       }
                                     ]
@@ -1704,61 +820,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 30,
-                                "startCol": 12,
-                                "end": 30,
-                                "endCol": 47,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 30,
-                                    "startCol": 15,
-                                    "end": 30,
-                                    "endCol": 34,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 30,
-                                        "startCol": 16,
-                                        "end": 30,
-                                        "endCol": 33,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 30,
-                                            "startCol": 16,
-                                            "end": 30,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 30,
-                                            "startCol": 18,
-                                            "end": 30,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 30,
-                                            "startCol": 24,
-                                            "end": 30,
-                                            "endCol": 33,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 30,
-                                                "startCol": 25,
-                                                "end": 30,
-                                                "endCol": 32,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 30,
-                                                    "startCol": 26,
-                                                    "end": 30,
-                                                    "endCol": 31,
                                                     "text": "total"
                                                   }
                                                 ]
@@ -1771,17 +855,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 30,
-                                    "startCol": 35,
-                                    "end": 30,
-                                    "endCol": 47,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 30,
-                                        "startCol": 42,
-                                        "end": 30,
-                                        "endCol": 46,
                                         "text": "true"
                                       }
                                     ]
@@ -1790,17 +866,9 @@
                               },
                               {
                                 "kind": "return_statement",
-                                "start": 31,
-                                "startCol": 12,
-                                "end": 31,
-                                "endCol": 25,
                                 "children": [
                                   {
                                     "kind": "false",
-                                    "start": 31,
-                                    "startCol": 19,
-                                    "end": 31,
-                                    "endCol": 24,
                                     "text": "false"
                                   }
                                 ]
@@ -1815,81 +883,37 @@
               },
               {
                 "kind": "field_declaration",
-                "start": 35,
-                "startCol": 4,
-                "end": 35,
-                "endCol": 550,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 35,
-                    "startCol": 4,
-                    "end": 35,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "generic_type",
-                    "start": 35,
-                    "startCol": 11,
-                    "end": 35,
-                    "endCol": 34,
                     "children": [
                       {
                         "kind": "scoped_type_identifier",
-                        "start": 35,
-                        "startCol": 11,
-                        "end": 35,
-                        "endCol": 25,
                         "children": [
                           {
                             "kind": "scoped_type_identifier",
-                            "start": 35,
-                            "startCol": 11,
-                            "end": 35,
-                            "endCol": 20,
                             "children": [
                               {
                                 "kind": "type_identifier",
-                                "start": 35,
-                                "startCol": 11,
-                                "end": 35,
-                                "endCol": 15,
                                 "text": "java"
                               },
                               {
                                 "kind": "type_identifier",
-                                "start": 35,
-                                "startCol": 16,
-                                "end": 35,
-                                "endCol": 20,
                                 "text": "util"
                               }
                             ]
                           },
                           {
                             "kind": "type_identifier",
-                            "start": 35,
-                            "startCol": 21,
-                            "end": 35,
-                            "endCol": 25,
                             "text": "List"
                           }
                         ]
                       },
                       {
                         "kind": "type_arguments",
-                        "start": 35,
-                        "startCol": 25,
-                        "end": 35,
-                        "endCol": 34,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 35,
-                            "startCol": 26,
-                            "end": 35,
-                            "endCol": 33,
                             "text": "Result4"
                           }
                         ]
@@ -1898,88 +922,44 @@
                   },
                   {
                     "kind": "variable_declarator",
-                    "start": 35,
-                    "startCol": 35,
-                    "end": 35,
-                    "endCol": 549,
                     "children": [
                       {
                         "kind": "identifier",
-                        "start": 35,
-                        "startCol": 35,
-                        "end": 35,
-                        "endCol": 41,
                         "text": "result"
                       },
                       {
                         "kind": "object_creation_expression",
-                        "start": 35,
-                        "startCol": 44,
-                        "end": 35,
-                        "endCol": 549,
                         "children": [
                           {
                             "kind": "generic_type",
-                            "start": 35,
-                            "startCol": 48,
-                            "end": 35,
-                            "endCol": 76,
                             "children": [
                               {
                                 "kind": "scoped_type_identifier",
-                                "start": 35,
-                                "startCol": 48,
-                                "end": 35,
-                                "endCol": 67,
                                 "children": [
                                   {
                                     "kind": "scoped_type_identifier",
-                                    "start": 35,
-                                    "startCol": 48,
-                                    "end": 35,
-                                    "endCol": 57,
                                     "children": [
                                       {
                                         "kind": "type_identifier",
-                                        "start": 35,
-                                        "startCol": 48,
-                                        "end": 35,
-                                        "endCol": 52,
                                         "text": "java"
                                       },
                                       {
                                         "kind": "type_identifier",
-                                        "start": 35,
-                                        "startCol": 53,
-                                        "end": 35,
-                                        "endCol": 57,
                                         "text": "util"
                                       }
                                     ]
                                   },
                                   {
                                     "kind": "type_identifier",
-                                    "start": 35,
-                                    "startCol": 58,
-                                    "end": 35,
-                                    "endCol": 67,
                                     "text": "ArrayList"
                                   }
                                 ]
                               },
                               {
                                 "kind": "type_arguments",
-                                "start": 35,
-                                "startCol": 67,
-                                "end": 35,
-                                "endCol": 76,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 35,
-                                    "startCol": 68,
-                                    "end": 35,
-                                    "endCol": 75,
                                     "text": "Result4"
                                   }
                                 ]
@@ -1987,96 +967,44 @@
                             ]
                           },
                           {
-                            "kind": "argument_list",
-                            "start": 35,
-                            "startCol": 76,
-                            "end": 35,
-                            "endCol": 78,
-                            "text": "()"
-                          },
-                          {
                             "kind": "class_body",
-                            "start": 35,
-                            "startCol": 79,
-                            "end": 35,
-                            "endCol": 549,
                             "children": [
                               {
                                 "kind": "block",
-                                "start": 35,
-                                "startCol": 80,
-                                "end": 35,
-                                "endCol": 548,
                                 "children": [
                                   {
                                     "kind": "local_variable_declaration",
-                                    "start": 35,
-                                    "startCol": 82,
-                                    "end": 35,
-                                    "endCol": 146,
                                     "children": [
                                       {
                                         "kind": "generic_type",
-                                        "start": 35,
-                                        "startCol": 82,
-                                        "end": 35,
-                                        "endCol": 110,
                                         "children": [
                                           {
                                             "kind": "scoped_type_identifier",
-                                            "start": 35,
-                                            "startCol": 82,
-                                            "end": 35,
-                                            "endCol": 101,
                                             "children": [
                                               {
                                                 "kind": "scoped_type_identifier",
-                                                "start": 35,
-                                                "startCol": 82,
-                                                "end": 35,
-                                                "endCol": 91,
                                                 "children": [
                                                   {
                                                     "kind": "type_identifier",
-                                                    "start": 35,
-                                                    "startCol": 82,
-                                                    "end": 35,
-                                                    "endCol": 86,
                                                     "text": "java"
                                                   },
                                                   {
                                                     "kind": "type_identifier",
-                                                    "start": 35,
-                                                    "startCol": 87,
-                                                    "end": 35,
-                                                    "endCol": 91,
                                                     "text": "util"
                                                   }
                                                 ]
                                               },
                                               {
                                                 "kind": "type_identifier",
-                                                "start": 35,
-                                                "startCol": 92,
-                                                "end": 35,
-                                                "endCol": 101,
                                                 "text": "ArrayList"
                                               }
                                             ]
                                           },
                                           {
                                             "kind": "type_arguments",
-                                            "start": 35,
-                                            "startCol": 101,
-                                            "end": 35,
-                                            "endCol": 110,
                                             "children": [
                                               {
                                                 "kind": "type_identifier",
-                                                "start": 35,
-                                                "startCol": 102,
-                                                "end": 35,
-                                                "endCol": 109,
                                                 "text": "Result4"
                                               }
                                             ]
@@ -2085,92 +1013,40 @@
                                       },
                                       {
                                         "kind": "variable_declarator",
-                                        "start": 35,
-                                        "startCol": 111,
-                                        "end": 35,
-                                        "endCol": 145,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 111,
-                                            "end": 35,
-                                            "endCol": 115,
                                             "text": "_tmp"
                                           },
                                           {
                                             "kind": "object_creation_expression",
-                                            "start": 35,
-                                            "startCol": 118,
-                                            "end": 35,
-                                            "endCol": 145,
                                             "children": [
                                               {
                                                 "kind": "generic_type",
-                                                "start": 35,
-                                                "startCol": 122,
-                                                "end": 35,
-                                                "endCol": 143,
                                                 "children": [
                                                   {
                                                     "kind": "scoped_type_identifier",
-                                                    "start": 35,
-                                                    "startCol": 122,
-                                                    "end": 35,
-                                                    "endCol": 141,
                                                     "children": [
                                                       {
                                                         "kind": "scoped_type_identifier",
-                                                        "start": 35,
-                                                        "startCol": 122,
-                                                        "end": 35,
-                                                        "endCol": 131,
                                                         "children": [
                                                           {
                                                             "kind": "type_identifier",
-                                                            "start": 35,
-                                                            "startCol": 122,
-                                                            "end": 35,
-                                                            "endCol": 126,
                                                             "text": "java"
                                                           },
                                                           {
                                                             "kind": "type_identifier",
-                                                            "start": 35,
-                                                            "startCol": 127,
-                                                            "end": 35,
-                                                            "endCol": 131,
                                                             "text": "util"
                                                           }
                                                         ]
                                                       },
                                                       {
                                                         "kind": "type_identifier",
-                                                        "start": 35,
-                                                        "startCol": 132,
-                                                        "end": 35,
-                                                        "endCol": 141,
                                                         "text": "ArrayList"
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "kind": "type_arguments",
-                                                    "start": 35,
-                                                    "startCol": 141,
-                                                    "end": 35,
-                                                    "endCol": 143,
-                                                    "text": "\u003c\u003e"
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": "argument_list",
-                                                "start": 35,
-                                                "startCol": 143,
-                                                "end": 35,
-                                                "endCol": 145,
-                                                "text": "()"
                                               }
                                             ]
                                           }
@@ -2180,211 +1056,99 @@
                                   },
                                   {
                                     "kind": "enhanced_for_statement",
-                                    "start": 35,
-                                    "startCol": 147,
-                                    "end": 35,
-                                    "endCol": 322,
                                     "children": [
                                       {
                                         "kind": "type_identifier",
-                                        "start": 35,
-                                        "startCol": 152,
-                                        "end": 35,
-                                        "endCol": 155,
                                         "text": "var"
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 35,
-                                        "startCol": 156,
-                                        "end": 35,
-                                        "endCol": 157,
                                         "text": "o"
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 35,
-                                        "startCol": 160,
-                                        "end": 35,
-                                        "endCol": 166,
                                         "text": "orders"
                                       },
                                       {
                                         "kind": "block",
-                                        "start": 35,
-                                        "startCol": 168,
-                                        "end": 35,
-                                        "endCol": 322,
                                         "children": [
                                           {
                                             "kind": "enhanced_for_statement",
-                                            "start": 35,
-                                            "startCol": 170,
-                                            "end": 35,
-                                            "endCol": 320,
                                             "children": [
                                               {
                                                 "kind": "type_identifier",
-                                                "start": 35,
-                                                "startCol": 175,
-                                                "end": 35,
-                                                "endCol": 178,
                                                 "text": "var"
                                               },
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 179,
-                                                "end": 35,
-                                                "endCol": 180,
                                                 "text": "c"
                                               },
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 183,
-                                                "end": 35,
-                                                "endCol": 192,
                                                 "text": "customers"
                                               },
                                               {
                                                 "kind": "block",
-                                                "start": 35,
-                                                "startCol": 194,
-                                                "end": 35,
-                                                "endCol": 320,
                                                 "children": [
                                                   {
                                                     "kind": "expression_statement",
-                                                    "start": 35,
-                                                    "startCol": 196,
-                                                    "end": 35,
-                                                    "endCol": 318,
                                                     "children": [
                                                       {
                                                         "kind": "method_invocation",
-                                                        "start": 35,
-                                                        "startCol": 196,
-                                                        "end": 35,
-                                                        "endCol": 317,
                                                         "children": [
                                                           {
                                                             "kind": "identifier",
-                                                            "start": 35,
-                                                            "startCol": 196,
-                                                            "end": 35,
-                                                            "endCol": 200,
                                                             "text": "_tmp"
                                                           },
                                                           {
                                                             "kind": "identifier",
-                                                            "start": 35,
-                                                            "startCol": 201,
-                                                            "end": 35,
-                                                            "endCol": 204,
                                                             "text": "add"
                                                           },
                                                           {
                                                             "kind": "argument_list",
-                                                            "start": 35,
-                                                            "startCol": 204,
-                                                            "end": 35,
-                                                            "endCol": 317,
                                                             "children": [
                                                               {
                                                                 "kind": "object_creation_expression",
-                                                                "start": 35,
-                                                                "startCol": 205,
-                                                                "end": 35,
-                                                                "endCol": 316,
                                                                 "children": [
                                                                   {
                                                                     "kind": "type_identifier",
-                                                                    "start": 35,
-                                                                    "startCol": 209,
-                                                                    "end": 35,
-                                                                    "endCol": 216,
                                                                     "text": "Result4"
                                                                   },
                                                                   {
                                                                     "kind": "argument_list",
-                                                                    "start": 35,
-                                                                    "startCol": 216,
-                                                                    "end": 35,
-                                                                    "endCol": 316,
                                                                     "children": [
                                                                       {
                                                                         "kind": "parenthesized_expression",
-                                                                        "start": 35,
-                                                                        "startCol": 217,
-                                                                        "end": 35,
-                                                                        "endCol": 242,
                                                                         "children": [
                                                                           {
                                                                             "kind": "cast_expression",
-                                                                            "start": 35,
-                                                                            "startCol": 218,
-                                                                            "end": 35,
-                                                                            "endCol": 241,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "type_identifier",
-                                                                                "start": 35,
-                                                                                "startCol": 219,
-                                                                                "end": 35,
-                                                                                "endCol": 226,
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
                                                                                 "kind": "parenthesized_expression",
-                                                                                "start": 35,
-                                                                                "startCol": 228,
-                                                                                "end": 35,
-                                                                                "endCol": 241,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "method_invocation",
-                                                                                    "start": 35,
-                                                                                    "startCol": 229,
-                                                                                    "end": 35,
-                                                                                    "endCol": 240,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 229,
-                                                                                        "end": 35,
-                                                                                        "endCol": 230,
                                                                                         "text": "o"
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 231,
-                                                                                        "end": 35,
-                                                                                        "endCol": 234,
                                                                                         "text": "get"
                                                                                       },
                                                                                       {
                                                                                         "kind": "argument_list",
-                                                                                        "start": 35,
-                                                                                        "startCol": 234,
-                                                                                        "end": 35,
-                                                                                        "endCol": 240,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "string_literal",
-                                                                                            "start": 35,
-                                                                                            "startCol": 235,
-                                                                                            "end": 35,
-                                                                                            "endCol": 239,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "string_fragment",
-                                                                                                "start": 35,
-                                                                                                "startCol": 236,
-                                                                                                "end": 35,
-                                                                                                "endCol": 238,
                                                                                                 "text": "id"
                                                                                               }
                                                                                             ]
@@ -2401,76 +1165,36 @@
                                                                       },
                                                                       {
                                                                         "kind": "parenthesized_expression",
-                                                                        "start": 35,
-                                                                        "startCol": 244,
-                                                                        "end": 35,
-                                                                        "endCol": 277,
                                                                         "children": [
                                                                           {
                                                                             "kind": "cast_expression",
-                                                                            "start": 35,
-                                                                            "startCol": 245,
-                                                                            "end": 35,
-                                                                            "endCol": 276,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "type_identifier",
-                                                                                "start": 35,
-                                                                                "startCol": 246,
-                                                                                "end": 35,
-                                                                                "endCol": 253,
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
                                                                                 "kind": "parenthesized_expression",
-                                                                                "start": 35,
-                                                                                "startCol": 255,
-                                                                                "end": 35,
-                                                                                "endCol": 276,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "method_invocation",
-                                                                                    "start": 35,
-                                                                                    "startCol": 256,
-                                                                                    "end": 35,
-                                                                                    "endCol": 275,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 256,
-                                                                                        "end": 35,
-                                                                                        "endCol": 257,
                                                                                         "text": "o"
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 258,
-                                                                                        "end": 35,
-                                                                                        "endCol": 261,
                                                                                         "text": "get"
                                                                                       },
                                                                                       {
                                                                                         "kind": "argument_list",
-                                                                                        "start": 35,
-                                                                                        "startCol": 261,
-                                                                                        "end": 35,
-                                                                                        "endCol": 275,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "string_literal",
-                                                                                            "start": 35,
-                                                                                            "startCol": 262,
-                                                                                            "end": 35,
-                                                                                            "endCol": 274,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "string_fragment",
-                                                                                                "start": 35,
-                                                                                                "startCol": 263,
-                                                                                                "end": 35,
-                                                                                                "endCol": 273,
                                                                                                 "text": "customerId"
                                                                                               }
                                                                                             ]
@@ -2487,101 +1211,49 @@
                                                                       },
                                                                       {
                                                                         "kind": "field_access",
-                                                                        "start": 35,
-                                                                        "startCol": 279,
-                                                                        "end": 35,
-                                                                        "endCol": 285,
                                                                         "children": [
                                                                           {
                                                                             "kind": "identifier",
-                                                                            "start": 35,
-                                                                            "startCol": 279,
-                                                                            "end": 35,
-                                                                            "endCol": 280,
                                                                             "text": "c"
                                                                           },
                                                                           {
                                                                             "kind": "identifier",
-                                                                            "start": 35,
-                                                                            "startCol": 281,
-                                                                            "end": 35,
-                                                                            "endCol": 285,
                                                                             "text": "name"
                                                                           }
                                                                         ]
                                                                       },
                                                                       {
                                                                         "kind": "parenthesized_expression",
-                                                                        "start": 35,
-                                                                        "startCol": 287,
-                                                                        "end": 35,
-                                                                        "endCol": 315,
                                                                         "children": [
                                                                           {
                                                                             "kind": "cast_expression",
-                                                                            "start": 35,
-                                                                            "startCol": 288,
-                                                                            "end": 35,
-                                                                            "endCol": 314,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "type_identifier",
-                                                                                "start": 35,
-                                                                                "startCol": 289,
-                                                                                "end": 35,
-                                                                                "endCol": 296,
                                                                                 "text": "Integer"
                                                                               },
                                                                               {
                                                                                 "kind": "parenthesized_expression",
-                                                                                "start": 35,
-                                                                                "startCol": 298,
-                                                                                "end": 35,
-                                                                                "endCol": 314,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "method_invocation",
-                                                                                    "start": 35,
-                                                                                    "startCol": 299,
-                                                                                    "end": 35,
-                                                                                    "endCol": 313,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 299,
-                                                                                        "end": 35,
-                                                                                        "endCol": 300,
                                                                                         "text": "o"
                                                                                       },
                                                                                       {
                                                                                         "kind": "identifier",
-                                                                                        "start": 35,
-                                                                                        "startCol": 301,
-                                                                                        "end": 35,
-                                                                                        "endCol": 304,
                                                                                         "text": "get"
                                                                                       },
                                                                                       {
                                                                                         "kind": "argument_list",
-                                                                                        "start": 35,
-                                                                                        "startCol": 304,
-                                                                                        "end": 35,
-                                                                                        "endCol": 313,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "string_literal",
-                                                                                            "start": 35,
-                                                                                            "startCol": 305,
-                                                                                            "end": 35,
-                                                                                            "endCol": 312,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "string_fragment",
-                                                                                                "start": 35,
-                                                                                                "startCol": 306,
-                                                                                                "end": 35,
-                                                                                                "endCol": 311,
                                                                                                 "text": "total"
                                                                                               }
                                                                                             ]
@@ -2616,73 +1288,37 @@
                                   },
                                   {
                                     "kind": "local_variable_declaration",
-                                    "start": 35,
-                                    "startCol": 323,
-                                    "end": 35,
-                                    "endCol": 364,
                                     "children": [
                                       {
                                         "kind": "generic_type",
-                                        "start": 35,
-                                        "startCol": 323,
-                                        "end": 35,
-                                        "endCol": 351,
                                         "children": [
                                           {
                                             "kind": "scoped_type_identifier",
-                                            "start": 35,
-                                            "startCol": 323,
-                                            "end": 35,
-                                            "endCol": 342,
                                             "children": [
                                               {
                                                 "kind": "scoped_type_identifier",
-                                                "start": 35,
-                                                "startCol": 323,
-                                                "end": 35,
-                                                "endCol": 332,
                                                 "children": [
                                                   {
                                                     "kind": "type_identifier",
-                                                    "start": 35,
-                                                    "startCol": 323,
-                                                    "end": 35,
-                                                    "endCol": 327,
                                                     "text": "java"
                                                   },
                                                   {
                                                     "kind": "type_identifier",
-                                                    "start": 35,
-                                                    "startCol": 328,
-                                                    "end": 35,
-                                                    "endCol": 332,
                                                     "text": "util"
                                                   }
                                                 ]
                                               },
                                               {
                                                 "kind": "type_identifier",
-                                                "start": 35,
-                                                "startCol": 333,
-                                                "end": 35,
-                                                "endCol": 342,
                                                 "text": "ArrayList"
                                               }
                                             ]
                                           },
                                           {
                                             "kind": "type_arguments",
-                                            "start": 35,
-                                            "startCol": 342,
-                                            "end": 35,
-                                            "endCol": 351,
                                             "children": [
                                               {
                                                 "kind": "type_identifier",
-                                                "start": 35,
-                                                "startCol": 343,
-                                                "end": 35,
-                                                "endCol": 350,
                                                 "text": "Result4"
                                               }
                                             ]
@@ -2691,25 +1327,13 @@
                                       },
                                       {
                                         "kind": "variable_declarator",
-                                        "start": 35,
-                                        "startCol": 352,
-                                        "end": 35,
-                                        "endCol": 363,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 352,
-                                            "end": 35,
-                                            "endCol": 356,
                                             "text": "list"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 359,
-                                            "end": 35,
-                                            "endCol": 363,
                                             "text": "_tmp"
                                           }
                                         ]
@@ -2718,40 +1342,16 @@
                                   },
                                   {
                                     "kind": "local_variable_declaration",
-                                    "start": 35,
-                                    "startCol": 365,
-                                    "end": 35,
-                                    "endCol": 378,
                                     "children": [
                                       {
-                                        "kind": "integral_type",
-                                        "start": 35,
-                                        "startCol": 365,
-                                        "end": 35,
-                                        "endCol": 368,
-                                        "text": "int"
-                                      },
-                                      {
                                         "kind": "variable_declarator",
-                                        "start": 35,
-                                        "startCol": 369,
-                                        "end": 35,
-                                        "endCol": 377,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 369,
-                                            "end": 35,
-                                            "endCol": 373,
                                             "text": "skip"
                                           },
                                           {
                                             "kind": "decimal_integer_literal",
-                                            "start": 35,
-                                            "startCol": 376,
-                                            "end": 35,
-                                            "endCol": 377,
                                             "text": "0"
                                           }
                                         ]
@@ -2760,47 +1360,19 @@
                                   },
                                   {
                                     "kind": "local_variable_declaration",
-                                    "start": 35,
-                                    "startCol": 379,
-                                    "end": 35,
-                                    "endCol": 393,
                                     "children": [
                                       {
-                                        "kind": "integral_type",
-                                        "start": 35,
-                                        "startCol": 379,
-                                        "end": 35,
-                                        "endCol": 382,
-                                        "text": "int"
-                                      },
-                                      {
                                         "kind": "variable_declarator",
-                                        "start": 35,
-                                        "startCol": 383,
-                                        "end": 35,
-                                        "endCol": 392,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 383,
-                                            "end": 35,
-                                            "endCol": 387,
                                             "text": "take"
                                           },
                                           {
                                             "kind": "unary_expression",
-                                            "start": 35,
-                                            "startCol": 390,
-                                            "end": 35,
-                                            "endCol": 392,
                                             "children": [
                                               {
                                                 "kind": "decimal_integer_literal",
-                                                "start": 35,
-                                                "startCol": 391,
-                                                "end": 35,
-                                                "endCol": 392,
                                                 "text": "1"
                                               }
                                             ]
@@ -2811,47 +1383,19 @@
                                   },
                                   {
                                     "kind": "for_statement",
-                                    "start": 35,
-                                    "startCol": 394,
-                                    "end": 35,
-                                    "endCol": 533,
                                     "children": [
                                       {
                                         "kind": "local_variable_declaration",
-                                        "start": 35,
-                                        "startCol": 399,
-                                        "end": 35,
-                                        "endCol": 409,
                                         "children": [
                                           {
-                                            "kind": "integral_type",
-                                            "start": 35,
-                                            "startCol": 399,
-                                            "end": 35,
-                                            "endCol": 402,
-                                            "text": "int"
-                                          },
-                                          {
                                             "kind": "variable_declarator",
-                                            "start": 35,
-                                            "startCol": 403,
-                                            "end": 35,
-                                            "endCol": 408,
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 403,
-                                                "end": 35,
-                                                "endCol": 404,
                                                 "text": "i"
                                               },
                                               {
                                                 "kind": "decimal_integer_literal",
-                                                "start": 35,
-                                                "startCol": 407,
-                                                "end": 35,
-                                                "endCol": 408,
                                                 "text": "0"
                                               }
                                             ]
@@ -2860,49 +1404,21 @@
                                       },
                                       {
                                         "kind": "binary_expression",
-                                        "start": 35,
-                                        "startCol": 410,
-                                        "end": 35,
-                                        "endCol": 425,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 410,
-                                            "end": 35,
-                                            "endCol": 411,
                                             "text": "i"
                                           },
                                           {
                                             "kind": "method_invocation",
-                                            "start": 35,
-                                            "startCol": 414,
-                                            "end": 35,
-                                            "endCol": 425,
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 414,
-                                                "end": 35,
-                                                "endCol": 418,
                                                 "text": "list"
                                               },
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 419,
-                                                "end": 35,
-                                                "endCol": 423,
                                                 "text": "size"
-                                              },
-                                              {
-                                                "kind": "argument_list",
-                                                "start": 35,
-                                                "startCol": 423,
-                                                "end": 35,
-                                                "endCol": 425,
-                                                "text": "()"
                                               }
                                             ]
                                           }
@@ -2910,161 +1426,77 @@
                                       },
                                       {
                                         "kind": "update_expression",
-                                        "start": 35,
-                                        "startCol": 427,
-                                        "end": 35,
-                                        "endCol": 430,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 427,
-                                            "end": 35,
-                                            "endCol": 428,
                                             "text": "i"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "block",
-                                        "start": 35,
-                                        "startCol": 432,
-                                        "end": 35,
-                                        "endCol": 533,
                                         "children": [
                                           {
                                             "kind": "if_statement",
-                                            "start": 35,
-                                            "startCol": 434,
-                                            "end": 35,
-                                            "endCol": 457,
                                             "children": [
                                               {
                                                 "kind": "parenthesized_expression",
-                                                "start": 35,
-                                                "startCol": 437,
-                                                "end": 35,
-                                                "endCol": 447,
                                                 "children": [
                                                   {
                                                     "kind": "binary_expression",
-                                                    "start": 35,
-                                                    "startCol": 438,
-                                                    "end": 35,
-                                                    "endCol": 446,
                                                     "children": [
                                                       {
                                                         "kind": "identifier",
-                                                        "start": 35,
-                                                        "startCol": 438,
-                                                        "end": 35,
-                                                        "endCol": 439,
                                                         "text": "i"
                                                       },
                                                       {
                                                         "kind": "identifier",
-                                                        "start": 35,
-                                                        "startCol": 442,
-                                                        "end": 35,
-                                                        "endCol": 446,
                                                         "text": "skip"
                                                       }
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": "continue_statement",
-                                                "start": 35,
-                                                "startCol": 448,
-                                                "end": 35,
-                                                "endCol": 457,
-                                                "text": "continue;"
                                               }
                                             ]
                                           },
                                           {
                                             "kind": "if_statement",
-                                            "start": 35,
-                                            "startCol": 458,
-                                            "end": 35,
-                                            "endCol": 499,
                                             "children": [
                                               {
                                                 "kind": "parenthesized_expression",
-                                                "start": 35,
-                                                "startCol": 461,
-                                                "end": 35,
-                                                "endCol": 492,
                                                 "children": [
                                                   {
                                                     "kind": "binary_expression",
-                                                    "start": 35,
-                                                    "startCol": 462,
-                                                    "end": 35,
-                                                    "endCol": 491,
                                                     "children": [
                                                       {
                                                         "kind": "binary_expression",
-                                                        "start": 35,
-                                                        "startCol": 462,
-                                                        "end": 35,
-                                                        "endCol": 471,
                                                         "children": [
                                                           {
                                                             "kind": "identifier",
-                                                            "start": 35,
-                                                            "startCol": 462,
-                                                            "end": 35,
-                                                            "endCol": 466,
                                                             "text": "take"
                                                           },
                                                           {
                                                             "kind": "decimal_integer_literal",
-                                                            "start": 35,
-                                                            "startCol": 470,
-                                                            "end": 35,
-                                                            "endCol": 471,
                                                             "text": "0"
                                                           }
                                                         ]
                                                       },
                                                       {
                                                         "kind": "binary_expression",
-                                                        "start": 35,
-                                                        "startCol": 475,
-                                                        "end": 35,
-                                                        "endCol": 491,
                                                         "children": [
                                                           {
                                                             "kind": "identifier",
-                                                            "start": 35,
-                                                            "startCol": 475,
-                                                            "end": 35,
-                                                            "endCol": 476,
                                                             "text": "i"
                                                           },
                                                           {
                                                             "kind": "binary_expression",
-                                                            "start": 35,
-                                                            "startCol": 480,
-                                                            "end": 35,
-                                                            "endCol": 491,
                                                             "children": [
                                                               {
                                                                 "kind": "identifier",
-                                                                "start": 35,
-                                                                "startCol": 480,
-                                                                "end": 35,
-                                                                "endCol": 484,
                                                                 "text": "skip"
                                                               },
                                                               {
                                                                 "kind": "identifier",
-                                                                "start": 35,
-                                                                "startCol": 487,
-                                                                "end": 35,
-                                                                "endCol": 491,
                                                                 "text": "take"
                                                               }
                                                             ]
@@ -3074,105 +1506,49 @@
                                                     ]
                                                   }
                                                 ]
-                                              },
-                                              {
-                                                "kind": "break_statement",
-                                                "start": 35,
-                                                "startCol": 493,
-                                                "end": 35,
-                                                "endCol": 499,
-                                                "text": "break;"
                                               }
                                             ]
                                           },
                                           {
                                             "kind": "expression_statement",
-                                            "start": 35,
-                                            "startCol": 500,
-                                            "end": 35,
-                                            "endCol": 531,
                                             "children": [
                                               {
                                                 "kind": "method_invocation",
-                                                "start": 35,
-                                                "startCol": 500,
-                                                "end": 35,
-                                                "endCol": 530,
                                                 "children": [
                                                   {
                                                     "kind": "identifier",
-                                                    "start": 35,
-                                                    "startCol": 500,
-                                                    "end": 35,
-                                                    "endCol": 504,
                                                     "text": "_tmp"
                                                   },
                                                   {
                                                     "kind": "identifier",
-                                                    "start": 35,
-                                                    "startCol": 505,
-                                                    "end": 35,
-                                                    "endCol": 508,
                                                     "text": "add"
                                                   },
                                                   {
                                                     "kind": "argument_list",
-                                                    "start": 35,
-                                                    "startCol": 508,
-                                                    "end": 35,
-                                                    "endCol": 530,
                                                     "children": [
                                                       {
                                                         "kind": "cast_expression",
-                                                        "start": 35,
-                                                        "startCol": 509,
-                                                        "end": 35,
-                                                        "endCol": 529,
                                                         "children": [
                                                           {
                                                             "kind": "type_identifier",
-                                                            "start": 35,
-                                                            "startCol": 510,
-                                                            "end": 35,
-                                                            "endCol": 517,
                                                             "text": "Result4"
                                                           },
                                                           {
                                                             "kind": "method_invocation",
-                                                            "start": 35,
-                                                            "startCol": 518,
-                                                            "end": 35,
-                                                            "endCol": 529,
                                                             "children": [
                                                               {
                                                                 "kind": "identifier",
-                                                                "start": 35,
-                                                                "startCol": 518,
-                                                                "end": 35,
-                                                                "endCol": 522,
                                                                 "text": "list"
                                                               },
                                                               {
                                                                 "kind": "identifier",
-                                                                "start": 35,
-                                                                "startCol": 523,
-                                                                "end": 35,
-                                                                "endCol": 526,
                                                                 "text": "get"
                                                               },
                                                               {
                                                                 "kind": "argument_list",
-                                                                "start": 35,
-                                                                "startCol": 526,
-                                                                "end": 35,
-                                                                "endCol": 529,
                                                                 "children": [
                                                                   {
                                                                     "kind": "identifier",
-                                                                    "start": 35,
-                                                                    "startCol": 527,
-                                                                    "end": 35,
-                                                                    "endCol": 528,
                                                                     "text": "i"
                                                                   }
                                                                 ]
@@ -3193,39 +1569,19 @@
                                   },
                                   {
                                     "kind": "expression_statement",
-                                    "start": 35,
-                                    "startCol": 534,
-                                    "end": 35,
-                                    "endCol": 547,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 35,
-                                        "startCol": 534,
-                                        "end": 35,
-                                        "endCol": 546,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 35,
-                                            "startCol": 534,
-                                            "end": 35,
-                                            "endCol": 540,
                                             "text": "addAll"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 35,
-                                            "startCol": 540,
-                                            "end": 35,
-                                            "endCol": 546,
                                             "children": [
                                               {
                                                 "kind": "identifier",
-                                                "start": 35,
-                                                "startCol": 541,
-                                                "end": 35,
-                                                "endCol": 545,
                                                 "text": "_tmp"
                                               }
                                             ]
@@ -3246,62 +1602,22 @@
               },
               {
                 "kind": "class_declaration",
-                "start": 36,
-                "startCol": 4,
-                "end": 54,
-                "endCol": 5,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 36,
-                    "startCol": 4,
-                    "end": 36,
-                    "endCol": 10,
-                    "text": "static"
-                  },
-                  {
                     "kind": "identifier",
-                    "start": 36,
-                    "startCol": 17,
-                    "end": 36,
-                    "endCol": 24,
                     "text": "Result4"
                   },
                   {
                     "kind": "class_body",
-                    "start": 36,
-                    "startCol": 25,
-                    "end": 54,
-                    "endCol": 5,
                     "children": [
                       {
                         "kind": "field_declaration",
-                        "start": 37,
-                        "startCol": 8,
-                        "end": 37,
-                        "endCol": 20,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 37,
-                            "startCol": 8,
-                            "end": 37,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 37,
-                            "startCol": 12,
-                            "end": 37,
-                            "endCol": 19,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 37,
-                                "startCol": 12,
-                                "end": 37,
-                                "endCol": 19,
                                 "text": "orderId"
                               }
                             ]
@@ -3310,32 +1626,12 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 38,
-                        "startCol": 8,
-                        "end": 38,
-                        "endCol": 28,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 38,
-                            "startCol": 8,
-                            "end": 38,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 38,
-                            "startCol": 12,
-                            "end": 38,
-                            "endCol": 27,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 38,
-                                "startCol": 12,
-                                "end": 38,
-                                "endCol": 27,
                                 "text": "orderCustomerId"
                               }
                             ]
@@ -3344,32 +1640,16 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 39,
-                        "startCol": 8,
-                        "end": 39,
-                        "endCol": 34,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 39,
-                            "startCol": 8,
-                            "end": 39,
-                            "endCol": 14,
                             "text": "Object"
                           },
                           {
                             "kind": "variable_declarator",
-                            "start": 39,
-                            "startCol": 15,
-                            "end": 39,
-                            "endCol": 33,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 39,
-                                "startCol": 15,
-                                "end": 39,
-                                "endCol": 33,
                                 "text": "pairedCustomerName"
                               }
                             ]
@@ -3378,32 +1658,12 @@
                       },
                       {
                         "kind": "field_declaration",
-                        "start": 40,
-                        "startCol": 8,
-                        "end": 40,
-                        "endCol": 23,
                         "children": [
                           {
-                            "kind": "integral_type",
-                            "start": 40,
-                            "startCol": 8,
-                            "end": 40,
-                            "endCol": 11,
-                            "text": "int"
-                          },
-                          {
                             "kind": "variable_declarator",
-                            "start": 40,
-                            "startCol": 12,
-                            "end": 40,
-                            "endCol": 22,
                             "children": [
                               {
                                 "kind": "identifier",
-                                "start": 40,
-                                "startCol": 12,
-                                "end": 40,
-                                "endCol": 22,
                                 "text": "orderTotal"
                               }
                             ]
@@ -3412,122 +1672,50 @@
                       },
                       {
                         "kind": "constructor_declaration",
-                        "start": 41,
-                        "startCol": 8,
-                        "end": 46,
-                        "endCol": 9,
                         "children": [
                           {
                             "kind": "identifier",
-                            "start": 41,
-                            "startCol": 8,
-                            "end": 41,
-                            "endCol": 15,
                             "text": "Result4"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 41,
-                            "startCol": 15,
-                            "end": 41,
-                            "endCol": 92,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 41,
-                                "startCol": 16,
-                                "end": 41,
-                                "endCol": 27,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 41,
-                                    "startCol": 16,
-                                    "end": 41,
-                                    "endCol": 19,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 41,
-                                    "startCol": 20,
-                                    "end": 41,
-                                    "endCol": 27,
                                     "text": "orderId"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 41,
-                                "startCol": 29,
-                                "end": 41,
-                                "endCol": 48,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 41,
-                                    "startCol": 29,
-                                    "end": 41,
-                                    "endCol": 32,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 41,
-                                    "startCol": 33,
-                                    "end": 41,
-                                    "endCol": 48,
                                     "text": "orderCustomerId"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 41,
-                                "startCol": 50,
-                                "end": 41,
-                                "endCol": 75,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 41,
-                                    "startCol": 50,
-                                    "end": 41,
-                                    "endCol": 56,
                                     "text": "Object"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 41,
-                                    "startCol": 57,
-                                    "end": 41,
-                                    "endCol": 75,
                                     "text": "pairedCustomerName"
                                   }
                                 ]
                               },
                               {
                                 "kind": "formal_parameter",
-                                "start": 41,
-                                "startCol": 77,
-                                "end": 41,
-                                "endCol": 91,
                                 "children": [
                                   {
-                                    "kind": "integral_type",
-                                    "start": 41,
-                                    "startCol": 77,
-                                    "end": 41,
-                                    "endCol": 80,
-                                    "text": "int"
-                                  },
-                                  {
                                     "kind": "identifier",
-                                    "start": 41,
-                                    "startCol": 81,
-                                    "end": 41,
-                                    "endCol": 91,
                                     "text": "orderTotal"
                                   }
                                 ]
@@ -3536,56 +1724,28 @@
                           },
                           {
                             "kind": "constructor_body",
-                            "start": 41,
-                            "startCol": 93,
-                            "end": 46,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "expression_statement",
-                                "start": 42,
-                                "startCol": 12,
-                                "end": 42,
-                                "endCol": 35,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 42,
-                                    "startCol": 12,
-                                    "end": 42,
-                                    "endCol": 34,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 42,
-                                        "startCol": 12,
-                                        "end": 42,
-                                        "endCol": 24,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 42,
-                                            "startCol": 12,
-                                            "end": 42,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 42,
-                                            "startCol": 17,
-                                            "end": 42,
-                                            "endCol": 24,
                                             "text": "orderId"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 42,
-                                        "startCol": 27,
-                                        "end": 42,
-                                        "endCol": 34,
                                         "text": "orderId"
                                       }
                                     ]
@@ -3594,49 +1754,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 43,
-                                "startCol": 12,
-                                "end": 43,
-                                "endCol": 51,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 43,
-                                    "startCol": 12,
-                                    "end": 43,
-                                    "endCol": 50,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 43,
-                                        "startCol": 12,
-                                        "end": 43,
-                                        "endCol": 32,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 43,
-                                            "startCol": 12,
-                                            "end": 43,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 43,
-                                            "startCol": 17,
-                                            "end": 43,
-                                            "endCol": 32,
                                             "text": "orderCustomerId"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 43,
-                                        "startCol": 35,
-                                        "end": 43,
-                                        "endCol": 50,
                                         "text": "orderCustomerId"
                                       }
                                     ]
@@ -3645,49 +1781,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 44,
-                                "startCol": 12,
-                                "end": 44,
-                                "endCol": 57,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 44,
-                                    "startCol": 12,
-                                    "end": 44,
-                                    "endCol": 56,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 44,
-                                        "startCol": 12,
-                                        "end": 44,
-                                        "endCol": 35,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 44,
-                                            "startCol": 12,
-                                            "end": 44,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 44,
-                                            "startCol": 17,
-                                            "end": 44,
-                                            "endCol": 35,
                                             "text": "pairedCustomerName"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 44,
-                                        "startCol": 38,
-                                        "end": 44,
-                                        "endCol": 56,
                                         "text": "pairedCustomerName"
                                       }
                                     ]
@@ -3696,49 +1808,25 @@
                               },
                               {
                                 "kind": "expression_statement",
-                                "start": 45,
-                                "startCol": 12,
-                                "end": 45,
-                                "endCol": 41,
                                 "children": [
                                   {
                                     "kind": "assignment_expression",
-                                    "start": 45,
-                                    "startCol": 12,
-                                    "end": 45,
-                                    "endCol": 40,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 45,
-                                        "startCol": 12,
-                                        "end": 45,
-                                        "endCol": 27,
                                         "children": [
                                           {
                                             "kind": "this",
-                                            "start": 45,
-                                            "startCol": 12,
-                                            "end": 45,
-                                            "endCol": 16,
                                             "text": "this"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 45,
-                                            "startCol": 17,
-                                            "end": 45,
-                                            "endCol": 27,
                                             "text": "orderTotal"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 45,
-                                        "startCol": 30,
-                                        "end": 45,
-                                        "endCol": 40,
                                         "text": "orderTotal"
                                       }
                                     ]
@@ -3751,55 +1839,23 @@
                       },
                       {
                         "kind": "method_declaration",
-                        "start": 47,
-                        "startCol": 8,
-                        "end": 53,
-                        "endCol": 9,
                         "children": [
                           {
-                            "kind": "boolean_type",
-                            "start": 47,
-                            "startCol": 8,
-                            "end": 47,
-                            "endCol": 15,
-                            "text": "boolean"
-                          },
-                          {
                             "kind": "identifier",
-                            "start": 47,
-                            "startCol": 16,
-                            "end": 47,
-                            "endCol": 27,
                             "text": "containsKey"
                           },
                           {
                             "kind": "formal_parameters",
-                            "start": 47,
-                            "startCol": 27,
-                            "end": 47,
-                            "endCol": 37,
                             "children": [
                               {
                                 "kind": "formal_parameter",
-                                "start": 47,
-                                "startCol": 28,
-                                "end": 47,
-                                "endCol": 36,
                                 "children": [
                                   {
                                     "kind": "type_identifier",
-                                    "start": 47,
-                                    "startCol": 28,
-                                    "end": 47,
-                                    "endCol": 34,
                                     "text": "String"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 47,
-                                    "startCol": 35,
-                                    "end": 47,
-                                    "endCol": 36,
                                     "text": "k"
                                   }
                                 ]
@@ -3808,68 +1864,32 @@
                           },
                           {
                             "kind": "block",
-                            "start": 47,
-                            "startCol": 38,
-                            "end": 53,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "if_statement",
-                                "start": 48,
-                                "startCol": 12,
-                                "end": 48,
-                                "endCol": 49,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 48,
-                                    "startCol": 15,
-                                    "end": 48,
-                                    "endCol": 36,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 48,
-                                        "startCol": 16,
-                                        "end": 48,
-                                        "endCol": 35,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 48,
-                                            "startCol": 16,
-                                            "end": 48,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 48,
-                                            "startCol": 18,
-                                            "end": 48,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 48,
-                                            "startCol": 24,
-                                            "end": 48,
-                                            "endCol": 35,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 48,
-                                                "startCol": 25,
-                                                "end": 48,
-                                                "endCol": 34,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 48,
-                                                    "startCol": 26,
-                                                    "end": 48,
-                                                    "endCol": 33,
                                                     "text": "orderId"
                                                   }
                                                 ]
@@ -3882,17 +1902,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 48,
-                                    "startCol": 37,
-                                    "end": 48,
-                                    "endCol": 49,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 48,
-                                        "startCol": 44,
-                                        "end": 48,
-                                        "endCol": 48,
                                         "text": "true"
                                       }
                                     ]
@@ -3901,61 +1913,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 49,
-                                "startCol": 12,
-                                "end": 49,
-                                "endCol": 57,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 49,
-                                    "startCol": 15,
-                                    "end": 49,
-                                    "endCol": 44,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 49,
-                                        "startCol": 16,
-                                        "end": 49,
-                                        "endCol": 43,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 49,
-                                            "startCol": 16,
-                                            "end": 49,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 49,
-                                            "startCol": 18,
-                                            "end": 49,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 49,
-                                            "startCol": 24,
-                                            "end": 49,
-                                            "endCol": 43,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 49,
-                                                "startCol": 25,
-                                                "end": 49,
-                                                "endCol": 42,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 49,
-                                                    "startCol": 26,
-                                                    "end": 49,
-                                                    "endCol": 41,
                                                     "text": "orderCustomerId"
                                                   }
                                                 ]
@@ -3968,17 +1948,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 49,
-                                    "startCol": 45,
-                                    "end": 49,
-                                    "endCol": 57,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 49,
-                                        "startCol": 52,
-                                        "end": 49,
-                                        "endCol": 56,
                                         "text": "true"
                                       }
                                     ]
@@ -3987,61 +1959,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 50,
-                                "startCol": 12,
-                                "end": 50,
-                                "endCol": 60,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 50,
-                                    "startCol": 15,
-                                    "end": 50,
-                                    "endCol": 47,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 50,
-                                        "startCol": 16,
-                                        "end": 50,
-                                        "endCol": 46,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 50,
-                                            "startCol": 16,
-                                            "end": 50,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 50,
-                                            "startCol": 18,
-                                            "end": 50,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 50,
-                                            "startCol": 24,
-                                            "end": 50,
-                                            "endCol": 46,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 50,
-                                                "startCol": 25,
-                                                "end": 50,
-                                                "endCol": 45,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 50,
-                                                    "startCol": 26,
-                                                    "end": 50,
-                                                    "endCol": 44,
                                                     "text": "pairedCustomerName"
                                                   }
                                                 ]
@@ -4054,17 +1994,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 50,
-                                    "startCol": 48,
-                                    "end": 50,
-                                    "endCol": 60,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 50,
-                                        "startCol": 55,
-                                        "end": 50,
-                                        "endCol": 59,
                                         "text": "true"
                                       }
                                     ]
@@ -4073,61 +2005,29 @@
                               },
                               {
                                 "kind": "if_statement",
-                                "start": 51,
-                                "startCol": 12,
-                                "end": 51,
-                                "endCol": 52,
                                 "children": [
                                   {
                                     "kind": "parenthesized_expression",
-                                    "start": 51,
-                                    "startCol": 15,
-                                    "end": 51,
-                                    "endCol": 39,
                                     "children": [
                                       {
                                         "kind": "method_invocation",
-                                        "start": 51,
-                                        "startCol": 16,
-                                        "end": 51,
-                                        "endCol": 38,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 51,
-                                            "startCol": 16,
-                                            "end": 51,
-                                            "endCol": 17,
                                             "text": "k"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 51,
-                                            "startCol": 18,
-                                            "end": 51,
-                                            "endCol": 24,
                                             "text": "equals"
                                           },
                                           {
                                             "kind": "argument_list",
-                                            "start": 51,
-                                            "startCol": 24,
-                                            "end": 51,
-                                            "endCol": 38,
                                             "children": [
                                               {
                                                 "kind": "string_literal",
-                                                "start": 51,
-                                                "startCol": 25,
-                                                "end": 51,
-                                                "endCol": 37,
                                                 "children": [
                                                   {
                                                     "kind": "string_fragment",
-                                                    "start": 51,
-                                                    "startCol": 26,
-                                                    "end": 51,
-                                                    "endCol": 36,
                                                     "text": "orderTotal"
                                                   }
                                                 ]
@@ -4140,17 +2040,9 @@
                                   },
                                   {
                                     "kind": "return_statement",
-                                    "start": 51,
-                                    "startCol": 40,
-                                    "end": 51,
-                                    "endCol": 52,
                                     "children": [
                                       {
                                         "kind": "true",
-                                        "start": 51,
-                                        "startCol": 47,
-                                        "end": 51,
-                                        "endCol": 51,
                                         "text": "true"
                                       }
                                     ]
@@ -4159,17 +2051,9 @@
                               },
                               {
                                 "kind": "return_statement",
-                                "start": 52,
-                                "startCol": 12,
-                                "end": 52,
-                                "endCol": 25,
                                 "children": [
                                   {
                                     "kind": "false",
-                                    "start": 52,
-                                    "startCol": 19,
-                                    "end": 52,
-                                    "endCol": 24,
                                     "text": "false"
                                   }
                                 ]
@@ -4184,80 +2068,28 @@
               },
               {
                 "kind": "method_declaration",
-                "start": 57,
-                "startCol": 4,
-                "end": 62,
-                "endCol": 5,
                 "children": [
                   {
-                    "kind": "modifiers",
-                    "start": 57,
-                    "startCol": 4,
-                    "end": 57,
-                    "endCol": 17,
-                    "text": "public static"
-                  },
-                  {
-                    "kind": "void_type",
-                    "start": 57,
-                    "startCol": 18,
-                    "end": 57,
-                    "endCol": 22,
-                    "text": "void"
-                  },
-                  {
                     "kind": "identifier",
-                    "start": 57,
-                    "startCol": 23,
-                    "end": 57,
-                    "endCol": 27,
                     "text": "main"
                   },
                   {
                     "kind": "formal_parameters",
-                    "start": 57,
-                    "startCol": 27,
-                    "end": 57,
-                    "endCol": 42,
                     "children": [
                       {
                         "kind": "formal_parameter",
-                        "start": 57,
-                        "startCol": 28,
-                        "end": 57,
-                        "endCol": 41,
                         "children": [
                           {
                             "kind": "array_type",
-                            "start": 57,
-                            "startCol": 28,
-                            "end": 57,
-                            "endCol": 36,
                             "children": [
                               {
                                 "kind": "type_identifier",
-                                "start": 57,
-                                "startCol": 28,
-                                "end": 57,
-                                "endCol": 34,
                                 "text": "String"
-                              },
-                              {
-                                "kind": "dimensions",
-                                "start": 57,
-                                "startCol": 34,
-                                "end": 57,
-                                "endCol": 36,
-                                "text": "[]"
                               }
                             ]
                           },
                           {
                             "kind": "identifier",
-                            "start": 57,
-                            "startCol": 37,
-                            "end": 57,
-                            "endCol": 41,
                             "text": "args"
                           }
                         ]
@@ -4266,78 +2098,38 @@
                   },
                   {
                     "kind": "block",
-                    "start": 57,
-                    "startCol": 43,
-                    "end": 62,
-                    "endCol": 5,
                     "children": [
                       {
                         "kind": "expression_statement",
-                        "start": 58,
-                        "startCol": 8,
-                        "end": 58,
-                        "endCol": 75,
                         "children": [
                           {
                             "kind": "method_invocation",
-                            "start": 58,
-                            "startCol": 8,
-                            "end": 58,
-                            "endCol": 74,
                             "children": [
                               {
                                 "kind": "field_access",
-                                "start": 58,
-                                "startCol": 8,
-                                "end": 58,
-                                "endCol": 18,
                                 "children": [
                                   {
                                     "kind": "identifier",
-                                    "start": 58,
-                                    "startCol": 8,
-                                    "end": 58,
-                                    "endCol": 14,
                                     "text": "System"
                                   },
                                   {
                                     "kind": "identifier",
-                                    "start": 58,
-                                    "startCol": 15,
-                                    "end": 58,
-                                    "endCol": 18,
                                     "text": "out"
                                   }
                                 ]
                               },
                               {
                                 "kind": "identifier",
-                                "start": 58,
-                                "startCol": 19,
-                                "end": 58,
-                                "endCol": 26,
                                 "text": "println"
                               },
                               {
                                 "kind": "argument_list",
-                                "start": 58,
-                                "startCol": 26,
-                                "end": 58,
-                                "endCol": 74,
                                 "children": [
                                   {
                                     "kind": "string_literal",
-                                    "start": 58,
-                                    "startCol": 27,
-                                    "end": 58,
-                                    "endCol": 73,
                                     "children": [
                                       {
                                         "kind": "string_fragment",
-                                        "start": 58,
-                                        "startCol": 28,
-                                        "end": 58,
-                                        "endCol": 72,
                                         "text": "--- Cross Join: All order-customer pairs ---"
                                       }
                                     ]
@@ -4350,224 +2142,104 @@
                       },
                       {
                         "kind": "enhanced_for_statement",
-                        "start": 59,
-                        "startCol": 8,
-                        "end": 61,
-                        "endCol": 9,
                         "children": [
                           {
                             "kind": "type_identifier",
-                            "start": 59,
-                            "startCol": 13,
-                            "end": 59,
-                            "endCol": 16,
                             "text": "var"
                           },
                           {
                             "kind": "identifier",
-                            "start": 59,
-                            "startCol": 17,
-                            "end": 59,
-                            "endCol": 22,
                             "text": "entry"
                           },
                           {
                             "kind": "identifier",
-                            "start": 59,
-                            "startCol": 25,
-                            "end": 59,
-                            "endCol": 31,
                             "text": "result"
                           },
                           {
                             "kind": "block",
-                            "start": 59,
-                            "startCol": 33,
-                            "end": 61,
-                            "endCol": 9,
                             "children": [
                               {
                                 "kind": "expression_statement",
-                                "start": 60,
-                                "startCol": 12,
-                                "end": 60,
-                                "endCol": 218,
                                 "children": [
                                   {
                                     "kind": "method_invocation",
-                                    "start": 60,
-                                    "startCol": 12,
-                                    "end": 60,
-                                    "endCol": 217,
                                     "children": [
                                       {
                                         "kind": "field_access",
-                                        "start": 60,
-                                        "startCol": 12,
-                                        "end": 60,
-                                        "endCol": 22,
                                         "children": [
                                           {
                                             "kind": "identifier",
-                                            "start": 60,
-                                            "startCol": 12,
-                                            "end": 60,
-                                            "endCol": 18,
                                             "text": "System"
                                           },
                                           {
                                             "kind": "identifier",
-                                            "start": 60,
-                                            "startCol": 19,
-                                            "end": 60,
-                                            "endCol": 22,
                                             "text": "out"
                                           }
                                         ]
                                       },
                                       {
                                         "kind": "identifier",
-                                        "start": 60,
-                                        "startCol": 23,
-                                        "end": 60,
-                                        "endCol": 30,
                                         "text": "println"
                                       },
                                       {
                                         "kind": "argument_list",
-                                        "start": 60,
-                                        "startCol": 30,
-                                        "end": 60,
-                                        "endCol": 217,
                                         "children": [
                                           {
                                             "kind": "binary_expression",
-                                            "start": 60,
-                                            "startCol": 31,
-                                            "end": 60,
-                                            "endCol": 216,
                                             "children": [
                                               {
                                                 "kind": "binary_expression",
-                                                "start": 60,
-                                                "startCol": 31,
-                                                "end": 60,
-                                                "endCol": 189,
                                                 "children": [
                                                   {
                                                     "kind": "binary_expression",
-                                                    "start": 60,
-                                                    "startCol": 31,
-                                                    "end": 60,
-                                                    "endCol": 183,
                                                     "children": [
                                                       {
                                                         "kind": "binary_expression",
-                                                        "start": 60,
-                                                        "startCol": 31,
-                                                        "end": 60,
-                                                        "endCol": 165,
                                                         "children": [
                                                           {
                                                             "kind": "binary_expression",
-                                                            "start": 60,
-                                                            "startCol": 31,
-                                                            "end": 60,
-                                                            "endCol": 159,
                                                             "children": [
                                                               {
                                                                 "kind": "binary_expression",
-                                                                "start": 60,
-                                                                "startCol": 31,
-                                                                "end": 60,
-                                                                "endCol": 140,
                                                                 "children": [
                                                                   {
                                                                     "kind": "binary_expression",
-                                                                    "start": 60,
-                                                                    "startCol": 31,
-                                                                    "end": 60,
-                                                                    "endCol": 134,
                                                                     "children": [
                                                                       {
                                                                         "kind": "binary_expression",
-                                                                        "start": 60,
-                                                                        "startCol": 31,
-                                                                        "end": 60,
-                                                                        "endCol": 119,
                                                                         "children": [
                                                                           {
                                                                             "kind": "binary_expression",
-                                                                            "start": 60,
-                                                                            "startCol": 31,
-                                                                            "end": 60,
-                                                                            "endCol": 113,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "binary_expression",
-                                                                                "start": 60,
-                                                                                "startCol": 31,
-                                                                                "end": 60,
-                                                                                "endCol": 89,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "binary_expression",
-                                                                                    "start": 60,
-                                                                                    "startCol": 31,
-                                                                                    "end": 60,
-                                                                                    "endCol": 83,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "binary_expression",
-                                                                                        "start": 60,
-                                                                                        "startCol": 31,
-                                                                                        "end": 60,
-                                                                                        "endCol": 66,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "binary_expression",
-                                                                                            "start": 60,
-                                                                                            "startCol": 31,
-                                                                                            "end": 60,
-                                                                                            "endCol": 60,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "binary_expression",
-                                                                                                "start": 60,
-                                                                                                "startCol": 31,
-                                                                                                "end": 60,
-                                                                                                "endCol": 44,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "string_literal",
-                                                                                                    "start": 60,
-                                                                                                    "startCol": 31,
-                                                                                                    "end": 60,
-                                                                                                    "endCol": 38,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_fragment",
-                                                                                                        "start": 60,
-                                                                                                        "startCol": 32,
-                                                                                                        "end": 60,
-                                                                                                        "endCol": 37,
                                                                                                         "text": "Order"
                                                                                                       }
                                                                                                     ]
                                                                                                   },
                                                                                                   {
                                                                                                     "kind": "string_literal",
-                                                                                                    "start": 60,
-                                                                                                    "startCol": 41,
-                                                                                                    "end": 60,
-                                                                                                    "endCol": 44,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_fragment",
-                                                                                                        "start": 60,
-                                                                                                        "startCol": 42,
-                                                                                                        "end": 60,
-                                                                                                        "endCol": 43,
                                                                                                         "text": " "
                                                                                                       }
                                                                                                     ]
@@ -4576,25 +2248,13 @@
                                                                                               },
                                                                                               {
                                                                                                 "kind": "field_access",
-                                                                                                "start": 60,
-                                                                                                "startCol": 47,
-                                                                                                "end": 60,
-                                                                                                "endCol": 60,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "identifier",
-                                                                                                    "start": 60,
-                                                                                                    "startCol": 47,
-                                                                                                    "end": 60,
-                                                                                                    "endCol": 52,
                                                                                                     "text": "entry"
                                                                                                   },
                                                                                                   {
                                                                                                     "kind": "identifier",
-                                                                                                    "start": 60,
-                                                                                                    "startCol": 53,
-                                                                                                    "end": 60,
-                                                                                                    "endCol": 60,
                                                                                                     "text": "orderId"
                                                                                                   }
                                                                                                 ]
@@ -4603,17 +2263,9 @@
                                                                                           },
                                                                                           {
                                                                                             "kind": "string_literal",
-                                                                                            "start": 60,
-                                                                                            "startCol": 63,
-                                                                                            "end": 60,
-                                                                                            "endCol": 66,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "string_fragment",
-                                                                                                "start": 60,
-                                                                                                "startCol": 64,
-                                                                                                "end": 60,
-                                                                                                "endCol": 65,
                                                                                                 "text": " "
                                                                                               }
                                                                                             ]
@@ -4622,17 +2274,9 @@
                                                                                       },
                                                                                       {
                                                                                         "kind": "string_literal",
-                                                                                        "start": 60,
-                                                                                        "startCol": 69,
-                                                                                        "end": 60,
-                                                                                        "endCol": 83,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "string_fragment",
-                                                                                            "start": 60,
-                                                                                            "startCol": 70,
-                                                                                            "end": 60,
-                                                                                            "endCol": 82,
                                                                                             "text": "(customerId:"
                                                                                           }
                                                                                         ]
@@ -4641,17 +2285,9 @@
                                                                                   },
                                                                                   {
                                                                                     "kind": "string_literal",
-                                                                                    "start": 60,
-                                                                                    "startCol": 86,
-                                                                                    "end": 60,
-                                                                                    "endCol": 89,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "string_fragment",
-                                                                                        "start": 60,
-                                                                                        "startCol": 87,
-                                                                                        "end": 60,
-                                                                                        "endCol": 88,
                                                                                         "text": " "
                                                                                       }
                                                                                     ]
@@ -4660,25 +2296,13 @@
                                                                               },
                                                                               {
                                                                                 "kind": "field_access",
-                                                                                "start": 60,
-                                                                                "startCol": 92,
-                                                                                "end": 60,
-                                                                                "endCol": 113,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "identifier",
-                                                                                    "start": 60,
-                                                                                    "startCol": 92,
-                                                                                    "end": 60,
-                                                                                    "endCol": 97,
                                                                                     "text": "entry"
                                                                                   },
                                                                                   {
                                                                                     "kind": "identifier",
-                                                                                    "start": 60,
-                                                                                    "startCol": 98,
-                                                                                    "end": 60,
-                                                                                    "endCol": 113,
                                                                                     "text": "orderCustomerId"
                                                                                   }
                                                                                 ]
@@ -4687,17 +2311,9 @@
                                                                           },
                                                                           {
                                                                             "kind": "string_literal",
-                                                                            "start": 60,
-                                                                            "startCol": 116,
-                                                                            "end": 60,
-                                                                            "endCol": 119,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "string_fragment",
-                                                                                "start": 60,
-                                                                                "startCol": 117,
-                                                                                "end": 60,
-                                                                                "endCol": 118,
                                                                                 "text": " "
                                                                               }
                                                                             ]
@@ -4706,17 +2322,9 @@
                                                                       },
                                                                       {
                                                                         "kind": "string_literal",
-                                                                        "start": 60,
-                                                                        "startCol": 122,
-                                                                        "end": 60,
-                                                                        "endCol": 134,
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_fragment",
-                                                                            "start": 60,
-                                                                            "startCol": 123,
-                                                                            "end": 60,
-                                                                            "endCol": 133,
                                                                             "text": ", total: $"
                                                                           }
                                                                         ]
@@ -4725,17 +2333,9 @@
                                                                   },
                                                                   {
                                                                     "kind": "string_literal",
-                                                                    "start": 60,
-                                                                    "startCol": 137,
-                                                                    "end": 60,
-                                                                    "endCol": 140,
                                                                     "children": [
                                                                       {
                                                                         "kind": "string_fragment",
-                                                                        "start": 60,
-                                                                        "startCol": 138,
-                                                                        "end": 60,
-                                                                        "endCol": 139,
                                                                         "text": " "
                                                                       }
                                                                     ]
@@ -4744,25 +2344,13 @@
                                                               },
                                                               {
                                                                 "kind": "field_access",
-                                                                "start": 60,
-                                                                "startCol": 143,
-                                                                "end": 60,
-                                                                "endCol": 159,
                                                                 "children": [
                                                                   {
                                                                     "kind": "identifier",
-                                                                    "start": 60,
-                                                                    "startCol": 143,
-                                                                    "end": 60,
-                                                                    "endCol": 148,
                                                                     "text": "entry"
                                                                   },
                                                                   {
                                                                     "kind": "identifier",
-                                                                    "start": 60,
-                                                                    "startCol": 149,
-                                                                    "end": 60,
-                                                                    "endCol": 159,
                                                                     "text": "orderTotal"
                                                                   }
                                                                 ]
@@ -4771,17 +2359,9 @@
                                                           },
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 60,
-                                                            "startCol": 162,
-                                                            "end": 60,
-                                                            "endCol": 165,
                                                             "children": [
                                                               {
                                                                 "kind": "string_fragment",
-                                                                "start": 60,
-                                                                "startCol": 163,
-                                                                "end": 60,
-                                                                "endCol": 164,
                                                                 "text": " "
                                                               }
                                                             ]
@@ -4790,17 +2370,9 @@
                                                       },
                                                       {
                                                         "kind": "string_literal",
-                                                        "start": 60,
-                                                        "startCol": 168,
-                                                        "end": 60,
-                                                        "endCol": 183,
                                                         "children": [
                                                           {
                                                             "kind": "string_fragment",
-                                                            "start": 60,
-                                                            "startCol": 169,
-                                                            "end": 60,
-                                                            "endCol": 182,
                                                             "text": ") paired with"
                                                           }
                                                         ]
@@ -4809,17 +2381,9 @@
                                                   },
                                                   {
                                                     "kind": "string_literal",
-                                                    "start": 60,
-                                                    "startCol": 186,
-                                                    "end": 60,
-                                                    "endCol": 189,
                                                     "children": [
                                                       {
                                                         "kind": "string_fragment",
-                                                        "start": 60,
-                                                        "startCol": 187,
-                                                        "end": 60,
-                                                        "endCol": 188,
                                                         "text": " "
                                                       }
                                                     ]
@@ -4828,25 +2392,13 @@
                                               },
                                               {
                                                 "kind": "field_access",
-                                                "start": 60,
-                                                "startCol": 192,
-                                                "end": 60,
-                                                "endCol": 216,
                                                 "children": [
                                                   {
                                                     "kind": "identifier",
-                                                    "start": 60,
-                                                    "startCol": 192,
-                                                    "end": 60,
-                                                    "endCol": 197,
                                                     "text": "entry"
                                                   },
                                                   {
                                                     "kind": "identifier",
-                                                    "start": 60,
-                                                    "startCol": 198,
-                                                    "end": 60,
-                                                    "endCol": 216,
                                                     "text": "pairedCustomerName"
                                                   }
                                                 ]

--- a/tools/json-ast/x/java/inspect.go
+++ b/tools/json-ast/x/java/inspect.go
@@ -12,7 +12,7 @@ import (
 
 // Program represents a parsed Java source file.
 type Program struct {
-	Root Node `json:"root"`
+	Root *Node `json:"root"`
 }
 
 // Inspect parses the given Java source code using tree-sitter and returns


### PR DESCRIPTION
## Summary
- compact JSON AST for Java
- drop position fields unless requested
- filter out non-value leaves when converting tree-sitter nodes
- regenerate `cross_join.java.json`

## Testing
- `go test -c ./tools/json-ast/x/java -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6889d5dda9fc8320939dc27e2cd395a6