### PR TITLE
Refactor Scheme JSON AST

### DIFF
--- a/tests/json-ast/x/scheme/cross_join.scheme.json
+++ b/tests/json-ast/x/scheme/cross_join.scheme.json
@@ -2,106 +2,54 @@
   "forms": [
     {
       "kind": "comment",
-      "text": ";; Generated on 2025-07-25 08:58 +0700",
-      "start": 1,
-      "startCol": 0,
-      "end": 1,
-      "endCol": 38
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
     },
     {
       "kind": "list",
-      "start": 2,
-      "startCol": 0,
-      "end": 2,
-      "endCol": 66,
       "children": [
         {
           "kind": "symbol",
-          "text": "import",
-          "start": 2,
-          "startCol": 1,
-          "end": 2,
-          "endCol": 7
+          "text": "import"
         },
         {
           "kind": "list",
-          "start": 2,
-          "startCol": 8,
-          "end": 2,
-          "endCol": 65,
           "children": [
             {
               "kind": "symbol",
-              "text": "only",
-              "start": 2,
-              "startCol": 9,
-              "end": 2,
-              "endCol": 13
+              "text": "only"
             },
             {
               "kind": "list",
-              "start": 2,
-              "startCol": 14,
-              "end": 2,
-              "endCol": 27,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "scheme",
-                  "start": 2,
-                  "startCol": 15,
-                  "end": 2,
-                  "endCol": 21
+                  "text": "scheme"
                 },
                 {
                   "kind": "symbol",
-                  "text": "base",
-                  "start": 2,
-                  "startCol": 22,
-                  "end": 2,
-                  "endCol": 26
+                  "text": "base"
                 }
               ]
             },
             {
               "kind": "symbol",
-              "text": "call/cc",
-              "start": 2,
-              "startCol": 28,
-              "end": 2,
-              "endCol": 35
+              "text": "call/cc"
             },
             {
               "kind": "symbol",
-              "text": "when",
-              "start": 2,
-              "startCol": 36,
-              "end": 2,
-              "endCol": 40
+              "text": "when"
             },
             {
               "kind": "symbol",
-              "text": "list-ref",
-              "start": 2,
-              "startCol": 41,
-              "end": 2,
-              "endCol": 49
+              "text": "list-ref"
             },
             {
               "kind": "symbol",
-              "text": "list-set!",
-              "start": 2,
-              "startCol": 50,
-              "end": 2,
-              "endCol": 59
+              "text": "list-set!"
             },
             {
               "kind": "symbol",
-              "text": "list",
-              "start": 2,
-              "startCol": 60,
-              "end": 2,
-              "endCol": 64
+              "text": "list"
             }
           ]
         }
@@ -109,41 +57,21 @@
     },
     {
       "kind": "list",
-      "start": 3,
-      "startCol": 0,
-      "end": 3,
-      "endCol": 22,
       "children": [
         {
           "kind": "symbol",
-          "text": "import",
-          "start": 3,
-          "startCol": 1,
-          "end": 3,
-          "endCol": 7
+          "text": "import"
         },
         {
           "kind": "list",
-          "start": 3,
-          "startCol": 8,
-          "end": 3,
-          "endCol": 21,
           "children": [
             {
               "kind": "symbol",
-              "text": "scheme",
-              "start": 3,
-              "startCol": 9,
-              "end": 3,
-              "endCol": 15
+              "text": "scheme"
             },
             {
               "kind": "symbol",
-              "text": "time",
-              "start": 3,
-              "startCol": 16,
-              "end": 3,
-              "endCol": 20
+              "text": "time"
             }
           ]
         }
@@ -151,41 +79,21 @@
     },
     {
       "kind": "list",
-      "start": 4,
-      "startCol": 0,
-      "end": 4,
-      "endCol": 23,
       "children": [
         {
           "kind": "symbol",
-          "text": "import",
-          "start": 4,
-          "startCol": 1,
-          "end": 4,
-          "endCol": 7
+          "text": "import"
         },
         {
           "kind": "list",
-          "start": 4,
-          "startCol": 8,
-          "end": 4,
-          "endCol": 22,
           "children": [
             {
               "kind": "symbol",
-              "text": "chibi",
-              "start": 4,
-              "startCol": 9,
-              "end": 4,
-              "endCol": 14
+              "text": "chibi"
             },
             {
               "kind": "symbol",
-              "text": "string",
-              "start": 4,
-              "startCol": 15,
-              "end": 4,
-              "endCol": 21
+              "text": "string"
             }
           ]
         }
@@ -193,74 +101,38 @@
     },
     {
       "kind": "list",
-      "start": 5,
-      "startCol": 0,
-      "end": 5,
-      "endCol": 59,
       "children": [
         {
           "kind": "symbol",
-          "text": "import",
-          "start": 5,
-          "startCol": 1,
-          "end": 5,
-          "endCol": 7
+          "text": "import"
         },
         {
           "kind": "list",
-          "start": 5,
-          "startCol": 8,
-          "end": 5,
-          "endCol": 58,
           "children": [
             {
               "kind": "symbol",
-              "text": "only",
-              "start": 5,
-              "startCol": 9,
-              "end": 5,
-              "endCol": 13
+              "text": "only"
             },
             {
               "kind": "list",
-              "start": 5,
-              "startCol": 14,
-              "end": 5,
-              "endCol": 27,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "scheme",
-                  "start": 5,
-                  "startCol": 15,
-                  "end": 5,
-                  "endCol": 21
+                  "text": "scheme"
                 },
                 {
                   "kind": "symbol",
-                  "text": "char",
-                  "start": 5,
-                  "startCol": 22,
-                  "end": 5,
-                  "endCol": 26
+                  "text": "char"
                 }
               ]
             },
             {
               "kind": "symbol",
-              "text": "string-upcase",
-              "start": 5,
-              "startCol": 28,
-              "end": 5,
-              "endCol": 41
+              "text": "string-upcase"
             },
             {
               "kind": "symbol",
-              "text": "string-downcase",
-              "start": 5,
-              "startCol": 42,
-              "end": 5,
-              "endCol": 57
+              "text": "string-downcase"
             }
           ]
         }
@@ -268,41 +140,21 @@
     },
     {
       "kind": "list",
-      "start": 6,
-      "startCol": 0,
-      "end": 6,
-      "endCol": 18,
       "children": [
         {
           "kind": "symbol",
-          "text": "import",
-          "start": 6,
-          "startCol": 1,
-          "end": 6,
-          "endCol": 7
+          "text": "import"
         },
         {
           "kind": "list",
-          "start": 6,
-          "startCol": 8,
-          "end": 6,
-          "endCol": 17,
           "children": [
             {
               "kind": "symbol",
-              "text": "srfi",
-              "start": 6,
-              "startCol": 9,
-              "end": 6,
-              "endCol": 13
+              "text": "srfi"
             },
             {
               "kind": "number",
-              "text": "69",
-              "start": 6,
-              "startCol": 14,
-              "end": 6,
-              "endCol": 16
+              "text": "69"
             }
           ]
         }
@@ -310,179 +162,91 @@
     },
     {
       "kind": "list",
-      "start": 7,
-      "startCol": 0,
-      "end": 12,
-      "endCol": 35,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 7,
-          "startCol": 1,
-          "end": 7,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "list",
-          "start": 7,
-          "startCol": 8,
-          "end": 7,
-          "endCol": 18,
           "children": [
             {
               "kind": "symbol",
-              "text": "to-str",
-              "start": 7,
-              "startCol": 9,
-              "end": 7,
-              "endCol": 15
+              "text": "to-str"
             },
             {
               "kind": "symbol",
-              "text": "x",
-              "start": 7,
-              "startCol": 16,
-              "end": 7,
-              "endCol": 17
+              "text": "x"
             }
           ]
         },
         {
           "kind": "list",
-          "start": 8,
-          "startCol": 2,
-          "end": 12,
-          "endCol": 34,
           "children": [
             {
               "kind": "symbol",
-              "text": "cond",
-              "start": 8,
-              "startCol": 3,
-              "end": 8,
-              "endCol": 7
+              "text": "cond"
             },
             {
               "kind": "list",
-              "start": 8,
-              "startCol": 8,
-              "end": 9,
-              "endCol": 67,
               "children": [
                 {
                   "kind": "list",
-                  "start": 8,
-                  "startCol": 9,
-                  "end": 8,
-                  "endCol": 18,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "pair?",
-                      "start": 8,
-                      "startCol": 10,
-                      "end": 8,
-                      "endCol": 15
+                      "text": "pair?"
                     },
                     {
                       "kind": "symbol",
-                      "text": "x",
-                      "start": 8,
-                      "startCol": 16,
-                      "end": 8,
-                      "endCol": 17
+                      "text": "x"
                     }
                   ]
                 },
                 {
                   "kind": "list",
-                  "start": 9,
-                  "startCol": 9,
-                  "end": 9,
-                  "endCol": 66,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "string-append",
-                      "start": 9,
-                      "startCol": 10,
-                      "end": 9,
-                      "endCol": 23
+                      "text": "string-append"
                     },
                     {
                       "kind": "string",
-                      "text": "\"[\"",
-                      "start": 9,
-                      "startCol": 24,
-                      "end": 9,
-                      "endCol": 27
+                      "text": "\"[\""
                     },
                     {
                       "kind": "list",
-                      "start": 9,
-                      "startCol": 28,
-                      "end": 9,
-                      "endCol": 61,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "string-join",
-                          "start": 9,
-                          "startCol": 29,
-                          "end": 9,
-                          "endCol": 40
+                          "text": "string-join"
                         },
                         {
                           "kind": "list",
-                          "start": 9,
-                          "startCol": 41,
-                          "end": 9,
-                          "endCol": 55,
                           "children": [
                             {
                               "kind": "symbol",
-                              "text": "map",
-                              "start": 9,
-                              "startCol": 42,
-                              "end": 9,
-                              "endCol": 45
+                              "text": "map"
                             },
                             {
                               "kind": "symbol",
-                              "text": "to-str",
-                              "start": 9,
-                              "startCol": 46,
-                              "end": 9,
-                              "endCol": 52
+                              "text": "to-str"
                             },
                             {
                               "kind": "symbol",
-                              "text": "x",
-                              "start": 9,
-                              "startCol": 53,
-                              "end": 9,
-                              "endCol": 54
+                              "text": "x"
                             }
                           ]
                         },
                         {
                           "kind": "string",
-                          "text": "\", \"",
-                          "start": 9,
-                          "startCol": 56,
-                          "end": 9,
-                          "endCol": 60
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
                       "kind": "string",
-                      "text": "\"]\"",
-                      "start": 9,
-                      "startCol": 62,
-                      "end": 9,
-                      "endCol": 65
+                      "text": "\"]\""
                     }
                   ]
                 }
@@ -490,116 +254,60 @@
             },
             {
               "kind": "list",
-              "start": 10,
-              "startCol": 8,
-              "end": 10,
-              "endCol": 23,
               "children": [
                 {
                   "kind": "list",
-                  "start": 10,
-                  "startCol": 9,
-                  "end": 10,
-                  "endCol": 20,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "string?",
-                      "start": 10,
-                      "startCol": 10,
-                      "end": 10,
-                      "endCol": 17
+                      "text": "string?"
                     },
                     {
                       "kind": "symbol",
-                      "text": "x",
-                      "start": 10,
-                      "startCol": 18,
-                      "end": 10,
-                      "endCol": 19
+                      "text": "x"
                     }
                   ]
                 },
                 {
                   "kind": "symbol",
-                  "text": "x",
-                  "start": 10,
-                  "startCol": 21,
-                  "end": 10,
-                  "endCol": 22
+                  "text": "x"
                 }
               ]
             },
             {
               "kind": "list",
-              "start": 11,
-              "startCol": 8,
-              "end": 11,
-              "endCol": 37,
               "children": [
                 {
                   "kind": "list",
-                  "start": 11,
-                  "startCol": 9,
-                  "end": 11,
-                  "endCol": 21,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "boolean?",
-                      "start": 11,
-                      "startCol": 10,
-                      "end": 11,
-                      "endCol": 18
+                      "text": "boolean?"
                     },
                     {
                       "kind": "symbol",
-                      "text": "x",
-                      "start": 11,
-                      "startCol": 19,
-                      "end": 11,
-                      "endCol": 20
+                      "text": "x"
                     }
                   ]
                 },
                 {
                   "kind": "list",
-                  "start": 11,
-                  "startCol": 22,
-                  "end": 11,
-                  "endCol": 36,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "if",
-                      "start": 11,
-                      "startCol": 23,
-                      "end": 11,
-                      "endCol": 25
+                      "text": "if"
                     },
                     {
                       "kind": "symbol",
-                      "text": "x",
-                      "start": 11,
-                      "startCol": 26,
-                      "end": 11,
-                      "endCol": 27
+                      "text": "x"
                     },
                     {
                       "kind": "string",
-                      "text": "\"1\"",
-                      "start": 11,
-                      "startCol": 28,
-                      "end": 11,
-                      "endCol": 31
+                      "text": "\"1\""
                     },
                     {
                       "kind": "string",
-                      "text": "\"0\"",
-                      "start": 11,
-                      "startCol": 32,
-                      "end": 11,
-                      "endCol": 35
+                      "text": "\"0\""
                     }
                   ]
                 }
@@ -607,41 +315,21 @@
             },
             {
               "kind": "list",
-              "start": 12,
-              "startCol": 8,
-              "end": 12,
-              "endCol": 33,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "else",
-                  "start": 12,
-                  "startCol": 9,
-                  "end": 12,
-                  "endCol": 13
+                  "text": "else"
                 },
                 {
                   "kind": "list",
-                  "start": 12,
-                  "startCol": 14,
-                  "end": 12,
-                  "endCol": 32,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "number-\u003estring",
-                      "start": 12,
-                      "startCol": 15,
-                      "end": 12,
-                      "endCol": 29
+                      "text": "number-\u003estring"
                     },
                     {
                       "kind": "symbol",
-                      "text": "x",
-                      "start": 12,
-                      "startCol": 30,
-                      "end": 12,
-                      "endCol": 31
+                      "text": "x"
                     }
                   ]
                 }
@@ -653,66 +341,34 @@
     },
     {
       "kind": "list",
-      "start": 13,
-      "startCol": 0,
-      "end": 13,
-      "endCol": 36,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 13,
-          "startCol": 1,
-          "end": 13,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "list",
-          "start": 13,
-          "startCol": 8,
-          "end": 13,
-          "endCol": 17,
           "children": [
             {
               "kind": "symbol",
-              "text": "upper",
-              "start": 13,
-              "startCol": 9,
-              "end": 13,
-              "endCol": 14
+              "text": "upper"
             },
             {
               "kind": "symbol",
-              "text": "s",
-              "start": 13,
-              "startCol": 15,
-              "end": 13,
-              "endCol": 16
+              "text": "s"
             }
           ]
         },
         {
           "kind": "list",
-          "start": 13,
-          "startCol": 18,
-          "end": 13,
-          "endCol": 35,
           "children": [
             {
               "kind": "symbol",
-              "text": "string-upcase",
-              "start": 13,
-              "startCol": 19,
-              "end": 13,
-              "endCol": 32
+              "text": "string-upcase"
             },
             {
               "kind": "symbol",
-              "text": "s",
-              "start": 13,
-              "startCol": 33,
-              "end": 13,
-              "endCol": 34
+              "text": "s"
             }
           ]
         }
@@ -720,66 +376,34 @@
     },
     {
       "kind": "list",
-      "start": 14,
-      "startCol": 0,
-      "end": 14,
-      "endCol": 38,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 14,
-          "startCol": 1,
-          "end": 14,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "list",
-          "start": 14,
-          "startCol": 8,
-          "end": 14,
-          "endCol": 17,
           "children": [
             {
               "kind": "symbol",
-              "text": "lower",
-              "start": 14,
-              "startCol": 9,
-              "end": 14,
-              "endCol": 14
+              "text": "lower"
             },
             {
               "kind": "symbol",
-              "text": "s",
-              "start": 14,
-              "startCol": 15,
-              "end": 14,
-              "endCol": 16
+              "text": "s"
             }
           ]
         },
         {
           "kind": "list",
-          "start": 14,
-          "startCol": 18,
-          "end": 14,
-          "endCol": 37,
           "children": [
             {
               "kind": "symbol",
-              "text": "string-downcase",
-              "start": 14,
-              "startCol": 19,
-              "end": 14,
-              "endCol": 34
+              "text": "string-downcase"
             },
             {
               "kind": "symbol",
-              "text": "s",
-              "start": 14,
-              "startCol": 35,
-              "end": 14,
-              "endCol": 36
+              "text": "s"
             }
           ]
         }
@@ -787,135 +411,67 @@
     },
     {
       "kind": "list",
-      "start": 15,
-      "startCol": 0,
-      "end": 15,
-      "endCol": 47,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 15,
-          "startCol": 1,
-          "end": 15,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "list",
-          "start": 15,
-          "startCol": 8,
-          "end": 15,
-          "endCol": 18,
           "children": [
             {
               "kind": "symbol",
-              "text": "fmod",
-              "start": 15,
-              "startCol": 9,
-              "end": 15,
-              "endCol": 13
+              "text": "fmod"
             },
             {
               "kind": "symbol",
-              "text": "a",
-              "start": 15,
-              "startCol": 14,
-              "end": 15,
-              "endCol": 15
+              "text": "a"
             },
             {
               "kind": "symbol",
-              "text": "b",
-              "start": 15,
-              "startCol": 16,
-              "end": 15,
-              "endCol": 17
+              "text": "b"
             }
           ]
         },
         {
           "kind": "list",
-          "start": 15,
-          "startCol": 19,
-          "end": 15,
-          "endCol": 46,
           "children": [
             {
               "kind": "symbol",
-              "text": "-",
-              "start": 15,
-              "startCol": 20,
-              "end": 15,
-              "endCol": 21
+              "text": "-"
             },
             {
               "kind": "symbol",
-              "text": "a",
-              "start": 15,
-              "startCol": 22,
-              "end": 15,
-              "endCol": 23
+              "text": "a"
             },
             {
               "kind": "list",
-              "start": 15,
-              "startCol": 24,
-              "end": 15,
-              "endCol": 45,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "*",
-                  "start": 15,
-                  "startCol": 25,
-                  "end": 15,
-                  "endCol": 26
+                  "text": "*"
                 },
                 {
                   "kind": "list",
-                  "start": 15,
-                  "startCol": 27,
-                  "end": 15,
-                  "endCol": 42,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "floor",
-                      "start": 15,
-                      "startCol": 28,
-                      "end": 15,
-                      "endCol": 33
+                      "text": "floor"
                     },
                     {
                       "kind": "list",
-                      "start": 15,
-                      "startCol": 34,
-                      "end": 15,
-                      "endCol": 41,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "/",
-                          "start": 15,
-                          "startCol": 35,
-                          "end": 15,
-                          "endCol": 36
+                          "text": "/"
                         },
                         {
                           "kind": "symbol",
-                          "text": "a",
-                          "start": 15,
-                          "startCol": 37,
-                          "end": 15,
-                          "endCol": 38
+                          "text": "a"
                         },
                         {
                           "kind": "symbol",
-                          "text": "b",
-                          "start": 15,
-                          "startCol": 39,
-                          "end": 15,
-                          "endCol": 40
+                          "text": "b"
                         }
                       ]
                     }
@@ -923,11 +479,7 @@
                 },
                 {
                   "kind": "symbol",
-                  "text": "b",
-                  "start": 15,
-                  "startCol": 43,
-                  "end": 15,
-                  "endCol": 44
+                  "text": "b"
                 }
               ]
             }
@@ -937,135 +489,67 @@
     },
     {
       "kind": "list",
-      "start": 16,
-      "startCol": 0,
-      "end": 29,
-      "endCol": 1,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 16,
-          "startCol": 1,
-          "end": 16,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "symbol",
-          "text": "customers",
-          "start": 16,
-          "startCol": 8,
-          "end": 16,
-          "endCol": 17
+          "text": "customers"
         },
         {
           "kind": "list",
-          "start": 16,
-          "startCol": 18,
-          "end": 28,
-          "endCol": 1,
           "children": [
             {
               "kind": "symbol",
-              "text": "list",
-              "start": 16,
-              "startCol": 19,
-              "end": 16,
-              "endCol": 23
+              "text": "list"
             },
             {
               "kind": "list",
-              "start": 16,
-              "startCol": 24,
-              "end": 19,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 16,
-                  "startCol": 25,
-                  "end": 16,
-                  "endCol": 42
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 16,
-                  "startCol": 43,
-                  "end": 18,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 16,
-                      "startCol": 44,
-                      "end": 16,
-                      "endCol": 48
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 16,
-                      "startCol": 49,
-                      "end": 16,
-                      "endCol": 62,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 16,
-                          "startCol": 50,
-                          "end": 16,
-                          "endCol": 54
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 16,
-                          "startCol": 55,
-                          "end": 16,
-                          "endCol": 59
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "1",
-                          "start": 16,
-                          "startCol": 60,
-                          "end": 16,
-                          "endCol": 61
+                          "text": "1"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 17,
-                      "startCol": 1,
-                      "end": 17,
-                      "endCol": 22,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 17,
-                          "startCol": 2,
-                          "end": 17,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"name\"",
-                          "start": 17,
-                          "startCol": 7,
-                          "end": 17,
-                          "endCol": 13
+                          "text": "\"name\""
                         },
                         {
                           "kind": "string",
-                          "text": "\"Alice\"",
-                          "start": 17,
-                          "startCol": 14,
-                          "end": 17,
-                          "endCol": 21
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -1075,97 +559,49 @@
             },
             {
               "kind": "list",
-              "start": 20,
-              "startCol": 1,
-              "end": 23,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 20,
-                  "startCol": 2,
-                  "end": 20,
-                  "endCol": 19
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 20,
-                  "startCol": 20,
-                  "end": 22,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 20,
-                      "startCol": 21,
-                      "end": 20,
-                      "endCol": 25
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 20,
-                      "startCol": 26,
-                      "end": 20,
-                      "endCol": 39,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 20,
-                          "startCol": 27,
-                          "end": 20,
-                          "endCol": 31
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 20,
-                          "startCol": 32,
-                          "end": 20,
-                          "endCol": 36
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "2",
-                          "start": 20,
-                          "startCol": 37,
-                          "end": 20,
-                          "endCol": 38
+                          "text": "2"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 21,
-                      "startCol": 1,
-                      "end": 21,
-                      "endCol": 20,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 21,
-                          "startCol": 2,
-                          "end": 21,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"name\"",
-                          "start": 21,
-                          "startCol": 7,
-                          "end": 21,
-                          "endCol": 13
+                          "text": "\"name\""
                         },
                         {
                           "kind": "string",
-                          "text": "\"Bob\"",
-                          "start": 21,
-                          "startCol": 14,
-                          "end": 21,
-                          "endCol": 19
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -1175,97 +611,49 @@
             },
             {
               "kind": "list",
-              "start": 24,
-              "startCol": 1,
-              "end": 27,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 24,
-                  "startCol": 2,
-                  "end": 24,
-                  "endCol": 19
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 24,
-                  "startCol": 20,
-                  "end": 26,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 24,
-                      "startCol": 21,
-                      "end": 24,
-                      "endCol": 25
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 24,
-                      "startCol": 26,
-                      "end": 24,
-                      "endCol": 39,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 24,
-                          "startCol": 27,
-                          "end": 24,
-                          "endCol": 31
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 24,
-                          "startCol": 32,
-                          "end": 24,
-                          "endCol": 36
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "3",
-                          "start": 24,
-                          "startCol": 37,
-                          "end": 24,
-                          "endCol": 38
+                          "text": "3"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 25,
-                      "startCol": 1,
-                      "end": 25,
-                      "endCol": 24,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 25,
-                          "startCol": 2,
-                          "end": 25,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"name\"",
-                          "start": 25,
-                          "startCol": 7,
-                          "end": 25,
-                          "endCol": 13
+                          "text": "\"name\""
                         },
                         {
                           "kind": "string",
-                          "text": "\"Charlie\"",
-                          "start": 25,
-                          "startCol": 14,
-                          "end": 25,
-                          "endCol": 23
+                          "text": "\"Charlie\""
                         }
                       ]
                     }
@@ -1279,168 +667,84 @@
     },
     {
       "kind": "list",
-      "start": 30,
-      "startCol": 0,
-      "end": 46,
-      "endCol": 1,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 30,
-          "startCol": 1,
-          "end": 30,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "symbol",
-          "text": "orders",
-          "start": 30,
-          "startCol": 8,
-          "end": 30,
-          "endCol": 14
+          "text": "orders"
         },
         {
           "kind": "list",
-          "start": 30,
-          "startCol": 15,
-          "end": 45,
-          "endCol": 1,
           "children": [
             {
               "kind": "symbol",
-              "text": "list",
-              "start": 30,
-              "startCol": 16,
-              "end": 30,
-              "endCol": 20
+              "text": "list"
             },
             {
               "kind": "list",
-              "start": 30,
-              "startCol": 21,
-              "end": 34,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 30,
-                  "startCol": 22,
-                  "end": 30,
-                  "endCol": 39
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 30,
-                  "startCol": 40,
-                  "end": 33,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 30,
-                      "startCol": 41,
-                      "end": 30,
-                      "endCol": 45
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 30,
-                      "startCol": 46,
-                      "end": 30,
-                      "endCol": 61,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 30,
-                          "startCol": 47,
-                          "end": 30,
-                          "endCol": 51
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 30,
-                          "startCol": 52,
-                          "end": 30,
-                          "endCol": 56
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "100",
-                          "start": 30,
-                          "startCol": 57,
-                          "end": 30,
-                          "endCol": 60
+                          "text": "100"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 31,
-                      "startCol": 1,
-                      "end": 31,
-                      "endCol": 22,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 31,
-                          "startCol": 2,
-                          "end": 31,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"customerId\"",
-                          "start": 31,
-                          "startCol": 7,
-                          "end": 31,
-                          "endCol": 19
+                          "text": "\"customerId\""
                         },
                         {
                           "kind": "number",
-                          "text": "1",
-                          "start": 31,
-                          "startCol": 20,
-                          "end": 31,
-                          "endCol": 21
+                          "text": "1"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 32,
-                      "startCol": 1,
-                      "end": 32,
-                      "endCol": 19,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 32,
-                          "startCol": 2,
-                          "end": 32,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"total\"",
-                          "start": 32,
-                          "startCol": 7,
-                          "end": 32,
-                          "endCol": 14
+                          "text": "\"total\""
                         },
                         {
                           "kind": "number",
-                          "text": "250",
-                          "start": 32,
-                          "startCol": 15,
-                          "end": 32,
-                          "endCol": 18
+                          "text": "250"
                         }
                       ]
                     }
@@ -1450,130 +754,66 @@
             },
             {
               "kind": "list",
-              "start": 35,
-              "startCol": 1,
-              "end": 39,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 35,
-                  "startCol": 2,
-                  "end": 35,
-                  "endCol": 19
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 35,
-                  "startCol": 20,
-                  "end": 38,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 35,
-                      "startCol": 21,
-                      "end": 35,
-                      "endCol": 25
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 35,
-                      "startCol": 26,
-                      "end": 35,
-                      "endCol": 41,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 35,
-                          "startCol": 27,
-                          "end": 35,
-                          "endCol": 31
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 35,
-                          "startCol": 32,
-                          "end": 35,
-                          "endCol": 36
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "101",
-                          "start": 35,
-                          "startCol": 37,
-                          "end": 35,
-                          "endCol": 40
+                          "text": "101"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 36,
-                      "startCol": 1,
-                      "end": 36,
-                      "endCol": 22,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 36,
-                          "startCol": 2,
-                          "end": 36,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"customerId\"",
-                          "start": 36,
-                          "startCol": 7,
-                          "end": 36,
-                          "endCol": 19
+                          "text": "\"customerId\""
                         },
                         {
                           "kind": "number",
-                          "text": "2",
-                          "start": 36,
-                          "startCol": 20,
-                          "end": 36,
-                          "endCol": 21
+                          "text": "2"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 37,
-                      "startCol": 1,
-                      "end": 37,
-                      "endCol": 19,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 37,
-                          "startCol": 2,
-                          "end": 37,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"total\"",
-                          "start": 37,
-                          "startCol": 7,
-                          "end": 37,
-                          "endCol": 14
+                          "text": "\"total\""
                         },
                         {
                           "kind": "number",
-                          "text": "125",
-                          "start": 37,
-                          "startCol": 15,
-                          "end": 37,
-                          "endCol": 18
+                          "text": "125"
                         }
                       ]
                     }
@@ -1583,130 +823,66 @@
             },
             {
               "kind": "list",
-              "start": 40,
-              "startCol": 1,
-              "end": 44,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "alist-\u003ehash-table",
-                  "start": 40,
-                  "startCol": 2,
-                  "end": 40,
-                  "endCol": 19
+                  "text": "alist-\u003ehash-table"
                 },
                 {
                   "kind": "list",
-                  "start": 40,
-                  "startCol": 20,
-                  "end": 43,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "list",
-                      "start": 40,
-                      "startCol": 21,
-                      "end": 40,
-                      "endCol": 25
+                      "text": "list"
                     },
                     {
                       "kind": "list",
-                      "start": 40,
-                      "startCol": 26,
-                      "end": 40,
-                      "endCol": 41,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 40,
-                          "startCol": 27,
-                          "end": 40,
-                          "endCol": 31
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"id\"",
-                          "start": 40,
-                          "startCol": 32,
-                          "end": 40,
-                          "endCol": 36
+                          "text": "\"id\""
                         },
                         {
                           "kind": "number",
-                          "text": "102",
-                          "start": 40,
-                          "startCol": 37,
-                          "end": 40,
-                          "endCol": 40
+                          "text": "102"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 41,
-                      "startCol": 1,
-                      "end": 41,
-                      "endCol": 22,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 41,
-                          "startCol": 2,
-                          "end": 41,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"customerId\"",
-                          "start": 41,
-                          "startCol": 7,
-                          "end": 41,
-                          "endCol": 19
+                          "text": "\"customerId\""
                         },
                         {
                           "kind": "number",
-                          "text": "1",
-                          "start": 41,
-                          "startCol": 20,
-                          "end": 41,
-                          "endCol": 21
+                          "text": "1"
                         }
                       ]
                     },
                     {
                       "kind": "list",
-                      "start": 42,
-                      "startCol": 1,
-                      "end": 42,
-                      "endCol": 19,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "cons",
-                          "start": 42,
-                          "startCol": 2,
-                          "end": 42,
-                          "endCol": 6
+                          "text": "cons"
                         },
                         {
                           "kind": "string",
-                          "text": "\"total\"",
-                          "start": 42,
-                          "startCol": 7,
-                          "end": 42,
-                          "endCol": 14
+                          "text": "\"total\""
                         },
                         {
                           "kind": "number",
-                          "text": "300",
-                          "start": 42,
-                          "startCol": 15,
-                          "end": 42,
-                          "endCol": 18
+                          "text": "300"
                         }
                       ]
                     }
@@ -1720,78 +896,38 @@
     },
     {
       "kind": "list",
-      "start": 47,
-      "startCol": 0,
-      "end": 71,
-      "endCol": 1,
       "children": [
         {
           "kind": "symbol",
-          "text": "define",
-          "start": 47,
-          "startCol": 1,
-          "end": 47,
-          "endCol": 7
+          "text": "define"
         },
         {
           "kind": "symbol",
-          "text": "result",
-          "start": 47,
-          "startCol": 8,
-          "end": 47,
-          "endCol": 14
+          "text": "result"
         },
         {
           "kind": "list",
-          "start": 47,
-          "startCol": 15,
-          "end": 70,
-          "endCol": 1,
           "children": [
             {
               "kind": "symbol",
-              "text": "let",
-              "start": 47,
-              "startCol": 16,
-              "end": 47,
-              "endCol": 19
+              "text": "let"
             },
             {
               "kind": "list",
-              "start": 47,
-              "startCol": 20,
-              "end": 49,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "list",
-                  "start": 47,
-                  "startCol": 21,
-                  "end": 48,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "res14",
-                      "start": 47,
-                      "startCol": 22,
-                      "end": 47,
-                      "endCol": 27
+                      "text": "res14"
                     },
                     {
                       "kind": "list",
-                      "start": 47,
-                      "startCol": 28,
-                      "end": 47,
-                      "endCol": 34,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "list",
-                          "start": 47,
-                          "startCol": 29,
-                          "end": 47,
-                          "endCol": 33
+                          "text": "list"
                         }
                       ]
                     }
@@ -1801,257 +937,125 @@
             },
             {
               "kind": "list",
-              "start": 50,
-              "startCol": 1,
-              "end": 69,
-              "endCol": 7,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "begin",
-                  "start": 50,
-                  "startCol": 2,
-                  "end": 50,
-                  "endCol": 7
+                  "text": "begin"
                 },
                 {
                   "kind": "list",
-                  "start": 50,
-                  "startCol": 8,
-                  "end": 68,
-                  "endCol": 8,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "for-each",
-                      "start": 50,
-                      "startCol": 9,
-                      "end": 50,
-                      "endCol": 17
+                      "text": "for-each"
                     },
                     {
                       "kind": "list",
-                      "start": 50,
-                      "startCol": 18,
-                      "end": 67,
-                      "endCol": 1,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "lambda",
-                          "start": 50,
-                          "startCol": 19,
-                          "end": 50,
-                          "endCol": 25
+                          "text": "lambda"
                         },
                         {
                           "kind": "list",
-                          "start": 50,
-                          "startCol": 26,
-                          "end": 50,
-                          "endCol": 29,
                           "children": [
                             {
                               "kind": "symbol",
-                              "text": "o",
-                              "start": 50,
-                              "startCol": 27,
-                              "end": 50,
-                              "endCol": 28
+                              "text": "o"
                             }
                           ]
                         },
                         {
                           "kind": "list",
-                          "start": 51,
-                          "startCol": 1,
-                          "end": 66,
-                          "endCol": 11,
                           "children": [
                             {
                               "kind": "symbol",
-                              "text": "for-each",
-                              "start": 51,
-                              "startCol": 2,
-                              "end": 51,
-                              "endCol": 10
+                              "text": "for-each"
                             },
                             {
                               "kind": "list",
-                              "start": 51,
-                              "startCol": 11,
-                              "end": 65,
-                              "endCol": 1,
                               "children": [
                                 {
                                   "kind": "symbol",
-                                  "text": "lambda",
-                                  "start": 51,
-                                  "startCol": 12,
-                                  "end": 51,
-                                  "endCol": 18
+                                  "text": "lambda"
                                 },
                                 {
                                   "kind": "list",
-                                  "start": 51,
-                                  "startCol": 19,
-                                  "end": 51,
-                                  "endCol": 22,
                                   "children": [
                                     {
                                       "kind": "symbol",
-                                      "text": "c",
-                                      "start": 51,
-                                      "startCol": 20,
-                                      "end": 51,
-                                      "endCol": 21
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": "list",
-                                  "start": 52,
-                                  "startCol": 1,
-                                  "end": 64,
-                                  "endCol": 1,
                                   "children": [
                                     {
                                       "kind": "symbol",
-                                      "text": "set!",
-                                      "start": 52,
-                                      "startCol": 2,
-                                      "end": 52,
-                                      "endCol": 6
+                                      "text": "set!"
                                     },
                                     {
                                       "kind": "symbol",
-                                      "text": "res14",
-                                      "start": 52,
-                                      "startCol": 7,
-                                      "end": 52,
-                                      "endCol": 12
+                                      "text": "res14"
                                     },
                                     {
                                       "kind": "list",
-                                      "start": 52,
-                                      "startCol": 13,
-                                      "end": 63,
-                                      "endCol": 1,
                                       "children": [
                                         {
                                           "kind": "symbol",
-                                          "text": "append",
-                                          "start": 52,
-                                          "startCol": 14,
-                                          "end": 52,
-                                          "endCol": 20
+                                          "text": "append"
                                         },
                                         {
                                           "kind": "symbol",
-                                          "text": "res14",
-                                          "start": 52,
-                                          "startCol": 21,
-                                          "end": 52,
-                                          "endCol": 26
+                                          "text": "res14"
                                         },
                                         {
                                           "kind": "list",
-                                          "start": 52,
-                                          "startCol": 27,
-                                          "end": 62,
-                                          "endCol": 1,
                                           "children": [
                                             {
                                               "kind": "symbol",
-                                              "text": "list",
-                                              "start": 52,
-                                              "startCol": 28,
-                                              "end": 52,
-                                              "endCol": 32
+                                              "text": "list"
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 52,
-                                              "startCol": 33,
-                                              "end": 61,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "alist-\u003ehash-table",
-                                                  "start": 52,
-                                                  "startCol": 34,
-                                                  "end": 52,
-                                                  "endCol": 51
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 52,
-                                                  "startCol": 52,
-                                                  "end": 60,
-                                                  "endCol": 1,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "list",
-                                                      "start": 52,
-                                                      "startCol": 53,
-                                                      "end": 52,
-                                                      "endCol": 57
+                                                      "text": "list"
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 52,
-                                                      "startCol": 58,
-                                                      "end": 53,
-                                                      "endCol": 1,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "cons",
-                                                          "start": 52,
-                                                          "startCol": 59,
-                                                          "end": 52,
-                                                          "endCol": 63
+                                                          "text": "cons"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderId\"",
-                                                          "start": 52,
-                                                          "startCol": 64,
-                                                          "end": 52,
-                                                          "endCol": 73
+                                                          "text": "\"orderId\""
                                                         },
                                                         {
                                                           "kind": "list",
-                                                          "start": 52,
-                                                          "startCol": 74,
-                                                          "end": 52,
-                                                          "endCol": 97,
                                                           "children": [
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "hash-table-ref",
-                                                              "start": 52,
-                                                              "startCol": 75,
-                                                              "end": 52,
-                                                              "endCol": 89
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "o",
-                                                              "start": 52,
-                                                              "startCol": 90,
-                                                              "end": 52,
-                                                              "endCol": 91
+                                                              "text": "o"
                                                             },
                                                             {
                                                               "kind": "string",
-                                                              "text": "\"id\"",
-                                                              "start": 52,
-                                                              "startCol": 92,
-                                                              "end": 52,
-                                                              "endCol": 96
+                                                              "text": "\"id\""
                                                             }
                                                           ]
                                                         }
@@ -2059,57 +1063,29 @@
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 54,
-                                                      "startCol": 1,
-                                                      "end": 55,
-                                                      "endCol": 1,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "cons",
-                                                          "start": 54,
-                                                          "startCol": 2,
-                                                          "end": 54,
-                                                          "endCol": 6
+                                                          "text": "cons"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderCustomerId\"",
-                                                          "start": 54,
-                                                          "startCol": 7,
-                                                          "end": 54,
-                                                          "endCol": 24
+                                                          "text": "\"orderCustomerId\""
                                                         },
                                                         {
                                                           "kind": "list",
-                                                          "start": 54,
-                                                          "startCol": 25,
-                                                          "end": 54,
-                                                          "endCol": 56,
                                                           "children": [
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "hash-table-ref",
-                                                              "start": 54,
-                                                              "startCol": 26,
-                                                              "end": 54,
-                                                              "endCol": 40
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "o",
-                                                              "start": 54,
-                                                              "startCol": 41,
-                                                              "end": 54,
-                                                              "endCol": 42
+                                                              "text": "o"
                                                             },
                                                             {
                                                               "kind": "string",
-                                                              "text": "\"customerId\"",
-                                                              "start": 54,
-                                                              "startCol": 43,
-                                                              "end": 54,
-                                                              "endCol": 55
+                                                              "text": "\"customerId\""
                                                             }
                                                           ]
                                                         }
@@ -2117,57 +1093,29 @@
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 56,
-                                                      "startCol": 1,
-                                                      "end": 57,
-                                                      "endCol": 1,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "cons",
-                                                          "start": 56,
-                                                          "startCol": 2,
-                                                          "end": 56,
-                                                          "endCol": 6
+                                                          "text": "cons"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"pairedCustomerName\"",
-                                                          "start": 56,
-                                                          "startCol": 7,
-                                                          "end": 56,
-                                                          "endCol": 27
+                                                          "text": "\"pairedCustomerName\""
                                                         },
                                                         {
                                                           "kind": "list",
-                                                          "start": 56,
-                                                          "startCol": 28,
-                                                          "end": 56,
-                                                          "endCol": 53,
                                                           "children": [
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "hash-table-ref",
-                                                              "start": 56,
-                                                              "startCol": 29,
-                                                              "end": 56,
-                                                              "endCol": 43
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "c",
-                                                              "start": 56,
-                                                              "startCol": 44,
-                                                              "end": 56,
-                                                              "endCol": 45
+                                                              "text": "c"
                                                             },
                                                             {
                                                               "kind": "string",
-                                                              "text": "\"name\"",
-                                                              "start": 56,
-                                                              "startCol": 46,
-                                                              "end": 56,
-                                                              "endCol": 52
+                                                              "text": "\"name\""
                                                             }
                                                           ]
                                                         }
@@ -2175,57 +1123,29 @@
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 58,
-                                                      "startCol": 1,
-                                                      "end": 59,
-                                                      "endCol": 1,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "cons",
-                                                          "start": 58,
-                                                          "startCol": 2,
-                                                          "end": 58,
-                                                          "endCol": 6
+                                                          "text": "cons"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderTotal\"",
-                                                          "start": 58,
-                                                          "startCol": 7,
-                                                          "end": 58,
-                                                          "endCol": 19
+                                                          "text": "\"orderTotal\""
                                                         },
                                                         {
                                                           "kind": "list",
-                                                          "start": 58,
-                                                          "startCol": 20,
-                                                          "end": 58,
-                                                          "endCol": 46,
                                                           "children": [
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "hash-table-ref",
-                                                              "start": 58,
-                                                              "startCol": 21,
-                                                              "end": 58,
-                                                              "endCol": 35
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
                                                               "kind": "symbol",
-                                                              "text": "o",
-                                                              "start": 58,
-                                                              "startCol": 36,
-                                                              "end": 58,
-                                                              "endCol": 37
+                                                              "text": "o"
                                                             },
                                                             {
                                                               "kind": "string",
-                                                              "text": "\"total\"",
-                                                              "start": 58,
-                                                              "startCol": 38,
-                                                              "end": 58,
-                                                              "endCol": 45
+                                                              "text": "\"total\""
                                                             }
                                                           ]
                                                         }
@@ -2245,11 +1165,7 @@
                             },
                             {
                               "kind": "symbol",
-                              "text": "customers",
-                              "start": 66,
-                              "startCol": 1,
-                              "end": 66,
-                              "endCol": 10
+                              "text": "customers"
                             }
                           ]
                         }
@@ -2257,21 +1173,13 @@
                     },
                     {
                       "kind": "symbol",
-                      "text": "orders",
-                      "start": 68,
-                      "startCol": 1,
-                      "end": 68,
-                      "endCol": 7
+                      "text": "orders"
                     }
                   ]
                 },
                 {
                   "kind": "symbol",
-                  "text": "res14",
-                  "start": 69,
-                  "startCol": 1,
-                  "end": 69,
-                  "endCol": 6
+                  "text": "res14"
                 }
               ]
             }
@@ -2281,41 +1189,21 @@
     },
     {
       "kind": "list",
-      "start": 72,
-      "startCol": 0,
-      "end": 73,
-      "endCol": 1,
       "children": [
         {
           "kind": "symbol",
-          "text": "display",
-          "start": 72,
-          "startCol": 1,
-          "end": 72,
-          "endCol": 8
+          "text": "display"
         },
         {
           "kind": "list",
-          "start": 72,
-          "startCol": 9,
-          "end": 72,
-          "endCol": 64,
           "children": [
             {
               "kind": "symbol",
-              "text": "to-str",
-              "start": 72,
-              "startCol": 10,
-              "end": 72,
-              "endCol": 16
+              "text": "to-str"
             },
             {
               "kind": "string",
-              "text": "\"--- Cross Join: All order-customer pairs ---\"",
-              "start": 72,
-              "startCol": 17,
-              "end": 72,
-              "endCol": 63
+              "text": "\"--- Cross Join: All order-customer pairs ---\""
             }
           ]
         }
@@ -2323,276 +1211,136 @@
     },
     {
       "kind": "list",
-      "start": 74,
-      "startCol": 0,
-      "end": 74,
-      "endCol": 9,
       "children": [
         {
           "kind": "symbol",
-          "text": "newline",
-          "start": 74,
-          "startCol": 1,
-          "end": 74,
-          "endCol": 8
+          "text": "newline"
         }
       ]
     },
     {
       "kind": "list",
-      "start": 75,
-      "startCol": 0,
-      "end": 123,
-      "endCol": 1,
       "children": [
         {
           "kind": "symbol",
-          "text": "call/cc",
-          "start": 75,
-          "startCol": 1,
-          "end": 75,
-          "endCol": 8
+          "text": "call/cc"
         },
         {
           "kind": "list",
-          "start": 75,
-          "startCol": 9,
-          "end": 122,
-          "endCol": 1,
           "children": [
             {
               "kind": "symbol",
-              "text": "lambda",
-              "start": 75,
-              "startCol": 10,
-              "end": 75,
-              "endCol": 16
+              "text": "lambda"
             },
             {
               "kind": "list",
-              "start": 75,
-              "startCol": 17,
-              "end": 75,
-              "endCol": 26,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "break16",
-                  "start": 75,
-                  "startCol": 18,
-                  "end": 75,
-                  "endCol": 25
+                  "text": "break16"
                 }
               ]
             },
             {
               "kind": "list",
-              "start": 76,
-              "startCol": 1,
-              "end": 121,
-              "endCol": 1,
               "children": [
                 {
                   "kind": "symbol",
-                  "text": "letrec",
-                  "start": 76,
-                  "startCol": 2,
-                  "end": 76,
-                  "endCol": 8
+                  "text": "letrec"
                 },
                 {
                   "kind": "list",
-                  "start": 76,
-                  "startCol": 9,
-                  "end": 119,
-                  "endCol": 1,
                   "children": [
                     {
                       "kind": "list",
-                      "start": 76,
-                      "startCol": 10,
-                      "end": 118,
-                      "endCol": 1,
                       "children": [
                         {
                           "kind": "symbol",
-                          "text": "loop15",
-                          "start": 76,
-                          "startCol": 11,
-                          "end": 76,
-                          "endCol": 17
+                          "text": "loop15"
                         },
                         {
                           "kind": "list",
-                          "start": 76,
-                          "startCol": 18,
-                          "end": 117,
-                          "endCol": 1,
                           "children": [
                             {
                               "kind": "symbol",
-                              "text": "lambda",
-                              "start": 76,
-                              "startCol": 19,
-                              "end": 76,
-                              "endCol": 25
+                              "text": "lambda"
                             },
                             {
                               "kind": "list",
-                              "start": 76,
-                              "startCol": 26,
-                              "end": 76,
-                              "endCol": 30,
                               "children": [
                                 {
                                   "kind": "symbol",
-                                  "text": "xs",
-                                  "start": 76,
-                                  "startCol": 27,
-                                  "end": 76,
-                                  "endCol": 29
+                                  "text": "xs"
                                 }
                               ]
                             },
                             {
                               "kind": "list",
-                              "start": 77,
-                              "startCol": 1,
-                              "end": 116,
-                              "endCol": 1,
                               "children": [
                                 {
                                   "kind": "symbol",
-                                  "text": "if",
-                                  "start": 77,
-                                  "startCol": 2,
-                                  "end": 77,
-                                  "endCol": 4
+                                  "text": "if"
                                 },
                                 {
                                   "kind": "list",
-                                  "start": 77,
-                                  "startCol": 5,
-                                  "end": 77,
-                                  "endCol": 15,
                                   "children": [
                                     {
                                       "kind": "symbol",
-                                      "text": "null?",
-                                      "start": 77,
-                                      "startCol": 6,
-                                      "end": 77,
-                                      "endCol": 11
+                                      "text": "null?"
                                     },
                                     {
                                       "kind": "symbol",
-                                      "text": "xs",
-                                      "start": 77,
-                                      "startCol": 12,
-                                      "end": 77,
-                                      "endCol": 14
+                                      "text": "xs"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": "list",
-                                  "start": 78,
-                                  "startCol": 1,
-                                  "end": 78,
-                                  "endCol": 12,
                                   "children": [
                                     {
                                       "kind": "symbol",
-                                      "text": "quote",
-                                      "start": 78,
-                                      "startCol": 2,
-                                      "end": 78,
-                                      "endCol": 7
+                                      "text": "quote"
                                     },
                                     {
                                       "kind": "symbol",
-                                      "text": "nil",
-                                      "start": 78,
-                                      "startCol": 8,
-                                      "end": 78,
-                                      "endCol": 11
+                                      "text": "nil"
                                     }
                                   ]
                                 },
                                 {
                                   "kind": "list",
-                                  "start": 79,
-                                  "startCol": 1,
-                                  "end": 115,
-                                  "endCol": 1,
                                   "children": [
                                     {
                                       "kind": "symbol",
-                                      "text": "begin",
-                                      "start": 79,
-                                      "startCol": 2,
-                                      "end": 79,
-                                      "endCol": 7
+                                      "text": "begin"
                                     },
                                     {
                                       "kind": "list",
-                                      "start": 79,
-                                      "startCol": 8,
-                                      "end": 112,
-                                      "endCol": 1,
                                       "children": [
                                         {
                                           "kind": "symbol",
-                                          "text": "let",
-                                          "start": 79,
-                                          "startCol": 9,
-                                          "end": 79,
-                                          "endCol": 12
+                                          "text": "let"
                                         },
                                         {
                                           "kind": "list",
-                                          "start": 79,
-                                          "startCol": 13,
-                                          "end": 81,
-                                          "endCol": 1,
                                           "children": [
                                             {
                                               "kind": "list",
-                                              "start": 79,
-                                              "startCol": 14,
-                                              "end": 80,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "entry",
-                                                  "start": 79,
-                                                  "startCol": 15,
-                                                  "end": 79,
-                                                  "endCol": 20
+                                                  "text": "entry"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 79,
-                                                  "startCol": 21,
-                                                  "end": 79,
-                                                  "endCol": 29,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "car",
-                                                      "start": 79,
-                                                      "startCol": 22,
-                                                      "end": 79,
-                                                      "endCol": 25
+                                                      "text": "car"
                                                     },
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "xs",
-                                                      "start": 79,
-                                                      "startCol": 26,
-                                                      "end": 79,
-                                                      "endCol": 28
+                                                      "text": "xs"
                                                     }
                                                   ]
                                                 }
@@ -2602,56 +1350,28 @@
                                         },
                                         {
                                           "kind": "list",
-                                          "start": 82,
-                                          "startCol": 1,
-                                          "end": 111,
-                                          "endCol": 1,
                                           "children": [
                                             {
                                               "kind": "symbol",
-                                              "text": "begin",
-                                              "start": 82,
-                                              "startCol": 2,
-                                              "end": 82,
-                                              "endCol": 7
+                                              "text": "begin"
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 82,
-                                              "startCol": 8,
-                                              "end": 83,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 82,
-                                                  "startCol": 9,
-                                                  "end": 82,
-                                                  "endCol": 16
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 82,
-                                                  "startCol": 17,
-                                                  "end": 82,
-                                                  "endCol": 33,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 82,
-                                                      "startCol": 18,
-                                                      "end": 82,
-                                                      "endCol": 24
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "string",
-                                                      "text": "\"Order\"",
-                                                      "start": 82,
-                                                      "startCol": 25,
-                                                      "end": 82,
-                                                      "endCol": 32
+                                                      "text": "\"Order\""
                                                     }
                                                   ]
                                                 }
@@ -2659,89 +1379,45 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 84,
-                                              "startCol": 1,
-                                              "end": 84,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 84,
-                                                  "startCol": 2,
-                                                  "end": 84,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 84,
-                                                  "startCol": 10,
-                                                  "end": 84,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 85,
-                                              "startCol": 1,
-                                              "end": 87,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 85,
-                                                  "startCol": 2,
-                                                  "end": 85,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 85,
-                                                  "startCol": 10,
-                                                  "end": 86,
-                                                  "endCol": 1,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 85,
-                                                      "startCol": 11,
-                                                      "end": 85,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 85,
-                                                      "startCol": 18,
-                                                      "end": 85,
-                                                      "endCol": 50,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "hash-table-ref",
-                                                          "start": 85,
-                                                          "startCol": 19,
-                                                          "end": 85,
-                                                          "endCol": 33
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "entry",
-                                                          "start": 85,
-                                                          "startCol": 34,
-                                                          "end": 85,
-                                                          "endCol": 39
+                                                          "text": "entry"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderId\"",
-                                                          "start": 85,
-                                                          "startCol": 40,
-                                                          "end": 85,
-                                                          "endCol": 49
+                                                          "text": "\"orderId\""
                                                         }
                                                       ]
                                                     }
@@ -2751,66 +1427,34 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 88,
-                                              "startCol": 1,
-                                              "end": 88,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 88,
-                                                  "startCol": 2,
-                                                  "end": 88,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 88,
-                                                  "startCol": 10,
-                                                  "end": 88,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 89,
-                                              "startCol": 1,
-                                              "end": 90,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 89,
-                                                  "startCol": 2,
-                                                  "end": 89,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 89,
-                                                  "startCol": 10,
-                                                  "end": 89,
-                                                  "endCol": 33,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 89,
-                                                      "startCol": 11,
-                                                      "end": 89,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "string",
-                                                      "text": "\"(customerId:\"",
-                                                      "start": 89,
-                                                      "startCol": 18,
-                                                      "end": 89,
-                                                      "endCol": 32
+                                                      "text": "\"(customerId:\""
                                                     }
                                                   ]
                                                 }
@@ -2818,89 +1462,45 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 91,
-                                              "startCol": 1,
-                                              "end": 91,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 91,
-                                                  "startCol": 2,
-                                                  "end": 91,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 91,
-                                                  "startCol": 10,
-                                                  "end": 91,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 92,
-                                              "startCol": 1,
-                                              "end": 94,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 92,
-                                                  "startCol": 2,
-                                                  "end": 92,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 92,
-                                                  "startCol": 10,
-                                                  "end": 93,
-                                                  "endCol": 1,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 92,
-                                                      "startCol": 11,
-                                                      "end": 92,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 92,
-                                                      "startCol": 18,
-                                                      "end": 92,
-                                                      "endCol": 58,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "hash-table-ref",
-                                                          "start": 92,
-                                                          "startCol": 19,
-                                                          "end": 92,
-                                                          "endCol": 33
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "entry",
-                                                          "start": 92,
-                                                          "startCol": 34,
-                                                          "end": 92,
-                                                          "endCol": 39
+                                                          "text": "entry"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderCustomerId\"",
-                                                          "start": 92,
-                                                          "startCol": 40,
-                                                          "end": 92,
-                                                          "endCol": 57
+                                                          "text": "\"orderCustomerId\""
                                                         }
                                                       ]
                                                     }
@@ -2910,66 +1510,34 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 95,
-                                              "startCol": 1,
-                                              "end": 95,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 95,
-                                                  "startCol": 2,
-                                                  "end": 95,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 95,
-                                                  "startCol": 10,
-                                                  "end": 95,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 96,
-                                              "startCol": 1,
-                                              "end": 97,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 96,
-                                                  "startCol": 2,
-                                                  "end": 96,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 96,
-                                                  "startCol": 10,
-                                                  "end": 96,
-                                                  "endCol": 31,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 96,
-                                                      "startCol": 11,
-                                                      "end": 96,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "string",
-                                                      "text": "\", total: $\"",
-                                                      "start": 96,
-                                                      "startCol": 18,
-                                                      "end": 96,
-                                                      "endCol": 30
+                                                      "text": "\", total: $\""
                                                     }
                                                   ]
                                                 }
@@ -2977,89 +1545,45 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 98,
-                                              "startCol": 1,
-                                              "end": 98,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 98,
-                                                  "startCol": 2,
-                                                  "end": 98,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 98,
-                                                  "startCol": 10,
-                                                  "end": 98,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 99,
-                                              "startCol": 1,
-                                              "end": 101,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 99,
-                                                  "startCol": 2,
-                                                  "end": 99,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 99,
-                                                  "startCol": 10,
-                                                  "end": 100,
-                                                  "endCol": 1,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 99,
-                                                      "startCol": 11,
-                                                      "end": 99,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 99,
-                                                      "startCol": 18,
-                                                      "end": 99,
-                                                      "endCol": 53,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "hash-table-ref",
-                                                          "start": 99,
-                                                          "startCol": 19,
-                                                          "end": 99,
-                                                          "endCol": 33
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "entry",
-                                                          "start": 99,
-                                                          "startCol": 34,
-                                                          "end": 99,
-                                                          "endCol": 39
+                                                          "text": "entry"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"orderTotal\"",
-                                                          "start": 99,
-                                                          "startCol": 40,
-                                                          "end": 99,
-                                                          "endCol": 52
+                                                          "text": "\"orderTotal\""
                                                         }
                                                       ]
                                                     }
@@ -3069,66 +1593,34 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 102,
-                                              "startCol": 1,
-                                              "end": 102,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 102,
-                                                  "startCol": 2,
-                                                  "end": 102,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 102,
-                                                  "startCol": 10,
-                                                  "end": 102,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 103,
-                                              "startCol": 1,
-                                              "end": 105,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 103,
-                                                  "startCol": 2,
-                                                  "end": 103,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 103,
-                                                  "startCol": 10,
-                                                  "end": 104,
-                                                  "endCol": 14,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 103,
-                                                      "startCol": 11,
-                                                      "end": 103,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "string",
-                                                      "text": "\")\n paired with\"",
-                                                      "start": 103,
-                                                      "startCol": 18,
-                                                      "end": 104,
-                                                      "endCol": 13
+                                                      "text": "\")\n paired with\""
                                                     }
                                                   ]
                                                 }
@@ -3136,89 +1628,45 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 106,
-                                              "startCol": 1,
-                                              "end": 106,
-                                              "endCol": 14,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 106,
-                                                  "startCol": 2,
-                                                  "end": 106,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "string",
-                                                  "text": "\" \"",
-                                                  "start": 106,
-                                                  "startCol": 10,
-                                                  "end": 106,
-                                                  "endCol": 13
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 107,
-                                              "startCol": 1,
-                                              "end": 109,
-                                              "endCol": 1,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "display",
-                                                  "start": 107,
-                                                  "startCol": 2,
-                                                  "end": 107,
-                                                  "endCol": 9
+                                                  "text": "display"
                                                 },
                                                 {
                                                   "kind": "list",
-                                                  "start": 107,
-                                                  "startCol": 10,
-                                                  "end": 108,
-                                                  "endCol": 1,
                                                   "children": [
                                                     {
                                                       "kind": "symbol",
-                                                      "text": "to-str",
-                                                      "start": 107,
-                                                      "startCol": 11,
-                                                      "end": 107,
-                                                      "endCol": 17
+                                                      "text": "to-str"
                                                     },
                                                     {
                                                       "kind": "list",
-                                                      "start": 107,
-                                                      "startCol": 18,
-                                                      "end": 107,
-                                                      "endCol": 61,
                                                       "children": [
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "hash-table-ref",
-                                                          "start": 107,
-                                                          "startCol": 19,
-                                                          "end": 107,
-                                                          "endCol": 33
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
                                                           "kind": "symbol",
-                                                          "text": "entry",
-                                                          "start": 107,
-                                                          "startCol": 34,
-                                                          "end": 107,
-                                                          "endCol": 39
+                                                          "text": "entry"
                                                         },
                                                         {
                                                           "kind": "string",
-                                                          "text": "\"pairedCustomerName\"",
-                                                          "start": 107,
-                                                          "startCol": 40,
-                                                          "end": 107,
-                                                          "endCol": 60
+                                                          "text": "\"pairedCustomerName\""
                                                         }
                                                       ]
                                                     }
@@ -3228,18 +1676,10 @@
                                             },
                                             {
                                               "kind": "list",
-                                              "start": 110,
-                                              "startCol": 1,
-                                              "end": 110,
-                                              "endCol": 10,
                                               "children": [
                                                 {
                                                   "kind": "symbol",
-                                                  "text": "newline",
-                                                  "start": 110,
-                                                  "startCol": 2,
-                                                  "end": 110,
-                                                  "endCol": 9
+                                                  "text": "newline"
                                                 }
                                               ]
                                             }
@@ -3249,41 +1689,21 @@
                                     },
                                     {
                                       "kind": "list",
-                                      "start": 113,
-                                      "startCol": 1,
-                                      "end": 114,
-                                      "endCol": 1,
                                       "children": [
                                         {
                                           "kind": "symbol",
-                                          "text": "loop15",
-                                          "start": 113,
-                                          "startCol": 2,
-                                          "end": 113,
-                                          "endCol": 8
+                                          "text": "loop15"
                                         },
                                         {
                                           "kind": "list",
-                                          "start": 113,
-                                          "startCol": 9,
-                                          "end": 113,
-                                          "endCol": 17,
                                           "children": [
                                             {
                                               "kind": "symbol",
-                                              "text": "cdr",
-                                              "start": 113,
-                                              "startCol": 10,
-                                              "end": 113,
-                                              "endCol": 13
+                                              "text": "cdr"
                                             },
                                             {
                                               "kind": "symbol",
-                                              "text": "xs",
-                                              "start": 113,
-                                              "startCol": 14,
-                                              "end": 113,
-                                              "endCol": 16
+                                              "text": "xs"
                                             }
                                           ]
                                         }
@@ -3301,26 +1721,14 @@
                 },
                 {
                   "kind": "list",
-                  "start": 120,
-                  "startCol": 1,
-                  "end": 120,
-                  "endCol": 16,
                   "children": [
                     {
                       "kind": "symbol",
-                      "text": "loop15",
-                      "start": 120,
-                      "startCol": 2,
-                      "end": 120,
-                      "endCol": 8
+                      "text": "loop15"
                     },
                     {
                       "kind": "symbol",
-                      "text": "result",
-                      "start": 120,
-                      "startCol": 9,
-                      "end": 120,
-                      "endCol": 15
+                      "text": "result"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- update Scheme json-ast Node to skip position fields unless enabled
- drop non-value leaves when converting
- regenerate cross_join.scheme.json without positions

## Testing
- `go test -tags slow -run 'TestInspect_Golden/cross_join$' -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6889d79f215c8320a845dd41dbeb7f33