### PR TITLE
Extend Elixir JSON AST structs

### DIFF
--- a/tools/json-ast/x/elixir/ast.go
+++ b/tools/json-ast/x/elixir/ast.go
@@ -33,6 +33,17 @@ type (
 	Pair           struct{ Node }
 	String         struct{ Node }
 	Integer        struct{ Node }
+	Call           struct{ Node }
+	Arguments      struct{ Node }
+	Dot            struct{ Node }
+	DoBlock        struct{ Node }
+	AnonymousFn    struct{ Node }
+	StabClause     struct{ Node }
+	Body           struct{ Node }
+	MapContent     struct{ Node }
+	Keywords       struct{ Node }
+	Keyword        struct{ Node }
+	Interpolation  struct{ Node }
 )
 
 // Program represents the root syntax tree for an Elixir file.


### PR DESCRIPTION
## Summary
- expand the typed node structs in the Elixir JSON AST
- no functional changes to conversion logic

## Testing
- `go test ./tools/json-ast/x/elixir -tags slow -run TestInspect_Golden`


------
https://chatgpt.com/codex/tasks/task_e_6889d9d305e08320a8d10c8b13002396