### PR TITLE
Refine TS json-ast options

### DIFF
--- a/tools/json-ast/x/ts/ast.go
+++ b/tools/json-ast/x/ts/ast.go
@@ -4,6 +4,11 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
+// IncludePositions controls whether Start/End position fields are populated.
+// When false (the default) these fields remain zero and are omitted from the
+// marshalled JSON due to the `omitempty` tags on the struct fields.
+var IncludePositions bool
+
 // Node represents a node in the TypeScript AST. Only leaf nodes that carry
 // a value (identifiers, literals, etc.) populate the Text field to keep the
 // resulting JSON minimal.
@@ -24,7 +29,7 @@ type Program struct {
 
 // convertNode converts a tree-sitter node into our Node representation.
 // Non-value leaves are omitted to keep the JSON small.
-func convertNode(n *sitter.Node, src []byte, withPos bool) *Node {
+func convertNode(n *sitter.Node, src []byte) *Node {
 	if n == nil {
 		return nil
 	}
@@ -33,7 +38,7 @@ func convertNode(n *sitter.Node, src []byte, withPos bool) *Node {
 	node := Node{
 		Kind: n.Type(),
 	}
-	if withPos {
+	if IncludePositions {
 		node.Start = int(start.Row) + 1
 		node.StartCol = int(start.Column)
 		node.End = int(end.Row) + 1
@@ -50,7 +55,7 @@ func convertNode(n *sitter.Node, src []byte, withPos bool) *Node {
 
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		child := n.NamedChild(i)
-		if c := convertNode(child, src, withPos); c != nil {
+		if c := convertNode(child, src); c != nil {
 			node.Children = append(node.Children, *c)
 		}
 	}

--- a/tools/json-ast/x/ts/inspect.go
+++ b/tools/json-ast/x/ts/inspect.go
@@ -7,7 +7,7 @@ import (
 
 // Inspect parses the given TypeScript source code using tree-sitter and
 // returns its Program structure.
-func Inspect(src string, withPos bool) (*Program, error) {
+func Inspect(src string) (*Program, error) {
 	p := sitter.NewParser()
 	p.SetLanguage(tstypescript.GetLanguage())
 	tree := p.Parse(nil, []byte(src))
@@ -15,7 +15,7 @@ func Inspect(src string, withPos bool) (*Program, error) {
 	var stmts []Node
 	for i := 0; i < int(root.NamedChildCount()); i++ {
 		child := root.NamedChild(i)
-		if n := convertNode(child, []byte(src), withPos); n != nil {
+		if n := convertNode(child, []byte(src)); n != nil {
 			stmts = append(stmts, *n)
 		}
 	}

--- a/tools/json-ast/x/ts/inspect_test.go
+++ b/tools/json-ast/x/ts/inspect_test.go
@@ -47,7 +47,7 @@ func TestInspect_Golden(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read src: %v", err)
 		}
-		prog, err := ts.Inspect(string(data), false)
+		prog, err := ts.Inspect(string(data))
 		if err != nil {
 			t.Fatalf("inspect: %v", err)
 		}


### PR DESCRIPTION
## Summary
- add `IncludePositions` flag in TypeScript json-ast
- use the flag when converting tree-sitter nodes
- adjust `Inspect` API and tests

## Testing
- `go test ./tools/json-ast/x/ts -tags slow -run TestInspect_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_6889d89693548320b8115a5541c6266a