### PR TITLE
Refactor prolog json-ast nodes

### DIFF
--- a/tools/json-ast/x/prolog/inspect.go
+++ b/tools/json-ast/x/prolog/inspect.go
@@ -13,7 +13,7 @@ import (
 //go:embed pl_ast.pl
 var plScript string
 
-func Inspect(src string) (*Node, error) {
+func Inspect(src string) (*Program, error) {
 	exe := os.Getenv("SWIPL")
 	if exe == "" {
 		exe = "swipl"
@@ -46,10 +46,9 @@ func Inspect(src string) (*Node, error) {
 		return nil, err
 	}
 
-	var prog Program
+	var prog rawProgram
 	if err := json.Unmarshal(out.Bytes(), &prog); err != nil {
 		return nil, err
 	}
-	node := programToNode(&prog, []byte(src))
-	return &node, nil
+	return programToNode(&prog, []byte(src)), nil
 }


### PR DESCRIPTION
## Summary
- redesign prolog ast Node to hold `Text` and position fields
- add type aliases for common node kinds
- convert helper structs to unexported types
- update inspector to return `Program`

## Testing
- `go vet ./tools/json-ast/x/prolog/...`
- `go test ./tools/json-ast/x/prolog -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_6889db750fb88320b7d48ab01074611a