### PR TITLE
Update C++ JSON AST positions

### DIFF
--- a/tools/json-ast/x/cpp/ast.go
+++ b/tools/json-ast/x/cpp/ast.go
@@ -44,8 +44,8 @@ func convert(n *sitter.Node, src []byte, opts Options) *Node {
 	if opts.WithPositions {
 		start := n.StartPoint()
 		end := n.EndPoint()
-		node.Start = int(n.StartByte())
-		node.End = int(n.EndByte())
+		node.Start = int(start.Row) + 1
+		node.End = int(end.Row) + 1
 		node.StartCol = int(start.Column)
 		node.EndCol = int(end.Column)
 	}


### PR DESCRIPTION
## Summary
- normalize C++ JSON AST node positions to use line numbers

## Testing
- `go test ./tools/json-ast/x/cpp -tags slow -run TestInspect_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6889d925f46c8320801bb34510d66d8b