### PR TITLE
Enhance Haskell AST types

### DIFF
--- a/tools/json-ast/x/haskell/ast.go
+++ b/tools/json-ast/x/haskell/ast.go
@@ -20,6 +20,54 @@ type Node struct {
 	Children []Node `json:"children,omitempty"`
 }
 
+// A set of concrete node types mirroring the kinds present in the JSON
+// representation.  They simply embed Node so the JSON layout stays the same
+// while providing a richer type structure in Go code.
+type (
+	Haskell           Node
+	Pragma            Node
+	Imports           Node
+	Import            Node
+	ImportList        Node
+	ImportName        Node
+	Module            Node
+	ModuleID          Node
+	Declarations      Node
+	DataType          Node
+	DataConstructors  Node
+	DataConstructor   Node
+	Deriving          Node
+	Signature         Node
+	Infix             Node
+	Bind              Node
+	Lambda            Node
+	Patterns          Node
+	Match             Node
+	Do                Node
+	Apply             Node
+	Generator         Node
+	Qualifiers        Node
+	Record            Node
+	Field             Node
+	FieldName         Node
+	FieldUpdate       Node
+	Fields            Node
+	Projection        Node
+	List              Node
+	ListComprehension Node
+	Parens            Node
+	Exp               Node
+	Literal           Node
+	Comment           Node
+	Constructor       Node
+	Integer           Node
+	Name              Node
+	Operator          Node
+	String            Node
+	Unit              Node
+	Variable          Node
+)
+
 // convert transforms a tree-sitter node into the Node structure defined above.
 // Only named children are traversed to keep the result compact.
 func convert(n *sitter.Node, src []byte, pos bool) *Node {

--- a/tools/json-ast/x/haskell/inspect.go
+++ b/tools/json-ast/x/haskell/inspect.go
@@ -9,7 +9,7 @@ import (
 
 // Program represents a parsed Haskell module.
 type Program struct {
-	Root *Node `json:"root"`
+	Root *Haskell `json:"root"`
 }
 
 // Inspect parses the provided Haskell source code using tree-sitter and
@@ -25,9 +25,9 @@ func Inspect(src string, includePos ...bool) (*Program, error) {
 	if len(includePos) > 0 && includePos[0] {
 		pos = true
 	}
-	root := convert(tree.RootNode(), []byte(src), pos)
-	if root == nil {
-		root = &Node{}
+	n := convert(tree.RootNode(), []byte(src), pos)
+	if n == nil {
+		n = &Node{}
 	}
-	return &Program{Root: root}, nil
+	return &Program{Root: (*Haskell)(n)}, nil
 }


### PR DESCRIPTION
## Summary
- expand Haskell AST with typed node aliases
- adapt `Program` to embed a typed `Haskell` node

## Testing
- `go vet ./tools/json-ast/x/haskell`
- `go test ./tools/json-ast/x/haskell -c`

------
https://chatgpt.com/codex/tasks/task_e_6889da6c05d883209201d0a16fb466a0