### PR TITLE
Update Kotlin AST generation

### DIFF
--- a/tests/json-ast/x/kotlin/cross_join.kt.json
+++ b/tests/json-ast/x/kotlin/cross_join.kt.json
@@ -1,134 +1,62 @@
 {
   "root": {
     "kind": "source_file",
-    "start": 1,
-    "startCol": 0,
-    "end": 18,
-    "endCol": 0,
     "children": [
       {
         "kind": "function_declaration",
-        "start": 1,
-        "startCol": 0,
-        "end": 17,
-        "endCol": 1,
         "children": [
           {
             "kind": "simple_identifier",
-            "text": "main",
-            "start": 1,
-            "startCol": 4,
-            "end": 1,
-            "endCol": 8
+            "text": "main"
           },
           {
             "kind": "function_body",
-            "start": 1,
-            "startCol": 11,
-            "end": 17,
-            "endCol": 1,
             "children": [
               {
                 "kind": "statements",
-                "start": 2,
-                "startCol": 4,
-                "end": 16,
-                "endCol": 5,
                 "children": [
                   {
                     "kind": "property_declaration",
-                    "start": 2,
-                    "startCol": 4,
-                    "end": 2,
-                    "endCol": 203,
                     "children": [
                       {
                         "kind": "variable_declaration",
-                        "start": 2,
-                        "startCol": 8,
-                        "end": 2,
-                        "endCol": 55,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "customers",
-                            "start": 2,
-                            "startCol": 8,
-                            "end": 2,
-                            "endCol": 17
+                            "text": "customers"
                           },
                           {
                             "kind": "user_type",
-                            "start": 2,
-                            "startCol": 19,
-                            "end": 2,
-                            "endCol": 55,
                             "children": [
                               {
                                 "kind": "type_identifier",
-                                "text": "MutableList",
-                                "start": 2,
-                                "startCol": 19,
-                                "end": 2,
-                                "endCol": 30
+                                "text": "MutableList"
                               },
                               {
                                 "kind": "type_arguments",
-                                "start": 2,
-                                "startCol": 30,
-                                "end": 2,
-                                "endCol": 55,
                                 "children": [
                                   {
                                     "kind": "type_projection",
-                                    "start": 2,
-                                    "startCol": 31,
-                                    "end": 2,
-                                    "endCol": 54,
                                     "children": [
                                       {
                                         "kind": "user_type",
-                                        "start": 2,
-                                        "startCol": 31,
-                                        "end": 2,
-                                        "endCol": 54,
                                         "children": [
                                           {
                                             "kind": "type_identifier",
-                                            "text": "MutableMap",
-                                            "start": 2,
-                                            "startCol": 31,
-                                            "end": 2,
-                                            "endCol": 41
+                                            "text": "MutableMap"
                                           },
                                           {
                                             "kind": "type_arguments",
-                                            "start": 2,
-                                            "startCol": 41,
-                                            "end": 2,
-                                            "endCol": 54,
                                             "children": [
                                               {
                                                 "kind": "type_projection",
-                                                "start": 2,
-                                                "startCol": 42,
-                                                "end": 2,
-                                                "endCol": 48,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 2,
-                                                    "startCol": 42,
-                                                    "end": 2,
-                                                    "endCol": 48,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "String",
-                                                        "start": 2,
-                                                        "startCol": 42,
-                                                        "end": 2,
-                                                        "endCol": 48
+                                                        "text": "String"
                                                       }
                                                     ]
                                                   }
@@ -136,25 +64,13 @@
                                               },
                                               {
                                                 "kind": "type_projection",
-                                                "start": 2,
-                                                "startCol": 50,
-                                                "end": 2,
-                                                "endCol": 53,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 2,
-                                                    "startCol": 50,
-                                                    "end": 2,
-                                                    "endCol": 53,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "Any",
-                                                        "start": 2,
-                                                        "startCol": 50,
-                                                        "end": 2,
-                                                        "endCol": 53
+                                                        "text": "Any"
                                                       }
                                                     ]
                                                   }
@@ -174,115 +90,55 @@
                       },
                       {
                         "kind": "call_expression",
-                        "start": 2,
-                        "startCol": 58,
-                        "end": 2,
-                        "endCol": 203,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "mutableListOf",
-                            "start": 2,
-                            "startCol": 58,
-                            "end": 2,
-                            "endCol": 71
+                            "text": "mutableListOf"
                           },
                           {
                             "kind": "call_suffix",
-                            "start": 2,
-                            "startCol": 71,
-                            "end": 2,
-                            "endCol": 203,
                             "children": [
                               {
                                 "kind": "value_arguments",
-                                "start": 2,
-                                "startCol": 71,
-                                "end": 2,
-                                "endCol": 203,
                                 "children": [
                                   {
                                     "kind": "value_argument",
-                                    "start": 2,
-                                    "startCol": 72,
-                                    "end": 2,
-                                    "endCol": 114,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 2,
-                                        "startCol": 72,
-                                        "end": 2,
-                                        "endCol": 114,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 2,
-                                            "startCol": 72,
-                                            "end": 2,
-                                            "endCol": 84
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 2,
-                                            "startCol": 84,
-                                            "end": 2,
-                                            "endCol": 114,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 2,
-                                                "startCol": 84,
-                                                "end": 2,
-                                                "endCol": 114,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 85,
-                                                    "end": 2,
-                                                    "endCol": 94,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 85,
-                                                        "end": 2,
-                                                        "endCol": 94,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 85,
-                                                            "end": 2,
-                                                            "endCol": 89,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 2,
-                                                                "startCol": 86,
-                                                                "end": 2,
-                                                                "endCol": 88
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 90,
-                                                            "end": 2,
-                                                            "endCol": 92
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "1",
-                                                            "start": 2,
-                                                            "startCol": 93,
-                                                            "end": 2,
-                                                            "endCol": 94
+                                                            "text": "1"
                                                           }
                                                         ]
                                                       }
@@ -290,57 +146,29 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 96,
-                                                    "end": 2,
-                                                    "endCol": 113,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 96,
-                                                        "end": 2,
-                                                        "endCol": 113,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 96,
-                                                            "end": 2,
-                                                            "endCol": 102,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "name",
-                                                                "start": 2,
-                                                                "startCol": 97,
-                                                                "end": 2,
-                                                                "endCol": 101
+                                                                "text": "name"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 103,
-                                                            "end": 2,
-                                                            "endCol": 105
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 106,
-                                                            "end": 2,
-                                                            "endCol": 113,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "Alice",
-                                                                "start": 2,
-                                                                "startCol": 107,
-                                                                "end": 2,
-                                                                "endCol": 112
+                                                                "text": "Alice"
                                                               }
                                                             ]
                                                           }
@@ -358,86 +186,42 @@
                                   },
                                   {
                                     "kind": "value_argument",
-                                    "start": 2,
-                                    "startCol": 116,
-                                    "end": 2,
-                                    "endCol": 156,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 2,
-                                        "startCol": 116,
-                                        "end": 2,
-                                        "endCol": 156,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 2,
-                                            "startCol": 116,
-                                            "end": 2,
-                                            "endCol": 128
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 2,
-                                            "startCol": 128,
-                                            "end": 2,
-                                            "endCol": 156,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 2,
-                                                "startCol": 128,
-                                                "end": 2,
-                                                "endCol": 156,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 129,
-                                                    "end": 2,
-                                                    "endCol": 138,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 129,
-                                                        "end": 2,
-                                                        "endCol": 138,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 129,
-                                                            "end": 2,
-                                                            "endCol": 133,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 2,
-                                                                "startCol": 130,
-                                                                "end": 2,
-                                                                "endCol": 132
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 134,
-                                                            "end": 2,
-                                                            "endCol": 136
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "2",
-                                                            "start": 2,
-                                                            "startCol": 137,
-                                                            "end": 2,
-                                                            "endCol": 138
+                                                            "text": "2"
                                                           }
                                                         ]
                                                       }
@@ -445,57 +229,29 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 140,
-                                                    "end": 2,
-                                                    "endCol": 155,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 140,
-                                                        "end": 2,
-                                                        "endCol": 155,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 140,
-                                                            "end": 2,
-                                                            "endCol": 146,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "name",
-                                                                "start": 2,
-                                                                "startCol": 141,
-                                                                "end": 2,
-                                                                "endCol": 145
+                                                                "text": "name"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 147,
-                                                            "end": 2,
-                                                            "endCol": 149
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 150,
-                                                            "end": 2,
-                                                            "endCol": 155,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "Bob",
-                                                                "start": 2,
-                                                                "startCol": 151,
-                                                                "end": 2,
-                                                                "endCol": 154
+                                                                "text": "Bob"
                                                               }
                                                             ]
                                                           }
@@ -513,86 +269,42 @@
                                   },
                                   {
                                     "kind": "value_argument",
-                                    "start": 2,
-                                    "startCol": 158,
-                                    "end": 2,
-                                    "endCol": 202,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 2,
-                                        "startCol": 158,
-                                        "end": 2,
-                                        "endCol": 202,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 2,
-                                            "startCol": 158,
-                                            "end": 2,
-                                            "endCol": 170
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 2,
-                                            "startCol": 170,
-                                            "end": 2,
-                                            "endCol": 202,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 2,
-                                                "startCol": 170,
-                                                "end": 2,
-                                                "endCol": 202,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 171,
-                                                    "end": 2,
-                                                    "endCol": 180,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 171,
-                                                        "end": 2,
-                                                        "endCol": 180,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 171,
-                                                            "end": 2,
-                                                            "endCol": 175,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 2,
-                                                                "startCol": 172,
-                                                                "end": 2,
-                                                                "endCol": 174
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 176,
-                                                            "end": 2,
-                                                            "endCol": 178
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "3",
-                                                            "start": 2,
-                                                            "startCol": 179,
-                                                            "end": 2,
-                                                            "endCol": 180
+                                                            "text": "3"
                                                           }
                                                         ]
                                                       }
@@ -600,57 +312,29 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 2,
-                                                    "startCol": 182,
-                                                    "end": 2,
-                                                    "endCol": 201,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 2,
-                                                        "startCol": 182,
-                                                        "end": 2,
-                                                        "endCol": 201,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 182,
-                                                            "end": 2,
-                                                            "endCol": 188,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "name",
-                                                                "start": 2,
-                                                                "startCol": 183,
-                                                                "end": 2,
-                                                                "endCol": 187
+                                                                "text": "name"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 2,
-                                                            "startCol": 189,
-                                                            "end": 2,
-                                                            "endCol": 191
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 2,
-                                                            "startCol": 192,
-                                                            "end": 2,
-                                                            "endCol": 201,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "Charlie",
-                                                                "start": 2,
-                                                                "startCol": 193,
-                                                                "end": 2,
-                                                                "endCol": 200
+                                                                "text": "Charlie"
                                                               }
                                                             ]
                                                           }
@@ -676,98 +360,46 @@
                   },
                   {
                     "kind": "property_declaration",
-                    "start": 3,
-                    "startCol": 4,
-                    "end": 3,
-                    "endCol": 254,
                     "children": [
                       {
                         "kind": "variable_declaration",
-                        "start": 3,
-                        "startCol": 8,
-                        "end": 3,
-                        "endCol": 52,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "orders",
-                            "start": 3,
-                            "startCol": 8,
-                            "end": 3,
-                            "endCol": 14
+                            "text": "orders"
                           },
                           {
                             "kind": "user_type",
-                            "start": 3,
-                            "startCol": 16,
-                            "end": 3,
-                            "endCol": 52,
                             "children": [
                               {
                                 "kind": "type_identifier",
-                                "text": "MutableList",
-                                "start": 3,
-                                "startCol": 16,
-                                "end": 3,
-                                "endCol": 27
+                                "text": "MutableList"
                               },
                               {
                                 "kind": "type_arguments",
-                                "start": 3,
-                                "startCol": 27,
-                                "end": 3,
-                                "endCol": 52,
                                 "children": [
                                   {
                                     "kind": "type_projection",
-                                    "start": 3,
-                                    "startCol": 28,
-                                    "end": 3,
-                                    "endCol": 51,
                                     "children": [
                                       {
                                         "kind": "user_type",
-                                        "start": 3,
-                                        "startCol": 28,
-                                        "end": 3,
-                                        "endCol": 51,
                                         "children": [
                                           {
                                             "kind": "type_identifier",
-                                            "text": "MutableMap",
-                                            "start": 3,
-                                            "startCol": 28,
-                                            "end": 3,
-                                            "endCol": 38
+                                            "text": "MutableMap"
                                           },
                                           {
                                             "kind": "type_arguments",
-                                            "start": 3,
-                                            "startCol": 38,
-                                            "end": 3,
-                                            "endCol": 51,
                                             "children": [
                                               {
                                                 "kind": "type_projection",
-                                                "start": 3,
-                                                "startCol": 39,
-                                                "end": 3,
-                                                "endCol": 45,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 3,
-                                                    "startCol": 39,
-                                                    "end": 3,
-                                                    "endCol": 45,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "String",
-                                                        "start": 3,
-                                                        "startCol": 39,
-                                                        "end": 3,
-                                                        "endCol": 45
+                                                        "text": "String"
                                                       }
                                                     ]
                                                   }
@@ -775,25 +407,13 @@
                                               },
                                               {
                                                 "kind": "type_projection",
-                                                "start": 3,
-                                                "startCol": 47,
-                                                "end": 3,
-                                                "endCol": 50,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 3,
-                                                    "startCol": 47,
-                                                    "end": 3,
-                                                    "endCol": 50,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "Int",
-                                                        "start": 3,
-                                                        "startCol": 47,
-                                                        "end": 3,
-                                                        "endCol": 50
+                                                        "text": "Int"
                                                       }
                                                     ]
                                                   }
@@ -813,115 +433,55 @@
                       },
                       {
                         "kind": "call_expression",
-                        "start": 3,
-                        "startCol": 55,
-                        "end": 3,
-                        "endCol": 254,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "mutableListOf",
-                            "start": 3,
-                            "startCol": 55,
-                            "end": 3,
-                            "endCol": 68
+                            "text": "mutableListOf"
                           },
                           {
                             "kind": "call_suffix",
-                            "start": 3,
-                            "startCol": 68,
-                            "end": 3,
-                            "endCol": 254,
                             "children": [
                               {
                                 "kind": "value_arguments",
-                                "start": 3,
-                                "startCol": 68,
-                                "end": 3,
-                                "endCol": 254,
                                 "children": [
                                   {
                                     "kind": "value_argument",
-                                    "start": 3,
-                                    "startCol": 69,
-                                    "end": 3,
-                                    "endCol": 129,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 3,
-                                        "startCol": 69,
-                                        "end": 3,
-                                        "endCol": 129,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 3,
-                                            "startCol": 69,
-                                            "end": 3,
-                                            "endCol": 81
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 3,
-                                            "startCol": 81,
-                                            "end": 3,
-                                            "endCol": 129,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 3,
-                                                "startCol": 81,
-                                                "end": 3,
-                                                "endCol": 129,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 82,
-                                                    "end": 3,
-                                                    "endCol": 93,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 82,
-                                                        "end": 3,
-                                                        "endCol": 93,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 82,
-                                                            "end": 3,
-                                                            "endCol": 86,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 3,
-                                                                "startCol": 83,
-                                                                "end": 3,
-                                                                "endCol": 85
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 87,
-                                                            "end": 3,
-                                                            "endCol": 89
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "100",
-                                                            "start": 3,
-                                                            "startCol": 90,
-                                                            "end": 3,
-                                                            "endCol": 93
+                                                            "text": "100"
                                                           }
                                                         ]
                                                       }
@@ -929,50 +489,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 95,
-                                                    "end": 3,
-                                                    "endCol": 112,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 95,
-                                                        "end": 3,
-                                                        "endCol": 112,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 95,
-                                                            "end": 3,
-                                                            "endCol": 107,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "customerId",
-                                                                "start": 3,
-                                                                "startCol": 96,
-                                                                "end": 3,
-                                                                "endCol": 106
+                                                                "text": "customerId"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 108,
-                                                            "end": 3,
-                                                            "endCol": 110
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "1",
-                                                            "start": 3,
-                                                            "startCol": 111,
-                                                            "end": 3,
-                                                            "endCol": 112
+                                                            "text": "1"
                                                           }
                                                         ]
                                                       }
@@ -980,50 +516,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 114,
-                                                    "end": 3,
-                                                    "endCol": 128,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 114,
-                                                        "end": 3,
-                                                        "endCol": 128,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 114,
-                                                            "end": 3,
-                                                            "endCol": 121,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "total",
-                                                                "start": 3,
-                                                                "startCol": 115,
-                                                                "end": 3,
-                                                                "endCol": 120
+                                                                "text": "total"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 122,
-                                                            "end": 3,
-                                                            "endCol": 124
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "250",
-                                                            "start": 3,
-                                                            "startCol": 125,
-                                                            "end": 3,
-                                                            "endCol": 128
+                                                            "text": "250"
                                                           }
                                                         ]
                                                       }
@@ -1039,86 +551,42 @@
                                   },
                                   {
                                     "kind": "value_argument",
-                                    "start": 3,
-                                    "startCol": 131,
-                                    "end": 3,
-                                    "endCol": 191,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 3,
-                                        "startCol": 131,
-                                        "end": 3,
-                                        "endCol": 191,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 3,
-                                            "startCol": 131,
-                                            "end": 3,
-                                            "endCol": 143
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 3,
-                                            "startCol": 143,
-                                            "end": 3,
-                                            "endCol": 191,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 3,
-                                                "startCol": 143,
-                                                "end": 3,
-                                                "endCol": 191,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 144,
-                                                    "end": 3,
-                                                    "endCol": 155,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 144,
-                                                        "end": 3,
-                                                        "endCol": 155,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 144,
-                                                            "end": 3,
-                                                            "endCol": 148,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 3,
-                                                                "startCol": 145,
-                                                                "end": 3,
-                                                                "endCol": 147
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 149,
-                                                            "end": 3,
-                                                            "endCol": 151
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "101",
-                                                            "start": 3,
-                                                            "startCol": 152,
-                                                            "end": 3,
-                                                            "endCol": 155
+                                                            "text": "101"
                                                           }
                                                         ]
                                                       }
@@ -1126,50 +594,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 157,
-                                                    "end": 3,
-                                                    "endCol": 174,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 157,
-                                                        "end": 3,
-                                                        "endCol": 174,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 157,
-                                                            "end": 3,
-                                                            "endCol": 169,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "customerId",
-                                                                "start": 3,
-                                                                "startCol": 158,
-                                                                "end": 3,
-                                                                "endCol": 168
+                                                                "text": "customerId"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 170,
-                                                            "end": 3,
-                                                            "endCol": 172
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "2",
-                                                            "start": 3,
-                                                            "startCol": 173,
-                                                            "end": 3,
-                                                            "endCol": 174
+                                                            "text": "2"
                                                           }
                                                         ]
                                                       }
@@ -1177,50 +621,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 176,
-                                                    "end": 3,
-                                                    "endCol": 190,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 176,
-                                                        "end": 3,
-                                                        "endCol": 190,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 176,
-                                                            "end": 3,
-                                                            "endCol": 183,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "total",
-                                                                "start": 3,
-                                                                "startCol": 177,
-                                                                "end": 3,
-                                                                "endCol": 182
+                                                                "text": "total"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 184,
-                                                            "end": 3,
-                                                            "endCol": 186
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "125",
-                                                            "start": 3,
-                                                            "startCol": 187,
-                                                            "end": 3,
-                                                            "endCol": 190
+                                                            "text": "125"
                                                           }
                                                         ]
                                                       }
@@ -1236,86 +656,42 @@
                                   },
                                   {
                                     "kind": "value_argument",
-                                    "start": 3,
-                                    "startCol": 193,
-                                    "end": 3,
-                                    "endCol": 253,
                                     "children": [
                                       {
                                         "kind": "call_expression",
-                                        "start": 3,
-                                        "startCol": 193,
-                                        "end": 3,
-                                        "endCol": 253,
                                         "children": [
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "mutableMapOf",
-                                            "start": 3,
-                                            "startCol": 193,
-                                            "end": 3,
-                                            "endCol": 205
+                                            "text": "mutableMapOf"
                                           },
                                           {
                                             "kind": "call_suffix",
-                                            "start": 3,
-                                            "startCol": 205,
-                                            "end": 3,
-                                            "endCol": 253,
                                             "children": [
                                               {
                                                 "kind": "value_arguments",
-                                                "start": 3,
-                                                "startCol": 205,
-                                                "end": 3,
-                                                "endCol": 253,
                                                 "children": [
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 206,
-                                                    "end": 3,
-                                                    "endCol": 217,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 206,
-                                                        "end": 3,
-                                                        "endCol": 217,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 206,
-                                                            "end": 3,
-                                                            "endCol": 210,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "id",
-                                                                "start": 3,
-                                                                "startCol": 207,
-                                                                "end": 3,
-                                                                "endCol": 209
+                                                                "text": "id"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 211,
-                                                            "end": 3,
-                                                            "endCol": 213
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "102",
-                                                            "start": 3,
-                                                            "startCol": 214,
-                                                            "end": 3,
-                                                            "endCol": 217
+                                                            "text": "102"
                                                           }
                                                         ]
                                                       }
@@ -1323,50 +699,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 219,
-                                                    "end": 3,
-                                                    "endCol": 236,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 219,
-                                                        "end": 3,
-                                                        "endCol": 236,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 219,
-                                                            "end": 3,
-                                                            "endCol": 231,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "customerId",
-                                                                "start": 3,
-                                                                "startCol": 220,
-                                                                "end": 3,
-                                                                "endCol": 230
+                                                                "text": "customerId"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 232,
-                                                            "end": 3,
-                                                            "endCol": 234
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "1",
-                                                            "start": 3,
-                                                            "startCol": 235,
-                                                            "end": 3,
-                                                            "endCol": 236
+                                                            "text": "1"
                                                           }
                                                         ]
                                                       }
@@ -1374,50 +726,26 @@
                                                   },
                                                   {
                                                     "kind": "value_argument",
-                                                    "start": 3,
-                                                    "startCol": 238,
-                                                    "end": 3,
-                                                    "endCol": 252,
                                                     "children": [
                                                       {
                                                         "kind": "infix_expression",
-                                                        "start": 3,
-                                                        "startCol": 238,
-                                                        "end": 3,
-                                                        "endCol": 252,
                                                         "children": [
                                                           {
                                                             "kind": "string_literal",
-                                                            "start": 3,
-                                                            "startCol": 238,
-                                                            "end": 3,
-                                                            "endCol": 245,
                                                             "children": [
                                                               {
                                                                 "kind": "string_content",
-                                                                "text": "total",
-                                                                "start": 3,
-                                                                "startCol": 239,
-                                                                "end": 3,
-                                                                "endCol": 244
+                                                                "text": "total"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "to",
-                                                            "start": 3,
-                                                            "startCol": 246,
-                                                            "end": 3,
-                                                            "endCol": 248
+                                                            "text": "to"
                                                           },
                                                           {
                                                             "kind": "integer_literal",
-                                                            "text": "300",
-                                                            "start": 3,
-                                                            "startCol": 249,
-                                                            "end": 3,
-                                                            "endCol": 252
+                                                            "text": "300"
                                                           }
                                                         ]
                                                       }
@@ -1441,98 +769,46 @@
                   },
                   {
                     "kind": "property_declaration",
-                    "start": 4,
-                    "startCol": 4,
-                    "end": 12,
-                    "endCol": 1,
                     "children": [
                       {
                         "kind": "variable_declaration",
-                        "start": 4,
-                        "startCol": 8,
-                        "end": 4,
-                        "endCol": 52,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "result",
-                            "start": 4,
-                            "startCol": 8,
-                            "end": 4,
-                            "endCol": 14
+                            "text": "result"
                           },
                           {
                             "kind": "user_type",
-                            "start": 4,
-                            "startCol": 16,
-                            "end": 4,
-                            "endCol": 52,
                             "children": [
                               {
                                 "kind": "type_identifier",
-                                "text": "MutableList",
-                                "start": 4,
-                                "startCol": 16,
-                                "end": 4,
-                                "endCol": 27
+                                "text": "MutableList"
                               },
                               {
                                 "kind": "type_arguments",
-                                "start": 4,
-                                "startCol": 27,
-                                "end": 4,
-                                "endCol": 52,
                                 "children": [
                                   {
                                     "kind": "type_projection",
-                                    "start": 4,
-                                    "startCol": 28,
-                                    "end": 4,
-                                    "endCol": 51,
                                     "children": [
                                       {
                                         "kind": "user_type",
-                                        "start": 4,
-                                        "startCol": 28,
-                                        "end": 4,
-                                        "endCol": 51,
                                         "children": [
                                           {
                                             "kind": "type_identifier",
-                                            "text": "MutableMap",
-                                            "start": 4,
-                                            "startCol": 28,
-                                            "end": 4,
-                                            "endCol": 38
+                                            "text": "MutableMap"
                                           },
                                           {
                                             "kind": "type_arguments",
-                                            "start": 4,
-                                            "startCol": 38,
-                                            "end": 4,
-                                            "endCol": 51,
                                             "children": [
                                               {
                                                 "kind": "type_projection",
-                                                "start": 4,
-                                                "startCol": 39,
-                                                "end": 4,
-                                                "endCol": 45,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 4,
-                                                    "startCol": 39,
-                                                    "end": 4,
-                                                    "endCol": 45,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "String",
-                                                        "start": 4,
-                                                        "startCol": 39,
-                                                        "end": 4,
-                                                        "endCol": 45
+                                                        "text": "String"
                                                       }
                                                     ]
                                                   }
@@ -1540,25 +816,13 @@
                                               },
                                               {
                                                 "kind": "type_projection",
-                                                "start": 4,
-                                                "startCol": 47,
-                                                "end": 4,
-                                                "endCol": 50,
                                                 "children": [
                                                   {
                                                     "kind": "user_type",
-                                                    "start": 4,
-                                                    "startCol": 47,
-                                                    "end": 4,
-                                                    "endCol": 50,
                                                     "children": [
                                                       {
                                                         "kind": "type_identifier",
-                                                        "text": "Int",
-                                                        "start": 4,
-                                                        "startCol": 47,
-                                                        "end": 4,
-                                                        "endCol": 50
+                                                        "text": "Int"
                                                       }
                                                     ]
                                                   }
@@ -1578,150 +842,70 @@
                       },
                       {
                         "kind": "call_expression",
-                        "start": 4,
-                        "startCol": 55,
-                        "end": 12,
-                        "endCol": 1,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "run",
-                            "start": 4,
-                            "startCol": 55,
-                            "end": 4,
-                            "endCol": 58
+                            "text": "run"
                           },
                           {
                             "kind": "call_suffix",
-                            "start": 4,
-                            "startCol": 59,
-                            "end": 12,
-                            "endCol": 1,
                             "children": [
                               {
                                 "kind": "annotated_lambda",
-                                "start": 4,
-                                "startCol": 59,
-                                "end": 12,
-                                "endCol": 1,
                                 "children": [
                                   {
                                     "kind": "lambda_literal",
-                                    "start": 4,
-                                    "startCol": 59,
-                                    "end": 12,
-                                    "endCol": 1,
                                     "children": [
                                       {
                                         "kind": "statements",
-                                        "start": 5,
-                                        "startCol": 4,
-                                        "end": 11,
-                                        "endCol": 8,
                                         "children": [
                                           {
                                             "kind": "property_declaration",
-                                            "start": 5,
-                                            "startCol": 4,
-                                            "end": 5,
-                                            "endCol": 55,
                                             "children": [
                                               {
                                                 "kind": "variable_declaration",
-                                                "start": 5,
-                                                "startCol": 8,
-                                                "end": 5,
-                                                "endCol": 12,
                                                 "children": [
                                                   {
                                                     "kind": "simple_identifier",
-                                                    "text": "_res",
-                                                    "start": 5,
-                                                    "startCol": 8,
-                                                    "end": 5,
-                                                    "endCol": 12
+                                                    "text": "_res"
                                                   }
                                                 ]
                                               },
                                               {
                                                 "kind": "call_expression",
-                                                "start": 5,
-                                                "startCol": 15,
-                                                "end": 5,
-                                                "endCol": 55,
                                                 "children": [
                                                   {
                                                     "kind": "simple_identifier",
-                                                    "text": "mutableListOf",
-                                                    "start": 5,
-                                                    "startCol": 15,
-                                                    "end": 5,
-                                                    "endCol": 28
+                                                    "text": "mutableListOf"
                                                   },
                                                   {
                                                     "kind": "call_suffix",
-                                                    "start": 5,
-                                                    "startCol": 28,
-                                                    "end": 5,
-                                                    "endCol": 55,
                                                     "children": [
                                                       {
                                                         "kind": "type_arguments",
-                                                        "start": 5,
-                                                        "startCol": 28,
-                                                        "end": 5,
-                                                        "endCol": 53,
                                                         "children": [
                                                           {
                                                             "kind": "type_projection",
-                                                            "start": 5,
-                                                            "startCol": 29,
-                                                            "end": 5,
-                                                            "endCol": 52,
                                                             "children": [
                                                               {
                                                                 "kind": "user_type",
-                                                                "start": 5,
-                                                                "startCol": 29,
-                                                                "end": 5,
-                                                                "endCol": 52,
                                                                 "children": [
                                                                   {
                                                                     "kind": "type_identifier",
-                                                                    "text": "MutableMap",
-                                                                    "start": 5,
-                                                                    "startCol": 29,
-                                                                    "end": 5,
-                                                                    "endCol": 39
+                                                                    "text": "MutableMap"
                                                                   },
                                                                   {
                                                                     "kind": "type_arguments",
-                                                                    "start": 5,
-                                                                    "startCol": 39,
-                                                                    "end": 5,
-                                                                    "endCol": 52,
                                                                     "children": [
                                                                       {
                                                                         "kind": "type_projection",
-                                                                        "start": 5,
-                                                                        "startCol": 40,
-                                                                        "end": 5,
-                                                                        "endCol": 46,
                                                                         "children": [
                                                                           {
                                                                             "kind": "user_type",
-                                                                            "start": 5,
-                                                                            "startCol": 40,
-                                                                            "end": 5,
-                                                                            "endCol": 46,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "type_identifier",
-                                                                                "text": "String",
-                                                                                "start": 5,
-                                                                                "startCol": 40,
-                                                                                "end": 5,
-                                                                                "endCol": 46
+                                                                                "text": "String"
                                                                               }
                                                                             ]
                                                                           }
@@ -1729,25 +913,13 @@
                                                                       },
                                                                       {
                                                                         "kind": "type_projection",
-                                                                        "start": 5,
-                                                                        "startCol": 48,
-                                                                        "end": 5,
-                                                                        "endCol": 51,
                                                                         "children": [
                                                                           {
                                                                             "kind": "user_type",
-                                                                            "start": 5,
-                                                                            "startCol": 48,
-                                                                            "end": 5,
-                                                                            "endCol": 51,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "type_identifier",
-                                                                                "text": "Any",
-                                                                                "start": 5,
-                                                                                "startCol": 48,
-                                                                                "end": 5,
-                                                                                "endCol": 51
+                                                                                "text": "Any"
                                                                               }
                                                                             ]
                                                                           }
@@ -1769,132 +941,64 @@
                                           },
                                           {
                                             "kind": "for_statement",
-                                            "start": 6,
-                                            "startCol": 4,
-                                            "end": 10,
-                                            "endCol": 5,
                                             "children": [
                                               {
                                                 "kind": "variable_declaration",
-                                                "start": 6,
-                                                "startCol": 9,
-                                                "end": 6,
-                                                "endCol": 10,
                                                 "children": [
                                                   {
                                                     "kind": "simple_identifier",
-                                                    "text": "o",
-                                                    "start": 6,
-                                                    "startCol": 9,
-                                                    "end": 6,
-                                                    "endCol": 10
+                                                    "text": "o"
                                                   }
                                                 ]
                                               },
                                               {
                                                 "kind": "simple_identifier",
-                                                "text": "orders",
-                                                "start": 6,
-                                                "startCol": 14,
-                                                "end": 6,
-                                                "endCol": 20
+                                                "text": "orders"
                                               },
                                               {
                                                 "kind": "control_structure_body",
-                                                "start": 6,
-                                                "startCol": 22,
-                                                "end": 10,
-                                                "endCol": 5,
                                                 "children": [
                                                   {
                                                     "kind": "statements",
-                                                    "start": 7,
-                                                    "startCol": 8,
-                                                    "end": 9,
-                                                    "endCol": 9,
                                                     "children": [
                                                       {
                                                         "kind": "for_statement",
-                                                        "start": 7,
-                                                        "startCol": 8,
-                                                        "end": 9,
-                                                        "endCol": 9,
                                                         "children": [
                                                           {
                                                             "kind": "variable_declaration",
-                                                            "start": 7,
-                                                            "startCol": 13,
-                                                            "end": 7,
-                                                            "endCol": 14,
                                                             "children": [
                                                               {
                                                                 "kind": "simple_identifier",
-                                                                "text": "c",
-                                                                "start": 7,
-                                                                "startCol": 13,
-                                                                "end": 7,
-                                                                "endCol": 14
+                                                                "text": "c"
                                                               }
                                                             ]
                                                           },
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "customers",
-                                                            "start": 7,
-                                                            "startCol": 18,
-                                                            "end": 7,
-                                                            "endCol": 27
+                                                            "text": "customers"
                                                           },
                                                           {
                                                             "kind": "control_structure_body",
-                                                            "start": 7,
-                                                            "startCol": 29,
-                                                            "end": 9,
-                                                            "endCol": 9,
                                                             "children": [
                                                               {
                                                                 "kind": "statements",
-                                                                "start": 8,
-                                                                "startCol": 12,
-                                                                "end": 8,
-                                                                "endCol": 157,
                                                                 "children": [
                                                                   {
                                                                     "kind": "call_expression",
-                                                                    "start": 8,
-                                                                    "startCol": 12,
-                                                                    "end": 8,
-                                                                    "endCol": 157,
                                                                     "children": [
                                                                       {
                                                                         "kind": "navigation_expression",
-                                                                        "start": 8,
-                                                                        "startCol": 12,
-                                                                        "end": 8,
-                                                                        "endCol": 20,
                                                                         "children": [
                                                                           {
                                                                             "kind": "simple_identifier",
-                                                                            "text": "_res",
-                                                                            "start": 8,
-                                                                            "startCol": 12,
-                                                                            "end": 8,
-                                                                            "endCol": 16
+                                                                            "text": "_res"
                                                                           },
                                                                           {
                                                                             "kind": "navigation_suffix",
-                                                                            "start": 8,
-                                                                            "startCol": 16,
-                                                                            "end": 8,
-                                                                            "endCol": 20,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "simple_identifier",
-                                                                                "text": "add",
-                                                                                "start": 8,
-                                                                                "startCol": 17,
-                                                                                "end": 8,
-                                                                                "endCol": 20
+                                                                                "text": "add"
                                                                               }
                                                                             ]
                                                                           }
@@ -1902,129 +1006,61 @@
                                                                       },
                                                                       {
                                                                         "kind": "call_suffix",
-                                                                        "start": 8,
-                                                                        "startCol": 20,
-                                                                        "end": 8,
-                                                                        "endCol": 157,
                                                                         "children": [
                                                                           {
                                                                             "kind": "value_arguments",
-                                                                            "start": 8,
-                                                                            "startCol": 20,
-                                                                            "end": 8,
-                                                                            "endCol": 157,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "value_argument",
-                                                                                "start": 8,
-                                                                                "startCol": 21,
-                                                                                "end": 8,
-                                                                                "endCol": 156,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "call_expression",
-                                                                                    "start": 8,
-                                                                                    "startCol": 21,
-                                                                                    "end": 8,
-                                                                                    "endCol": 156,
                                                                                     "children": [
                                                                                       {
                                                                                         "kind": "simple_identifier",
-                                                                                        "text": "mutableMapOf",
-                                                                                        "start": 8,
-                                                                                        "startCol": 21,
-                                                                                        "end": 8,
-                                                                                        "endCol": 33
+                                                                                        "text": "mutableMapOf"
                                                                                       },
                                                                                       {
                                                                                         "kind": "call_suffix",
-                                                                                        "start": 8,
-                                                                                        "startCol": 33,
-                                                                                        "end": 8,
-                                                                                        "endCol": 156,
                                                                                         "children": [
                                                                                           {
                                                                                             "kind": "value_arguments",
-                                                                                            "start": 8,
-                                                                                            "startCol": 33,
-                                                                                            "end": 8,
-                                                                                            "endCol": 156,
                                                                                             "children": [
                                                                                               {
                                                                                                 "kind": "value_argument",
-                                                                                                "start": 8,
-                                                                                                "startCol": 34,
-                                                                                                "end": 8,
-                                                                                                "endCol": 54,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "infix_expression",
-                                                                                                    "start": 8,
-                                                                                                    "startCol": 34,
-                                                                                                    "end": 8,
-                                                                                                    "endCol": 54,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_literal",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 34,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 43,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "string_content",
-                                                                                                            "text": "orderId",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 35,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 42
+                                                                                                            "text": "orderId"
                                                                                                           }
                                                                                                         ]
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "simple_identifier",
-                                                                                                        "text": "to",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 44,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 46
+                                                                                                        "text": "to"
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "indexing_expression",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 47,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 54,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "simple_identifier",
-                                                                                                            "text": "o",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 47,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 48
+                                                                                                            "text": "o"
                                                                                                           },
                                                                                                           {
                                                                                                             "kind": "indexing_suffix",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 48,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 54,
                                                                                                             "children": [
                                                                                                               {
                                                                                                                 "kind": "string_literal",
-                                                                                                                "start": 8,
-                                                                                                                "startCol": 49,
-                                                                                                                "end": 8,
-                                                                                                                "endCol": 53,
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string_content",
-                                                                                                                    "text": "id",
-                                                                                                                    "start": 8,
-                                                                                                                    "startCol": 50,
-                                                                                                                    "end": 8,
-                                                                                                                    "endCol": 52
+                                                                                                                    "text": "id"
                                                                                                                   }
                                                                                                                 ]
                                                                                                               }
@@ -2038,79 +1074,39 @@
                                                                                               },
                                                                                               {
                                                                                                 "kind": "value_argument",
-                                                                                                "start": 8,
-                                                                                                "startCol": 56,
-                                                                                                "end": 8,
-                                                                                                "endCol": 92,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "infix_expression",
-                                                                                                    "start": 8,
-                                                                                                    "startCol": 56,
-                                                                                                    "end": 8,
-                                                                                                    "endCol": 92,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_literal",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 56,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 73,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "string_content",
-                                                                                                            "text": "orderCustomerId",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 57,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 72
+                                                                                                            "text": "orderCustomerId"
                                                                                                           }
                                                                                                         ]
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "simple_identifier",
-                                                                                                        "text": "to",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 74,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 76
+                                                                                                        "text": "to"
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "indexing_expression",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 77,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 92,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "simple_identifier",
-                                                                                                            "text": "o",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 77,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 78
+                                                                                                            "text": "o"
                                                                                                           },
                                                                                                           {
                                                                                                             "kind": "indexing_suffix",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 78,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 92,
                                                                                                             "children": [
                                                                                                               {
                                                                                                                 "kind": "string_literal",
-                                                                                                                "start": 8,
-                                                                                                                "startCol": 79,
-                                                                                                                "end": 8,
-                                                                                                                "endCol": 91,
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string_content",
-                                                                                                                    "text": "customerId",
-                                                                                                                    "start": 8,
-                                                                                                                    "startCol": 80,
-                                                                                                                    "end": 8,
-                                                                                                                    "endCol": 90
+                                                                                                                    "text": "customerId"
                                                                                                                   }
                                                                                                                 ]
                                                                                                               }
@@ -2124,79 +1120,39 @@
                                                                                               },
                                                                                               {
                                                                                                 "kind": "value_argument",
-                                                                                                "start": 8,
-                                                                                                "startCol": 94,
-                                                                                                "end": 8,
-                                                                                                "endCol": 127,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "infix_expression",
-                                                                                                    "start": 8,
-                                                                                                    "startCol": 94,
-                                                                                                    "end": 8,
-                                                                                                    "endCol": 127,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_literal",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 94,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 114,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "string_content",
-                                                                                                            "text": "pairedCustomerName",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 95,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 113
+                                                                                                            "text": "pairedCustomerName"
                                                                                                           }
                                                                                                         ]
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "simple_identifier",
-                                                                                                        "text": "to",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 115,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 117
+                                                                                                        "text": "to"
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "indexing_expression",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 118,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 127,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "simple_identifier",
-                                                                                                            "text": "c",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 118,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 119
+                                                                                                            "text": "c"
                                                                                                           },
                                                                                                           {
                                                                                                             "kind": "indexing_suffix",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 119,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 127,
                                                                                                             "children": [
                                                                                                               {
                                                                                                                 "kind": "string_literal",
-                                                                                                                "start": 8,
-                                                                                                                "startCol": 120,
-                                                                                                                "end": 8,
-                                                                                                                "endCol": 126,
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string_content",
-                                                                                                                    "text": "name",
-                                                                                                                    "start": 8,
-                                                                                                                    "startCol": 121,
-                                                                                                                    "end": 8,
-                                                                                                                    "endCol": 125
+                                                                                                                    "text": "name"
                                                                                                                   }
                                                                                                                 ]
                                                                                                               }
@@ -2210,79 +1166,39 @@
                                                                                               },
                                                                                               {
                                                                                                 "kind": "value_argument",
-                                                                                                "start": 8,
-                                                                                                "startCol": 129,
-                                                                                                "end": 8,
-                                                                                                "endCol": 155,
                                                                                                 "children": [
                                                                                                   {
                                                                                                     "kind": "infix_expression",
-                                                                                                    "start": 8,
-                                                                                                    "startCol": 129,
-                                                                                                    "end": 8,
-                                                                                                    "endCol": 155,
                                                                                                     "children": [
                                                                                                       {
                                                                                                         "kind": "string_literal",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 129,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 141,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "string_content",
-                                                                                                            "text": "orderTotal",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 130,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 140
+                                                                                                            "text": "orderTotal"
                                                                                                           }
                                                                                                         ]
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "simple_identifier",
-                                                                                                        "text": "to",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 142,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 144
+                                                                                                        "text": "to"
                                                                                                       },
                                                                                                       {
                                                                                                         "kind": "indexing_expression",
-                                                                                                        "start": 8,
-                                                                                                        "startCol": 145,
-                                                                                                        "end": 8,
-                                                                                                        "endCol": 155,
                                                                                                         "children": [
                                                                                                           {
                                                                                                             "kind": "simple_identifier",
-                                                                                                            "text": "o",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 145,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 146
+                                                                                                            "text": "o"
                                                                                                           },
                                                                                                           {
                                                                                                             "kind": "indexing_suffix",
-                                                                                                            "start": 8,
-                                                                                                            "startCol": 146,
-                                                                                                            "end": 8,
-                                                                                                            "endCol": 155,
                                                                                                             "children": [
                                                                                                               {
                                                                                                                 "kind": "string_literal",
-                                                                                                                "start": 8,
-                                                                                                                "startCol": 147,
-                                                                                                                "end": 8,
-                                                                                                                "endCol": 154,
                                                                                                                 "children": [
                                                                                                                   {
                                                                                                                     "kind": "string_content",
-                                                                                                                    "text": "total",
-                                                                                                                    "start": 8,
-                                                                                                                    "startCol": 148,
-                                                                                                                    "end": 8,
-                                                                                                                    "endCol": 153
+                                                                                                                    "text": "total"
                                                                                                                   }
                                                                                                                 ]
                                                                                                               }
@@ -2322,11 +1238,7 @@
                                           },
                                           {
                                             "kind": "simple_identifier",
-                                            "text": "_res",
-                                            "start": 11,
-                                            "startCol": 4,
-                                            "end": 11,
-                                            "endCol": 8
+                                            "text": "_res"
                                           }
                                         ]
                                       }
@@ -2342,54 +1254,26 @@
                   },
                   {
                     "kind": "call_expression",
-                    "start": 13,
-                    "startCol": 4,
-                    "end": 13,
-                    "endCol": 59,
                     "children": [
                       {
                         "kind": "simple_identifier",
-                        "text": "println",
-                        "start": 13,
-                        "startCol": 4,
-                        "end": 13,
-                        "endCol": 11
+                        "text": "println"
                       },
                       {
                         "kind": "call_suffix",
-                        "start": 13,
-                        "startCol": 11,
-                        "end": 13,
-                        "endCol": 59,
                         "children": [
                           {
                             "kind": "value_arguments",
-                            "start": 13,
-                            "startCol": 11,
-                            "end": 13,
-                            "endCol": 59,
                             "children": [
                               {
                                 "kind": "value_argument",
-                                "start": 13,
-                                "startCol": 12,
-                                "end": 13,
-                                "endCol": 58,
                                 "children": [
                                   {
                                     "kind": "string_literal",
-                                    "start": 13,
-                                    "startCol": 12,
-                                    "end": 13,
-                                    "endCol": 58,
                                     "children": [
                                       {
                                         "kind": "string_content",
-                                        "text": "--- Cross Join: All order-customer pairs ---",
-                                        "start": 13,
-                                        "startCol": 13,
-                                        "end": 13,
-                                        "endCol": 57
+                                        "text": "--- Cross Join: All order-customer pairs ---"
                                       }
                                     ]
                                   }
@@ -2403,150 +1287,70 @@
                   },
                   {
                     "kind": "for_statement",
-                    "start": 14,
-                    "startCol": 4,
-                    "end": 16,
-                    "endCol": 5,
                     "children": [
                       {
                         "kind": "variable_declaration",
-                        "start": 14,
-                        "startCol": 9,
-                        "end": 14,
-                        "endCol": 14,
                         "children": [
                           {
                             "kind": "simple_identifier",
-                            "text": "entry",
-                            "start": 14,
-                            "startCol": 9,
-                            "end": 14,
-                            "endCol": 14
+                            "text": "entry"
                           }
                         ]
                       },
                       {
                         "kind": "simple_identifier",
-                        "text": "result",
-                        "start": 14,
-                        "startCol": 18,
-                        "end": 14,
-                        "endCol": 24
+                        "text": "result"
                       },
                       {
                         "kind": "control_structure_body",
-                        "start": 14,
-                        "startCol": 26,
-                        "end": 16,
-                        "endCol": 5,
                         "children": [
                           {
                             "kind": "statements",
-                            "start": 15,
-                            "startCol": 8,
-                            "end": 15,
-                            "endCol": 191,
                             "children": [
                               {
                                 "kind": "call_expression",
-                                "start": 15,
-                                "startCol": 8,
-                                "end": 15,
-                                "endCol": 191,
                                 "children": [
                                   {
                                     "kind": "simple_identifier",
-                                    "text": "println",
-                                    "start": 15,
-                                    "startCol": 8,
-                                    "end": 15,
-                                    "endCol": 15
+                                    "text": "println"
                                   },
                                   {
                                     "kind": "call_suffix",
-                                    "start": 15,
-                                    "startCol": 15,
-                                    "end": 15,
-                                    "endCol": 191,
                                     "children": [
                                       {
                                         "kind": "value_arguments",
-                                        "start": 15,
-                                        "startCol": 15,
-                                        "end": 15,
-                                        "endCol": 191,
                                         "children": [
                                           {
                                             "kind": "value_argument",
-                                            "start": 15,
-                                            "startCol": 16,
-                                            "end": 15,
-                                            "endCol": 190,
                                             "children": [
                                               {
                                                 "kind": "call_expression",
-                                                "start": 15,
-                                                "startCol": 16,
-                                                "end": 15,
-                                                "endCol": 190,
                                                 "children": [
                                                   {
                                                     "kind": "navigation_expression",
-                                                    "start": 15,
-                                                    "startCol": 16,
-                                                    "end": 15,
-                                                    "endCol": 185,
                                                     "children": [
                                                       {
                                                         "kind": "call_expression",
-                                                        "start": 15,
-                                                        "startCol": 16,
-                                                        "end": 15,
-                                                        "endCol": 172,
                                                         "children": [
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "listOf",
-                                                            "start": 15,
-                                                            "startCol": 16,
-                                                            "end": 15,
-                                                            "endCol": 22
+                                                            "text": "listOf"
                                                           },
                                                           {
                                                             "kind": "call_suffix",
-                                                            "start": 15,
-                                                            "startCol": 22,
-                                                            "end": 15,
-                                                            "endCol": 172,
                                                             "children": [
                                                               {
                                                                 "kind": "value_arguments",
-                                                                "start": 15,
-                                                                "startCol": 22,
-                                                                "end": 15,
-                                                                "endCol": 172,
                                                                 "children": [
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 23,
-                                                                    "end": 15,
-                                                                    "endCol": 30,
                                                                     "children": [
                                                                       {
                                                                         "kind": "string_literal",
-                                                                        "start": 15,
-                                                                        "startCol": 23,
-                                                                        "end": 15,
-                                                                        "endCol": 30,
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": "Order",
-                                                                            "start": 15,
-                                                                            "startCol": 24,
-                                                                            "end": 15,
-                                                                            "endCol": 29
+                                                                            "text": "Order"
                                                                           }
                                                                         ]
                                                                       }
@@ -2554,47 +1358,23 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 32,
-                                                                    "end": 15,
-                                                                    "endCol": 48,
                                                                     "children": [
                                                                       {
                                                                         "kind": "indexing_expression",
-                                                                        "start": 15,
-                                                                        "startCol": 32,
-                                                                        "end": 15,
-                                                                        "endCol": 48,
                                                                         "children": [
                                                                           {
                                                                             "kind": "simple_identifier",
-                                                                            "text": "entry",
-                                                                            "start": 15,
-                                                                            "startCol": 32,
-                                                                            "end": 15,
-                                                                            "endCol": 37
+                                                                            "text": "entry"
                                                                           },
                                                                           {
                                                                             "kind": "indexing_suffix",
-                                                                            "start": 15,
-                                                                            "startCol": 37,
-                                                                            "end": 15,
-                                                                            "endCol": 48,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "string_literal",
-                                                                                "start": 15,
-                                                                                "startCol": 38,
-                                                                                "end": 15,
-                                                                                "endCol": 47,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "string_content",
-                                                                                    "text": "orderId",
-                                                                                    "start": 15,
-                                                                                    "startCol": 39,
-                                                                                    "end": 15,
-                                                                                    "endCol": 46
+                                                                                    "text": "orderId"
                                                                                   }
                                                                                 ]
                                                                               }
@@ -2606,25 +1386,13 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 50,
-                                                                    "end": 15,
-                                                                    "endCol": 64,
                                                                     "children": [
                                                                       {
                                                                         "kind": "string_literal",
-                                                                        "start": 15,
-                                                                        "startCol": 50,
-                                                                        "end": 15,
-                                                                        "endCol": 64,
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": "(customerId:",
-                                                                            "start": 15,
-                                                                            "startCol": 51,
-                                                                            "end": 15,
-                                                                            "endCol": 63
+                                                                            "text": "(customerId:"
                                                                           }
                                                                         ]
                                                                       }
@@ -2632,47 +1400,23 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 66,
-                                                                    "end": 15,
-                                                                    "endCol": 90,
                                                                     "children": [
                                                                       {
                                                                         "kind": "indexing_expression",
-                                                                        "start": 15,
-                                                                        "startCol": 66,
-                                                                        "end": 15,
-                                                                        "endCol": 90,
                                                                         "children": [
                                                                           {
                                                                             "kind": "simple_identifier",
-                                                                            "text": "entry",
-                                                                            "start": 15,
-                                                                            "startCol": 66,
-                                                                            "end": 15,
-                                                                            "endCol": 71
+                                                                            "text": "entry"
                                                                           },
                                                                           {
                                                                             "kind": "indexing_suffix",
-                                                                            "start": 15,
-                                                                            "startCol": 71,
-                                                                            "end": 15,
-                                                                            "endCol": 90,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "string_literal",
-                                                                                "start": 15,
-                                                                                "startCol": 72,
-                                                                                "end": 15,
-                                                                                "endCol": 89,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "string_content",
-                                                                                    "text": "orderCustomerId",
-                                                                                    "start": 15,
-                                                                                    "startCol": 73,
-                                                                                    "end": 15,
-                                                                                    "endCol": 88
+                                                                                    "text": "orderCustomerId"
                                                                                   }
                                                                                 ]
                                                                               }
@@ -2684,33 +1428,17 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 92,
-                                                                    "end": 15,
-                                                                    "endCol": 104,
                                                                     "children": [
                                                                       {
                                                                         "kind": "string_literal",
-                                                                        "start": 15,
-                                                                        "startCol": 92,
-                                                                        "end": 15,
-                                                                        "endCol": 104,
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": ", total: ",
-                                                                            "start": 15,
-                                                                            "startCol": 93,
-                                                                            "end": 15,
-                                                                            "endCol": 102
+                                                                            "text": ", total: "
                                                                           },
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": "$",
-                                                                            "start": 15,
-                                                                            "startCol": 102,
-                                                                            "end": 15,
-                                                                            "endCol": 103
+                                                                            "text": "$"
                                                                           }
                                                                         ]
                                                                       }
@@ -2718,47 +1446,23 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 106,
-                                                                    "end": 15,
-                                                                    "endCol": 125,
                                                                     "children": [
                                                                       {
                                                                         "kind": "indexing_expression",
-                                                                        "start": 15,
-                                                                        "startCol": 106,
-                                                                        "end": 15,
-                                                                        "endCol": 125,
                                                                         "children": [
                                                                           {
                                                                             "kind": "simple_identifier",
-                                                                            "text": "entry",
-                                                                            "start": 15,
-                                                                            "startCol": 106,
-                                                                            "end": 15,
-                                                                            "endCol": 111
+                                                                            "text": "entry"
                                                                           },
                                                                           {
                                                                             "kind": "indexing_suffix",
-                                                                            "start": 15,
-                                                                            "startCol": 111,
-                                                                            "end": 15,
-                                                                            "endCol": 125,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "string_literal",
-                                                                                "start": 15,
-                                                                                "startCol": 112,
-                                                                                "end": 15,
-                                                                                "endCol": 124,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "string_content",
-                                                                                    "text": "orderTotal",
-                                                                                    "start": 15,
-                                                                                    "startCol": 113,
-                                                                                    "end": 15,
-                                                                                    "endCol": 123
+                                                                                    "text": "orderTotal"
                                                                                   }
                                                                                 ]
                                                                               }
@@ -2770,25 +1474,13 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 127,
-                                                                    "end": 15,
-                                                                    "endCol": 142,
                                                                     "children": [
                                                                       {
                                                                         "kind": "string_literal",
-                                                                        "start": 15,
-                                                                        "startCol": 127,
-                                                                        "end": 15,
-                                                                        "endCol": 142,
                                                                         "children": [
                                                                           {
                                                                             "kind": "string_content",
-                                                                            "text": ") paired with",
-                                                                            "start": 15,
-                                                                            "startCol": 128,
-                                                                            "end": 15,
-                                                                            "endCol": 141
+                                                                            "text": ") paired with"
                                                                           }
                                                                         ]
                                                                       }
@@ -2796,47 +1488,23 @@
                                                                   },
                                                                   {
                                                                     "kind": "value_argument",
-                                                                    "start": 15,
-                                                                    "startCol": 144,
-                                                                    "end": 15,
-                                                                    "endCol": 171,
                                                                     "children": [
                                                                       {
                                                                         "kind": "indexing_expression",
-                                                                        "start": 15,
-                                                                        "startCol": 144,
-                                                                        "end": 15,
-                                                                        "endCol": 171,
                                                                         "children": [
                                                                           {
                                                                             "kind": "simple_identifier",
-                                                                            "text": "entry",
-                                                                            "start": 15,
-                                                                            "startCol": 144,
-                                                                            "end": 15,
-                                                                            "endCol": 149
+                                                                            "text": "entry"
                                                                           },
                                                                           {
                                                                             "kind": "indexing_suffix",
-                                                                            "start": 15,
-                                                                            "startCol": 149,
-                                                                            "end": 15,
-                                                                            "endCol": 171,
                                                                             "children": [
                                                                               {
                                                                                 "kind": "string_literal",
-                                                                                "start": 15,
-                                                                                "startCol": 150,
-                                                                                "end": 15,
-                                                                                "endCol": 170,
                                                                                 "children": [
                                                                                   {
                                                                                     "kind": "string_content",
-                                                                                    "text": "pairedCustomerName",
-                                                                                    "start": 15,
-                                                                                    "startCol": 151,
-                                                                                    "end": 15,
-                                                                                    "endCol": 169
+                                                                                    "text": "pairedCustomerName"
                                                                                   }
                                                                                 ]
                                                                               }
@@ -2854,18 +1522,10 @@
                                                       },
                                                       {
                                                         "kind": "navigation_suffix",
-                                                        "start": 15,
-                                                        "startCol": 172,
-                                                        "end": 15,
-                                                        "endCol": 185,
                                                         "children": [
                                                           {
                                                             "kind": "simple_identifier",
-                                                            "text": "joinToString",
-                                                            "start": 15,
-                                                            "startCol": 173,
-                                                            "end": 15,
-                                                            "endCol": 185
+                                                            "text": "joinToString"
                                                           }
                                                         ]
                                                       }
@@ -2873,39 +1533,19 @@
                                                   },
                                                   {
                                                     "kind": "call_suffix",
-                                                    "start": 15,
-                                                    "startCol": 185,
-                                                    "end": 15,
-                                                    "endCol": 190,
                                                     "children": [
                                                       {
                                                         "kind": "value_arguments",
-                                                        "start": 15,
-                                                        "startCol": 185,
-                                                        "end": 15,
-                                                        "endCol": 190,
                                                         "children": [
                                                           {
                                                             "kind": "value_argument",
-                                                            "start": 15,
-                                                            "startCol": 186,
-                                                            "end": 15,
-                                                            "endCol": 189,
                                                             "children": [
                                                               {
                                                                 "kind": "string_literal",
-                                                                "start": 15,
-                                                                "startCol": 186,
-                                                                "end": 15,
-                                                                "endCol": 189,
                                                                 "children": [
                                                                   {
                                                                     "kind": "string_content",
-                                                                    "text": " ",
-                                                                    "start": 15,
-                                                                    "startCol": 187,
-                                                                    "end": 15,
-                                                                    "endCol": 188
+                                                                    "text": " "
                                                                   }
                                                                 ]
                                                               }

--- a/tools/json-ast/x/kotlin/inspect.go
+++ b/tools/json-ast/x/kotlin/inspect.go
@@ -12,13 +12,24 @@ type Program struct {
 	Root SourceFile `json:"root"`
 }
 
+// Option configures how Inspect behaves.
+type Option struct {
+	WithPositions bool
+}
+
 // Inspect parses Kotlin source code using tree-sitter and returns its AST.
-func Inspect(src string) (*Program, error) {
+// By default positional information is omitted from the returned tree. Pass an
+// Option with WithPositions set to true to include position fields.
+func Inspect(src string, opts ...Option) (*Program, error) {
+	var withPos bool
+	if len(opts) > 0 {
+		withPos = opts[0].WithPositions
+	}
 	p := sitter.NewParser()
 	p.SetLanguage(ts.GetLanguage())
 	data := []byte(src)
 	tree := p.Parse(nil, data)
-	root := convert(tree.RootNode(), data)
+	root := convert(tree.RootNode(), data, withPos)
 	return &Program{Root: SourceFile{Node: root}}, nil
 }
 


### PR DESCRIPTION
## Summary
- refactor Kotlin AST to optionally omit position fields
- add option to include positions when inspecting
- regenerate cross_join.kt.json without positions

## Testing
- `go test ./tools/json-ast/x/kotlin -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6889d606342883209eaaaf1c82ba993f