### PR TITLE
Simplify prolog json-ast output

### DIFF
--- a/tests/json-ast/x/prolog/cross_join.prolog.json
+++ b/tests/json-ast/x/prolog/cross_join.prolog.json
@@ -1,182 +1,90 @@
 {
   "kind": "program",
-  "start": 0,
-  "startCol": 0,
-  "end": 0,
-  "endCol": 0,
   "children": [
     {
       "kind": "clause",
-      "start": 1,
-      "startCol": 0,
-      "end": 1,
-      "endCol": 27,
       "children": [
         {
           "kind": ":-",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0,
           "children": [
             {
               "kind": "atom",
-              "text": "style_check(-singleton)",
-              "start": 0,
-              "startCol": 0,
-              "end": 0,
-              "endCol": 0
+              "text": "style_check(-singleton)"
             }
           ]
         },
         {
           "kind": "bool",
-          "text": "true",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0
+          "text": "true"
         }
       ]
     },
     {
       "kind": "clause",
-      "start": 1,
-      "startCol": 27,
-      "end": 2,
-      "endCol": 24,
       "children": [
         {
           "kind": ":-",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0,
           "children": [
             {
               "kind": "atom",
-              "text": "initialization main",
-              "start": 0,
-              "startCol": 0,
-              "end": 0,
-              "endCol": 0
+              "text": "initialization main"
             }
           ]
         },
         {
           "kind": "bool",
-          "text": "true",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0
+          "text": "true"
         }
       ]
     },
     {
       "kind": "clause",
-      "start": 2,
-      "startCol": 24,
-      "end": 26,
-      "endCol": 77,
       "children": [
         {
-          "kind": "main",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0
+          "kind": "main"
         },
         {
           "kind": ",",
-          "start": 0,
-          "startCol": 0,
-          "end": 0,
-          "endCol": 0,
           "children": [
             {
               "kind": "=",
-              "start": 0,
-              "startCol": 0,
-              "end": 0,
-              "endCol": 0,
               "children": [
                 {
                   "kind": "var",
-                  "text": "Customers",
-                  "start": 0,
-                  "startCol": 0,
-                  "end": 0,
-                  "endCol": 0
+                  "text": "Customers"
                 },
                 {
                   "kind": "list",
-                  "start": 0,
-                  "startCol": 0,
-                  "end": 0,
-                  "endCol": 0,
                   "children": [
                     {
                       "kind": "{}",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": ",",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "id",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "id"
                                 },
                                 {
                                   "kind": "number",
-                                  "text": "1",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "1"
                                 }
                               ]
                             },
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "name",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "name"
                                 },
                                 {
                                   "kind": "atom",
-                                  "text": "Alice",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "Alice"
                                 }
                               ]
                             }
@@ -186,65 +94,33 @@
                     },
                     {
                       "kind": "{}",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": ",",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "id",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "id"
                                 },
                                 {
                                   "kind": "number",
-                                  "text": "2",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "2"
                                 }
                               ]
                             },
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "name",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "name"
                                 },
                                 {
                                   "kind": "atom",
-                                  "text": "Bob",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "Bob"
                                 }
                               ]
                             }
@@ -254,65 +130,33 @@
                     },
                     {
                       "kind": "{}",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": ",",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "id",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "id"
                                 },
                                 {
                                   "kind": "number",
-                                  "text": "3",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "3"
                                 }
                               ]
                             },
                             {
                               "kind": ":",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "atom",
-                                  "text": "name",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "name"
                                 },
                                 {
                                   "kind": "atom",
-                                  "text": "Charlie",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "Charlie"
                                 }
                               ]
                             }
@@ -326,126 +170,62 @@
             },
             {
               "kind": ",",
-              "start": 0,
-              "startCol": 0,
-              "end": 0,
-              "endCol": 0,
               "children": [
                 {
                   "kind": "=",
-                  "start": 0,
-                  "startCol": 0,
-                  "end": 0,
-                  "endCol": 0,
                   "children": [
                     {
                       "kind": "var",
-                      "text": "Orders",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0
+                      "text": "Orders"
                     },
                     {
                       "kind": "list",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": "{}",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ",",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ":",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": "atom",
-                                      "text": "id",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "id"
                                     },
                                     {
                                       "kind": "number",
-                                      "text": "100",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "100"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "customerId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "customerId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "1",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "1"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "total",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "total"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "250",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "250"
                                         }
                                       ]
                                     }
@@ -457,97 +237,49 @@
                         },
                         {
                           "kind": "{}",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ",",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ":",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": "atom",
-                                      "text": "id",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "id"
                                     },
                                     {
                                       "kind": "number",
-                                      "text": "101",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "101"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "customerId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "customerId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "2",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "2"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "total",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "total"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "125",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "125"
                                         }
                                       ]
                                     }
@@ -559,97 +291,49 @@
                         },
                         {
                           "kind": "{}",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": ",",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ":",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": "atom",
-                                      "text": "id",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "id"
                                     },
                                     {
                                       "kind": "number",
-                                      "text": "102",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "102"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "customerId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "customerId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "1",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "1"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "total",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "total"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "300",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "300"
                                         }
                                       ]
                                     }
@@ -665,158 +349,78 @@
                 },
                 {
                   "kind": ",",
-                  "start": 0,
-                  "startCol": 0,
-                  "end": 0,
-                  "endCol": 0,
                   "children": [
                     {
                       "kind": "=",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": "var",
-                          "text": "Result",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0
+                          "text": "Result"
                         },
                         {
                           "kind": "list",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "100",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "100"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Alice",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Alice"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "250",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "250"
                                                 }
                                               ]
                                             }
@@ -830,129 +434,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "100",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "100"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Bob",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Bob"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "250",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "250"
                                                 }
                                               ]
                                             }
@@ -966,129 +506,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "100",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "100"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Charlie",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Charlie"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "250",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "250"
                                                 }
                                               ]
                                             }
@@ -1102,129 +578,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "101",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "101"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "2",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "2"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Alice",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Alice"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "125",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "125"
                                                 }
                                               ]
                                             }
@@ -1238,129 +650,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "101",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "101"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "2",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "2"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Bob",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Bob"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "125",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "125"
                                                 }
                                               ]
                                             }
@@ -1374,129 +722,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "101",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "101"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "2",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "2"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Charlie",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Charlie"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "125",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "125"
                                                 }
                                               ]
                                             }
@@ -1510,129 +794,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "102",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "102"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Alice",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Alice"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "300",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "300"
                                                 }
                                               ]
                                             }
@@ -1646,129 +866,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "102",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "102"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Bob",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Bob"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "300",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "300"
                                                 }
                                               ]
                                             }
@@ -1782,129 +938,65 @@
                             },
                             {
                               "kind": "{}",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ":",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "atom",
-                                          "text": "orderId",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "orderId"
                                         },
                                         {
                                           "kind": "number",
-                                          "text": "102",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "102"
                                         }
                                       ]
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderCustomerId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderCustomerId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "1",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "1"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "pairedCustomerName",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "pairedCustomerName"
                                                 },
                                                 {
                                                   "kind": "atom",
-                                                  "text": "Charlie",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Charlie"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderTotal",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderTotal"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "300",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "300"
                                                 }
                                               ]
                                             }
@@ -1922,175 +1014,87 @@
                     },
                     {
                       "kind": ",",
-                      "start": 0,
-                      "startCol": 0,
-                      "end": 0,
-                      "endCol": 0,
                       "children": [
                         {
                           "kind": "writeln",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": "atom",
-                              "text": "--- Cross Join: All order-customer pairs ---",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0
+                              "text": "--- Cross Join: All order-customer pairs ---"
                             }
                           ]
                         },
                         {
                           "kind": ",",
-                          "start": 0,
-                          "startCol": 0,
-                          "end": 0,
-                          "endCol": 0,
                           "children": [
                             {
                               "kind": "=",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "var",
-                                  "text": "Entry",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0
+                                  "text": "Entry"
                                 },
                                 {
                                   "kind": "{}",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": ":",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "orderId",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "orderId"
                                             },
                                             {
                                               "kind": "number",
-                                              "text": "100",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "100"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ":",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "atom",
-                                                  "text": "orderCustomerId",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "orderCustomerId"
                                                 },
                                                 {
                                                   "kind": "number",
-                                                  "text": "1",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "1"
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": ",",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": ":",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": "atom",
-                                                      "text": "pairedCustomerName",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "pairedCustomerName"
                                                     },
                                                     {
                                                       "kind": "atom",
-                                                      "text": "Alice",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "Alice"
                                                     }
                                                   ]
                                                 },
                                                 {
                                                   "kind": ":",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": "atom",
-                                                      "text": "orderTotal",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "orderTotal"
                                                     },
                                                     {
                                                       "kind": "number",
-                                                      "text": "250",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "250"
                                                     }
                                                   ]
                                                 }
@@ -2106,175 +1110,87 @@
                             },
                             {
                               "kind": ",",
-                              "start": 0,
-                              "startCol": 0,
-                              "end": 0,
-                              "endCol": 0,
                               "children": [
                                 {
                                   "kind": "writeln",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": "atom",
-                                      "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Alice",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0
+                                      "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Alice"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": ",",
-                                  "start": 0,
-                                  "startCol": 0,
-                                  "end": 0,
-                                  "endCol": 0,
                                   "children": [
                                     {
                                       "kind": "=",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "var",
-                                          "text": "Entry1",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0
+                                          "text": "Entry1"
                                         },
                                         {
                                           "kind": "{}",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": ",",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": ":",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": "atom",
-                                                      "text": "orderId",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "orderId"
                                                     },
                                                     {
                                                       "kind": "number",
-                                                      "text": "100",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "100"
                                                     }
                                                   ]
                                                 },
                                                 {
                                                   "kind": ",",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": ":",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0,
                                                       "children": [
                                                         {
                                                           "kind": "atom",
-                                                          "text": "orderCustomerId",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0
+                                                          "text": "orderCustomerId"
                                                         },
                                                         {
                                                           "kind": "number",
-                                                          "text": "1",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0
+                                                          "text": "1"
                                                         }
                                                       ]
                                                     },
                                                     {
                                                       "kind": ",",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0,
                                                       "children": [
                                                         {
                                                           "kind": ":",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": "atom",
-                                                              "text": "pairedCustomerName",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "pairedCustomerName"
                                                             },
                                                             {
                                                               "kind": "atom",
-                                                              "text": "Bob",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "Bob"
                                                             }
                                                           ]
                                                         },
                                                         {
                                                           "kind": ":",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": "atom",
-                                                              "text": "orderTotal",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "orderTotal"
                                                             },
                                                             {
                                                               "kind": "number",
-                                                              "text": "250",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "250"
                                                             }
                                                           ]
                                                         }
@@ -2290,175 +1206,87 @@
                                     },
                                     {
                                       "kind": ",",
-                                      "start": 0,
-                                      "startCol": 0,
-                                      "end": 0,
-                                      "endCol": 0,
                                       "children": [
                                         {
                                           "kind": "writeln",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "atom",
-                                              "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Bob",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0
+                                              "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Bob"
                                             }
                                           ]
                                         },
                                         {
                                           "kind": ",",
-                                          "start": 0,
-                                          "startCol": 0,
-                                          "end": 0,
-                                          "endCol": 0,
                                           "children": [
                                             {
                                               "kind": "=",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "var",
-                                                  "text": "Entry2",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0
+                                                  "text": "Entry2"
                                                 },
                                                 {
                                                   "kind": "{}",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": ",",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0,
                                                       "children": [
                                                         {
                                                           "kind": ":",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": "atom",
-                                                              "text": "orderId",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "orderId"
                                                             },
                                                             {
                                                               "kind": "number",
-                                                              "text": "100",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "100"
                                                             }
                                                           ]
                                                         },
                                                         {
                                                           "kind": ",",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": ":",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0,
                                                               "children": [
                                                                 {
                                                                   "kind": "atom",
-                                                                  "text": "orderCustomerId",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0
+                                                                  "text": "orderCustomerId"
                                                                 },
                                                                 {
                                                                   "kind": "number",
-                                                                  "text": "1",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0
+                                                                  "text": "1"
                                                                 }
                                                               ]
                                                             },
                                                             {
                                                               "kind": ",",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0,
                                                               "children": [
                                                                 {
                                                                   "kind": ":",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": "atom",
-                                                                      "text": "pairedCustomerName",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "pairedCustomerName"
                                                                     },
                                                                     {
                                                                       "kind": "atom",
-                                                                      "text": "Charlie",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "Charlie"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
                                                                   "kind": ":",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": "atom",
-                                                                      "text": "orderTotal",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "orderTotal"
                                                                     },
                                                                     {
                                                                       "kind": "number",
-                                                                      "text": "250",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "250"
                                                                     }
                                                                   ]
                                                                 }
@@ -2474,175 +1302,87 @@
                                             },
                                             {
                                               "kind": ",",
-                                              "start": 0,
-                                              "startCol": 0,
-                                              "end": 0,
-                                              "endCol": 0,
                                               "children": [
                                                 {
                                                   "kind": "writeln",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": "atom",
-                                                      "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0
+                                                      "text": "Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie"
                                                     }
                                                   ]
                                                 },
                                                 {
                                                   "kind": ",",
-                                                  "start": 0,
-                                                  "startCol": 0,
-                                                  "end": 0,
-                                                  "endCol": 0,
                                                   "children": [
                                                     {
                                                       "kind": "=",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0,
                                                       "children": [
                                                         {
                                                           "kind": "var",
-                                                          "text": "Entry3",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0
+                                                          "text": "Entry3"
                                                         },
                                                         {
                                                           "kind": "{}",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": ",",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0,
                                                               "children": [
                                                                 {
                                                                   "kind": ":",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": "atom",
-                                                                      "text": "orderId",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "orderId"
                                                                     },
                                                                     {
                                                                       "kind": "number",
-                                                                      "text": "101",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "101"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
                                                                   "kind": ",",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": ":",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0,
                                                                       "children": [
                                                                         {
                                                                           "kind": "atom",
-                                                                          "text": "orderCustomerId",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0
+                                                                          "text": "orderCustomerId"
                                                                         },
                                                                         {
                                                                           "kind": "number",
-                                                                          "text": "2",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0
+                                                                          "text": "2"
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
                                                                       "kind": ",",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0,
                                                                       "children": [
                                                                         {
                                                                           "kind": ":",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": "atom",
-                                                                              "text": "pairedCustomerName",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "pairedCustomerName"
                                                                             },
                                                                             {
                                                                               "kind": "atom",
-                                                                              "text": "Alice",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "Alice"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
                                                                           "kind": ":",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": "atom",
-                                                                              "text": "orderTotal",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "orderTotal"
                                                                             },
                                                                             {
                                                                               "kind": "number",
-                                                                              "text": "125",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "125"
                                                                             }
                                                                           ]
                                                                         }
@@ -2658,175 +1398,87 @@
                                                     },
                                                     {
                                                       "kind": ",",
-                                                      "start": 0,
-                                                      "startCol": 0,
-                                                      "end": 0,
-                                                      "endCol": 0,
                                                       "children": [
                                                         {
                                                           "kind": "writeln",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": "atom",
-                                                              "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Alice",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0
+                                                              "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Alice"
                                                             }
                                                           ]
                                                         },
                                                         {
                                                           "kind": ",",
-                                                          "start": 0,
-                                                          "startCol": 0,
-                                                          "end": 0,
-                                                          "endCol": 0,
                                                           "children": [
                                                             {
                                                               "kind": "=",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0,
                                                               "children": [
                                                                 {
                                                                   "kind": "var",
-                                                                  "text": "Entry4",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0
+                                                                  "text": "Entry4"
                                                                 },
                                                                 {
                                                                   "kind": "{}",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": ",",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0,
                                                                       "children": [
                                                                         {
                                                                           "kind": ":",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": "atom",
-                                                                              "text": "orderId",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "orderId"
                                                                             },
                                                                             {
                                                                               "kind": "number",
-                                                                              "text": "101",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "101"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
                                                                           "kind": ",",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": ":",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0,
                                                                               "children": [
                                                                                 {
                                                                                   "kind": "atom",
-                                                                                  "text": "orderCustomerId",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0
+                                                                                  "text": "orderCustomerId"
                                                                                 },
                                                                                 {
                                                                                   "kind": "number",
-                                                                                  "text": "2",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0
+                                                                                  "text": "2"
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
                                                                               "kind": ",",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0,
                                                                               "children": [
                                                                                 {
                                                                                   "kind": ":",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": "atom",
-                                                                                      "text": "pairedCustomerName",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "pairedCustomerName"
                                                                                     },
                                                                                     {
                                                                                       "kind": "atom",
-                                                                                      "text": "Bob",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "Bob"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
                                                                                   "kind": ":",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": "atom",
-                                                                                      "text": "orderTotal",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "orderTotal"
                                                                                     },
                                                                                     {
                                                                                       "kind": "number",
-                                                                                      "text": "125",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "125"
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -2842,175 +1494,87 @@
                                                             },
                                                             {
                                                               "kind": ",",
-                                                              "start": 0,
-                                                              "startCol": 0,
-                                                              "end": 0,
-                                                              "endCol": 0,
                                                               "children": [
                                                                 {
                                                                   "kind": "writeln",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": "atom",
-                                                                      "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Bob",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0
+                                                                      "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Bob"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
                                                                   "kind": ",",
-                                                                  "start": 0,
-                                                                  "startCol": 0,
-                                                                  "end": 0,
-                                                                  "endCol": 0,
                                                                   "children": [
                                                                     {
                                                                       "kind": "=",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0,
                                                                       "children": [
                                                                         {
                                                                           "kind": "var",
-                                                                          "text": "Entry5",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0
+                                                                          "text": "Entry5"
                                                                         },
                                                                         {
                                                                           "kind": "{}",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": ",",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0,
                                                                               "children": [
                                                                                 {
                                                                                   "kind": ":",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": "atom",
-                                                                                      "text": "orderId",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "orderId"
                                                                                     },
                                                                                     {
                                                                                       "kind": "number",
-                                                                                      "text": "101",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "101"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
                                                                                   "kind": ",",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": ":",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0,
                                                                                       "children": [
                                                                                         {
                                                                                           "kind": "atom",
-                                                                                          "text": "orderCustomerId",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0
+                                                                                          "text": "orderCustomerId"
                                                                                         },
                                                                                         {
                                                                                           "kind": "number",
-                                                                                          "text": "2",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0
+                                                                                          "text": "2"
                                                                                         }
                                                                                       ]
                                                                                     },
                                                                                     {
                                                                                       "kind": ",",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0,
                                                                                       "children": [
                                                                                         {
                                                                                           "kind": ":",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": "atom",
-                                                                                              "text": "pairedCustomerName",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "pairedCustomerName"
                                                                                             },
                                                                                             {
                                                                                               "kind": "atom",
-                                                                                              "text": "Charlie",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "Charlie"
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
                                                                                           "kind": ":",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": "atom",
-                                                                                              "text": "orderTotal",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "orderTotal"
                                                                                             },
                                                                                             {
                                                                                               "kind": "number",
-                                                                                              "text": "125",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "125"
                                                                                             }
                                                                                           ]
                                                                                         }
@@ -3026,175 +1590,87 @@
                                                                     },
                                                                     {
                                                                       "kind": ",",
-                                                                      "start": 0,
-                                                                      "startCol": 0,
-                                                                      "end": 0,
-                                                                      "endCol": 0,
                                                                       "children": [
                                                                         {
                                                                           "kind": "writeln",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": "atom",
-                                                                              "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0
+                                                                              "text": "Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
                                                                           "kind": ",",
-                                                                          "start": 0,
-                                                                          "startCol": 0,
-                                                                          "end": 0,
-                                                                          "endCol": 0,
                                                                           "children": [
                                                                             {
                                                                               "kind": "=",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0,
                                                                               "children": [
                                                                                 {
                                                                                   "kind": "var",
-                                                                                  "text": "Entry6",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0
+                                                                                  "text": "Entry6"
                                                                                 },
                                                                                 {
                                                                                   "kind": "{}",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": ",",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0,
                                                                                       "children": [
                                                                                         {
                                                                                           "kind": ":",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": "atom",
-                                                                                              "text": "orderId",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "orderId"
                                                                                             },
                                                                                             {
                                                                                               "kind": "number",
-                                                                                              "text": "102",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "102"
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
                                                                                           "kind": ",",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": ":",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0,
                                                                                               "children": [
                                                                                                 {
                                                                                                   "kind": "atom",
-                                                                                                  "text": "orderCustomerId",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0
+                                                                                                  "text": "orderCustomerId"
                                                                                                 },
                                                                                                 {
                                                                                                   "kind": "number",
-                                                                                                  "text": "1",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0
+                                                                                                  "text": "1"
                                                                                                 }
                                                                                               ]
                                                                                             },
                                                                                             {
                                                                                               "kind": ",",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0,
                                                                                               "children": [
                                                                                                 {
                                                                                                   "kind": ":",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0,
                                                                                                   "children": [
                                                                                                     {
                                                                                                       "kind": "atom",
-                                                                                                      "text": "pairedCustomerName",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "pairedCustomerName"
                                                                                                     },
                                                                                                     {
                                                                                                       "kind": "atom",
-                                                                                                      "text": "Alice",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "Alice"
                                                                                                     }
                                                                                                   ]
                                                                                                 },
                                                                                                 {
                                                                                                   "kind": ":",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0,
                                                                                                   "children": [
                                                                                                     {
                                                                                                       "kind": "atom",
-                                                                                                      "text": "orderTotal",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "orderTotal"
                                                                                                     },
                                                                                                     {
                                                                                                       "kind": "number",
-                                                                                                      "text": "300",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "300"
                                                                                                     }
                                                                                                   ]
                                                                                                 }
@@ -3210,175 +1686,87 @@
                                                                             },
                                                                             {
                                                                               "kind": ",",
-                                                                              "start": 0,
-                                                                              "startCol": 0,
-                                                                              "end": 0,
-                                                                              "endCol": 0,
                                                                               "children": [
                                                                                 {
                                                                                   "kind": "writeln",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": "atom",
-                                                                                      "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Alice",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0
+                                                                                      "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Alice"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
                                                                                   "kind": ",",
-                                                                                  "start": 0,
-                                                                                  "startCol": 0,
-                                                                                  "end": 0,
-                                                                                  "endCol": 0,
                                                                                   "children": [
                                                                                     {
                                                                                       "kind": "=",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0,
                                                                                       "children": [
                                                                                         {
                                                                                           "kind": "var",
-                                                                                          "text": "Entry7",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0
+                                                                                          "text": "Entry7"
                                                                                         },
                                                                                         {
                                                                                           "kind": "{}",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": ",",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0,
                                                                                               "children": [
                                                                                                 {
                                                                                                   "kind": ":",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0,
                                                                                                   "children": [
                                                                                                     {
                                                                                                       "kind": "atom",
-                                                                                                      "text": "orderId",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "orderId"
                                                                                                     },
                                                                                                     {
                                                                                                       "kind": "number",
-                                                                                                      "text": "102",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0
+                                                                                                      "text": "102"
                                                                                                     }
                                                                                                   ]
                                                                                                 },
                                                                                                 {
                                                                                                   "kind": ",",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0,
                                                                                                   "children": [
                                                                                                     {
                                                                                                       "kind": ":",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0,
                                                                                                       "children": [
                                                                                                         {
                                                                                                           "kind": "atom",
-                                                                                                          "text": "orderCustomerId",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0
+                                                                                                          "text": "orderCustomerId"
                                                                                                         },
                                                                                                         {
                                                                                                           "kind": "number",
-                                                                                                          "text": "1",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0
+                                                                                                          "text": "1"
                                                                                                         }
                                                                                                       ]
                                                                                                     },
                                                                                                     {
                                                                                                       "kind": ",",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0,
                                                                                                       "children": [
                                                                                                         {
                                                                                                           "kind": ":",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0,
                                                                                                           "children": [
                                                                                                             {
                                                                                                               "kind": "atom",
-                                                                                                              "text": "pairedCustomerName",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "pairedCustomerName"
                                                                                                             },
                                                                                                             {
                                                                                                               "kind": "atom",
-                                                                                                              "text": "Bob",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "Bob"
                                                                                                             }
                                                                                                           ]
                                                                                                         },
                                                                                                         {
                                                                                                           "kind": ":",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0,
                                                                                                           "children": [
                                                                                                             {
                                                                                                               "kind": "atom",
-                                                                                                              "text": "orderTotal",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "orderTotal"
                                                                                                             },
                                                                                                             {
                                                                                                               "kind": "number",
-                                                                                                              "text": "300",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "300"
                                                                                                             }
                                                                                                           ]
                                                                                                         }
@@ -3394,175 +1782,87 @@
                                                                                     },
                                                                                     {
                                                                                       "kind": ",",
-                                                                                      "start": 0,
-                                                                                      "startCol": 0,
-                                                                                      "end": 0,
-                                                                                      "endCol": 0,
                                                                                       "children": [
                                                                                         {
                                                                                           "kind": "writeln",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": "atom",
-                                                                                              "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Bob",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0
+                                                                                              "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Bob"
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
                                                                                           "kind": ",",
-                                                                                          "start": 0,
-                                                                                          "startCol": 0,
-                                                                                          "end": 0,
-                                                                                          "endCol": 0,
                                                                                           "children": [
                                                                                             {
                                                                                               "kind": "=",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0,
                                                                                               "children": [
                                                                                                 {
                                                                                                   "kind": "var",
-                                                                                                  "text": "Entry8",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0
+                                                                                                  "text": "Entry8"
                                                                                                 },
                                                                                                 {
                                                                                                   "kind": "{}",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0,
                                                                                                   "children": [
                                                                                                     {
                                                                                                       "kind": ",",
-                                                                                                      "start": 0,
-                                                                                                      "startCol": 0,
-                                                                                                      "end": 0,
-                                                                                                      "endCol": 0,
                                                                                                       "children": [
                                                                                                         {
                                                                                                           "kind": ":",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0,
                                                                                                           "children": [
                                                                                                             {
                                                                                                               "kind": "atom",
-                                                                                                              "text": "orderId",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "orderId"
                                                                                                             },
                                                                                                             {
                                                                                                               "kind": "number",
-                                                                                                              "text": "102",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0
+                                                                                                              "text": "102"
                                                                                                             }
                                                                                                           ]
                                                                                                         },
                                                                                                         {
                                                                                                           "kind": ",",
-                                                                                                          "start": 0,
-                                                                                                          "startCol": 0,
-                                                                                                          "end": 0,
-                                                                                                          "endCol": 0,
                                                                                                           "children": [
                                                                                                             {
                                                                                                               "kind": ":",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0,
                                                                                                               "children": [
                                                                                                                 {
                                                                                                                   "kind": "atom",
-                                                                                                                  "text": "orderCustomerId",
-                                                                                                                  "start": 0,
-                                                                                                                  "startCol": 0,
-                                                                                                                  "end": 0,
-                                                                                                                  "endCol": 0
+                                                                                                                  "text": "orderCustomerId"
                                                                                                                 },
                                                                                                                 {
                                                                                                                   "kind": "number",
-                                                                                                                  "text": "1",
-                                                                                                                  "start": 0,
-                                                                                                                  "startCol": 0,
-                                                                                                                  "end": 0,
-                                                                                                                  "endCol": 0
+                                                                                                                  "text": "1"
                                                                                                                 }
                                                                                                               ]
                                                                                                             },
                                                                                                             {
                                                                                                               "kind": ",",
-                                                                                                              "start": 0,
-                                                                                                              "startCol": 0,
-                                                                                                              "end": 0,
-                                                                                                              "endCol": 0,
                                                                                                               "children": [
                                                                                                                 {
                                                                                                                   "kind": ":",
-                                                                                                                  "start": 0,
-                                                                                                                  "startCol": 0,
-                                                                                                                  "end": 0,
-                                                                                                                  "endCol": 0,
                                                                                                                   "children": [
                                                                                                                     {
                                                                                                                       "kind": "atom",
-                                                                                                                      "text": "pairedCustomerName",
-                                                                                                                      "start": 0,
-                                                                                                                      "startCol": 0,
-                                                                                                                      "end": 0,
-                                                                                                                      "endCol": 0
+                                                                                                                      "text": "pairedCustomerName"
                                                                                                                     },
                                                                                                                     {
                                                                                                                       "kind": "atom",
-                                                                                                                      "text": "Charlie",
-                                                                                                                      "start": 0,
-                                                                                                                      "startCol": 0,
-                                                                                                                      "end": 0,
-                                                                                                                      "endCol": 0
+                                                                                                                      "text": "Charlie"
                                                                                                                     }
                                                                                                                   ]
                                                                                                                 },
                                                                                                                 {
                                                                                                                   "kind": ":",
-                                                                                                                  "start": 0,
-                                                                                                                  "startCol": 0,
-                                                                                                                  "end": 0,
-                                                                                                                  "endCol": 0,
                                                                                                                   "children": [
                                                                                                                     {
                                                                                                                       "kind": "atom",
-                                                                                                                      "text": "orderTotal",
-                                                                                                                      "start": 0,
-                                                                                                                      "startCol": 0,
-                                                                                                                      "end": 0,
-                                                                                                                      "endCol": 0
+                                                                                                                      "text": "orderTotal"
                                                                                                                     },
                                                                                                                     {
                                                                                                                       "kind": "number",
-                                                                                                                      "text": "300",
-                                                                                                                      "start": 0,
-                                                                                                                      "startCol": 0,
-                                                                                                                      "end": 0,
-                                                                                                                      "endCol": 0
+                                                                                                                      "text": "300"
                                                                                                                     }
                                                                                                                   ]
                                                                                                                 }
@@ -3578,18 +1878,10 @@
                                                                                             },
                                                                                             {
                                                                                               "kind": "writeln",
-                                                                                              "start": 0,
-                                                                                              "startCol": 0,
-                                                                                              "end": 0,
-                                                                                              "endCol": 0,
                                                                                               "children": [
                                                                                                 {
                                                                                                   "kind": "atom",
-                                                                                                  "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie",
-                                                                                                  "start": 0,
-                                                                                                  "startCol": 0,
-                                                                                                  "end": 0,
-                                                                                                  "endCol": 0
+                                                                                                  "text": "Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie"
                                                                                                 }
                                                                                               ]
                                                                                             }


### PR DESCRIPTION
## Summary
- make json-ast for Prolog omit position information by default
- keep only nodes with values and add optional position fields
- regenerate `cross_join.prolog.json`

## Testing
- `go test -tags=slow ./tools/json-ast/x/prolog -run TestInspect_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_6889d683c4ac83209417f7df4176727d