### PR TITLE
Refactor Scheme JSON AST and regenerate goldens

### DIFF
--- a/tests/json-ast/x/scheme/append_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/append_builtin.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,53 +393,70 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "a"
+          "kind": "symbol",
+          "text": "a"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "append"
+                  "kind": "symbol",
+                  "text": "append"
                 },
                 {
-                  "atom": "a"
+                  "kind": "symbol",
+                  "text": "a"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 }
@@ -357,9 +467,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/avg_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/avg_builtin.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,40 +393,54 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "let"
+                  "kind": "symbol",
+                  "text": "let"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "xs"
+                          "kind": "symbol",
+                          "text": "xs"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "list"
+                              "kind": "symbol",
+                              "text": "list"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             },
                             {
-                              "atom": "3"
+                              "kind": "number",
+                              "text": "3"
                             }
                           ]
                         }
@@ -342,35 +449,46 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "exact-\u003einexact"
+                      "kind": "symbol",
+                      "text": "exact-\u003einexact"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "apply"
+                              "kind": "symbol",
+                              "text": "apply"
                             },
                             {
-                              "atom": "+"
+                              "kind": "symbol",
+                              "text": "+"
                             },
                             {
-                              "atom": "xs"
+                              "kind": "symbol",
+                              "text": "xs"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "length"
+                              "kind": "symbol",
+                              "text": "length"
                             },
                             {
-                              "atom": "xs"
+                              "kind": "symbol",
+                              "text": "xs"
                             }
                           ]
                         }
@@ -385,9 +503,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/basic_compare.scheme.json
+++ b/tests/json-ast/x/scheme/basic_compare.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,108 +393,133 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "a"
+          "kind": "symbol",
+          "text": "a"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "-"
             },
             {
-              "atom": "10"
+              "kind": "number",
+              "text": "10"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "b"
+          "kind": "symbol",
+          "text": "b"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "equal?"
+                      "kind": "symbol",
+                      "text": "equal?"
                     },
                     {
-                      "atom": "a"
+                      "kind": "symbol",
+                      "text": "a"
                     },
                     {
-                      "atom": "7"
+                      "kind": "number",
+                      "text": "7"
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -410,45 +528,51 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "\u003c"
+                      "kind": "symbol",
+                      "text": "\u003c"
                     },
                     {
-                      "atom": "b"
+                      "kind": "symbol",
+                      "text": "b"
                     },
                     {
-                      "atom": "5"
+                      "kind": "number",
+                      "text": "5"
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -457,9 +581,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/bench_block.scheme.json
+++ b/tests/json-ast/x/scheme/bench_block.scheme.json
@@ -1,207 +1,271 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "atom": "when"
+              "kind": "symbol",
+              "text": "when"
             },
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "list-set!"
+              "kind": "symbol",
+              "text": "list-set!"
             },
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "scheme"
+              "kind": "symbol",
+              "text": "scheme"
             },
             {
-              "atom": "time"
+              "kind": "symbol",
+              "text": "time"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "time"
+              "kind": "symbol",
+              "text": "time"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "98"
+              "kind": "number",
+              "text": "98"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "_now_seeded"
-        },
-        {
-          "atom": "#f"
+          "kind": "symbol",
+          "text": "_now_seeded"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "_now_seed"
+          "kind": "symbol",
+          "text": "_now_seed"
         },
         {
-          "atom": "0"
+          "kind": "number",
+          "text": "0"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "now"
+              "kind": "symbol",
+              "text": "now"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "when"
+              "kind": "symbol",
+              "text": "when"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "not"
+                  "kind": "symbol",
+                  "text": "not"
                 },
                 {
-                  "atom": "_now_seeded"
+                  "kind": "symbol",
+                  "text": "_now_seeded"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "let"
+                  "kind": "symbol",
+                  "text": "let"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "get-environment-variable"
+                              "kind": "symbol",
+                              "text": "get-environment-variable"
                             },
                             {
-                              "atom": "MOCHI_NOW_SEED"
+                              "kind": "string",
+                              "text": "\"MOCHI_NOW_SEED\""
                             }
                           ]
                         }
@@ -210,60 +274,74 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "when"
+                      "kind": "symbol",
+                      "text": "when"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "and"
+                          "kind": "symbol",
+                          "text": "and"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-\u003enumber"
+                              "kind": "symbol",
+                              "text": "string-\u003enumber"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "set!"
+                          "kind": "symbol",
+                          "text": "set!"
                         },
                         {
-                          "atom": "_now_seed"
+                          "kind": "symbol",
+                          "text": "_now_seed"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-\u003enumber"
+                              "kind": "symbol",
+                              "text": "string-\u003enumber"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "set!"
+                          "kind": "symbol",
+                          "text": "set!"
                         },
                         {
-                          "atom": "_now_seeded"
-                        },
-                        {
-                          "atom": "#t"
+                          "kind": "symbol",
+                          "text": "_now_seeded"
                         }
                       ]
                     }
@@ -274,80 +352,104 @@
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "atom": "_now_seeded"
+              "kind": "symbol",
+              "text": "_now_seeded"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "set!"
+                      "kind": "symbol",
+                      "text": "set!"
                     },
                     {
-                      "atom": "_now_seed"
+                      "kind": "symbol",
+                      "text": "_now_seed"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "modulo"
+                          "kind": "symbol",
+                          "text": "modulo"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "+"
+                              "kind": "symbol",
+                              "text": "+"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "*"
+                                  "kind": "symbol",
+                                  "text": "*"
                                 },
                                 {
-                                  "atom": "_now_seed"
+                                  "kind": "symbol",
+                                  "text": "_now_seed"
                                 },
                                 {
-                                  "atom": "1664525"
+                                  "kind": "number",
+                                  "text": "1664525"
                                 }
                               ]
                             },
                             {
-                              "atom": "1013904223"
+                              "kind": "number",
+                              "text": "1013904223"
                             }
                           ]
                         },
                         {
-                          "atom": "2147483647"
+                          "kind": "number",
+                          "text": "2147483647"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "_now_seed"
+                  "kind": "symbol",
+                  "text": "_now_seed"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "current-seconds"
+                      "kind": "symbol",
+                      "text": "current-seconds"
                     }
                   ]
                 },
                 {
-                  "atom": "1000000000"
+                  "kind": "number",
+                  "text": "1000000000"
                 }
               ]
             }
@@ -356,151 +458,197 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "json"
+              "kind": "symbol",
+              "text": "json"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -511,112 +659,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -625,21 +807,28 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "let"
+          "kind": "symbol",
+          "text": "let"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "start6"
+                  "kind": "symbol",
+                  "text": "start6"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "now"
+                      "kind": "symbol",
+                      "text": "now"
                     }
                   ]
                 }
@@ -648,145 +837,195 @@
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "let"
+                  "kind": "symbol",
+                  "text": "let"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "n"
+                          "kind": "symbol",
+                          "text": "n"
                         },
                         {
-                          "atom": "1000"
+                          "kind": "number",
+                          "text": "1000"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "begin"
+                      "kind": "symbol",
+                      "text": "begin"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "let"
+                          "kind": "symbol",
+                          "text": "let"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "s"
+                                  "kind": "symbol",
+                                  "text": "s"
                                 },
                                 {
-                                  "atom": "0"
+                                  "kind": "number",
+                                  "text": "0"
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "begin"
+                              "kind": "symbol",
+                              "text": "begin"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "call/cc"
+                                  "kind": "symbol",
+                                  "text": "call/cc"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "lambda"
+                                      "kind": "symbol",
+                                      "text": "lambda"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "break5"
+                                          "kind": "symbol",
+                                          "text": "break5"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "letrec"
+                                          "kind": "symbol",
+                                          "text": "letrec"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "loop4"
+                                                  "kind": "symbol",
+                                                  "text": "loop4"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "lambda"
+                                                      "kind": "symbol",
+                                                      "text": "lambda"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "i"
+                                                          "kind": "symbol",
+                                                          "text": "i"
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "if"
+                                                          "kind": "symbol",
+                                                          "text": "if"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "\u003c"
+                                                              "kind": "symbol",
+                                                              "text": "\u003c"
                                                             },
                                                             {
-                                                              "atom": "i"
+                                                              "kind": "symbol",
+                                                              "text": "i"
                                                             },
                                                             {
-                                                              "atom": "n"
+                                                              "kind": "symbol",
+                                                              "text": "n"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "begin"
+                                                              "kind": "symbol",
+                                                              "text": "begin"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "begin"
+                                                                  "kind": "symbol",
+                                                                  "text": "begin"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "set!"
+                                                                      "kind": "symbol",
+                                                                      "text": "set!"
                                                                     },
                                                                     {
-                                                                      "atom": "s"
+                                                                      "kind": "symbol",
+                                                                      "text": "s"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "+"
+                                                                          "kind": "symbol",
+                                                                          "text": "+"
                                                                         },
                                                                         {
-                                                                          "atom": "s"
+                                                                          "kind": "symbol",
+                                                                          "text": "s"
                                                                         },
                                                                         {
-                                                                          "atom": "i"
+                                                                          "kind": "symbol",
+                                                                          "text": "i"
                                                                         }
                                                                       ]
                                                                     }
@@ -795,20 +1034,26 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "loop4"
+                                                                  "kind": "symbol",
+                                                                  "text": "loop4"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "+"
+                                                                      "kind": "symbol",
+                                                                      "text": "+"
                                                                     },
                                                                     {
-                                                                      "atom": "i"
+                                                                      "kind": "symbol",
+                                                                      "text": "i"
                                                                     },
                                                                     {
-                                                                      "atom": "1"
+                                                                      "kind": "number",
+                                                                      "text": "1"
                                                                     }
                                                                   ]
                                                                 }
@@ -817,12 +1062,15 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "quote"
+                                                              "kind": "symbol",
+                                                              "text": "quote"
                                                             },
                                                             {
-                                                              "atom": "nil"
+                                                              "kind": "symbol",
+                                                              "text": "nil"
                                                             }
                                                           ]
                                                         }
@@ -835,12 +1083,15 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "loop4"
+                                              "kind": "symbol",
+                                              "text": "loop4"
                                             },
                                             {
-                                              "atom": "1"
+                                              "kind": "number",
+                                              "text": "1"
                                             }
                                           ]
                                         }
@@ -859,21 +1110,28 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "let"
+                  "kind": "symbol",
+                  "text": "let"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "end7"
+                          "kind": "symbol",
+                          "text": "end7"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "now"
+                              "kind": "symbol",
+                              "text": "now"
                             }
                           ]
                         }
@@ -882,37 +1140,49 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "let"
+                      "kind": "symbol",
+                      "text": "let"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "dur8"
+                              "kind": "symbol",
+                              "text": "dur8"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "quotient"
+                                  "kind": "symbol",
+                                  "text": "quotient"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "-"
+                                      "kind": "symbol",
+                                      "text": "-"
                                     },
                                     {
-                                      "atom": "end7"
+                                      "kind": "symbol",
+                                      "text": "end7"
                                     },
                                     {
-                                      "atom": "start6"
+                                      "kind": "symbol",
+                                      "text": "start6"
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "1000"
+                                  "kind": "number",
+                                  "text": "1000"
                                 }
                               ]
                             }
@@ -921,44 +1191,49 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "string-append"
+                                  "kind": "symbol",
+                                  "text": "string-append"
                                 },
                                 {
-                                  "atom": "{\n  \"duration_us\": "
-                                },
-                                {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "number-\u003estring"
+                                      "kind": "symbol",
+                                      "text": "number-\u003estring"
                                     },
                                     {
-                                      "atom": "dur8"
+                                      "kind": "symbol",
+                                      "text": "dur8"
                                     }
                                   ]
-                                },
-                                {
-                                  "atom": ",\n  \"memory_bytes\": 0,\n  \"name\": \"simple\"\n}"
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "newline"
+                              "kind": "symbol",
+                              "text": "newline"
                             }
                           ]
                         }

--- a/tests/json-ast/x/scheme/binary_precedence.scheme.json
+++ b/tests/json-ast/x/scheme/binary_precedence.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,33 +393,44 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "*"
+                      "kind": "symbol",
+                      "text": "*"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 }
@@ -337,42 +441,55 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "+"
+                      "kind": "symbol",
+                      "text": "+"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 }
               ]
             }
@@ -381,42 +498,55 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "*"
+                      "kind": "symbol",
+                      "text": "*"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 }
               ]
             }
@@ -425,40 +555,53 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "+"
+                      "kind": "symbol",
+                      "text": "+"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 }
@@ -469,9 +612,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/bool_chain.scheme.json
+++ b/tests/json-ast/x/scheme/bool_chain.scheme.json
@@ -1,427 +1,313 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "atom": "when"
+              "kind": "symbol",
+              "text": "when"
             },
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "list-set!"
+              "kind": "symbol",
+              "text": "list-set!"
             },
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "scheme"
+              "kind": "symbol",
+              "text": "scheme"
             },
             {
-              "atom": "time"
+              "kind": "symbol",
+              "text": "time"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "else"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "number-\u003estring"
-                    },
-                    {
-                      "atom": "x"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "upper"
             },
             {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-upcase"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "fmod"
-            },
-            {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "-"
-            },
-            {
-              "atom": "a"
-            },
-            {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "list": [
-                        {
-                          "atom": "/"
-                        },
-                        {
-                          "atom": "a"
-                        },
-                        {
-                          "atom": "b"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "atom": "b"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "boom"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "call/cc"
-            },
-            {
-              "list": [
-                {
-                  "atom": "lambda"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "ret9"
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "begin"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "display"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "to-str"
-                            },
-                            {
-                              "atom": "boom"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "newline"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "ret9"
-                        },
-                        {
-                          "atom": "#t"
-                        }
-                      ]
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -432,78 +318,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "string-upcase"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "lower"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "string-downcase"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "and"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "and"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "list": [
-                            {
-                              "atom": "\u003c"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            }
-                          ]
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "list": [
-                            {
-                              "atom": "\u003c"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "\u003c"
-                        },
-                        {
-                          "atom": "3"
-                        },
-                        {
-                          "atom": "4"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -512,79 +466,92 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "boom"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "lambda"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "and"
+                      "kind": "symbol",
+                      "text": "ret9"
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "begin"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "and"
+                          "kind": "symbol",
+                          "text": "display"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "\u003c"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            }
-                          ]
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "\u003e"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
+                              "kind": "string",
+                              "text": "\"boom\""
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "boom"
+                          "kind": "symbol",
+                          "text": "newline"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "ret9"
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -593,99 +560,314 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "to-str"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "if"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "and"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "and"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "\u003c"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "\u003c"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "\u003c"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "3"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "and"
+                      "kind": "symbol",
+                      "text": "and"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "and"
+                          "kind": "symbol",
+                          "text": "and"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "and"
+                              "kind": "symbol",
+                              "text": "\u003c"
                             },
                             {
-                              "list": [
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "\u003e"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "boom"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "to-str"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "if"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "and"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "and"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "and"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "\u003c"
+                                  "kind": "symbol",
+                                  "text": "\u003c"
                                 },
                                 {
-                                  "atom": "1"
+                                  "kind": "number",
+                                  "text": "1"
                                 },
                                 {
-                                  "atom": "2"
+                                  "kind": "number",
+                                  "text": "2"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "\u003c"
+                                  "kind": "symbol",
+                                  "text": "\u003c"
                                 },
                                 {
-                                  "atom": "2"
+                                  "kind": "number",
+                                  "text": "2"
                                 },
                                 {
-                                  "atom": "3"
+                                  "kind": "number",
+                                  "text": "3"
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "\u003e"
+                              "kind": "symbol",
+                              "text": "\u003e"
                             },
                             {
-                              "atom": "3"
+                              "kind": "number",
+                              "text": "3"
                             },
                             {
-                              "atom": "4"
+                              "kind": "number",
+                              "text": "4"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "boom"
+                          "kind": "symbol",
+                          "text": "boom"
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -694,9 +876,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/break_continue.scheme.json
+++ b/tests/json-ast/x/scheme/break_continue.scheme.json
@@ -1,237 +1,313 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "atom": "when"
+              "kind": "symbol",
+              "text": "when"
             },
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "list-set!"
+              "kind": "symbol",
+              "text": "list-set!"
             },
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "scheme"
+              "kind": "symbol",
+              "text": "scheme"
             },
             {
-              "atom": "time"
+              "kind": "symbol",
+              "text": "time"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -242,112 +318,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -356,139 +466,186 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "numbers"
+          "kind": "symbol",
+          "text": "numbers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             },
             {
-              "atom": "4"
+              "kind": "number",
+              "text": "4"
             },
             {
-              "atom": "5"
+              "kind": "number",
+              "text": "5"
             },
             {
-              "atom": "6"
+              "kind": "number",
+              "text": "6"
             },
             {
-              "atom": "7"
+              "kind": "number",
+              "text": "7"
             },
             {
-              "atom": "8"
+              "kind": "number",
+              "text": "8"
             },
             {
-              "atom": "9"
+              "kind": "number",
+              "text": "9"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "call/cc"
+          "kind": "symbol",
+          "text": "call/cc"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "break11"
+                  "kind": "symbol",
+                  "text": "break11"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "letrec"
+                  "kind": "symbol",
+                  "text": "letrec"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "loop10"
+                          "kind": "symbol",
+                          "text": "loop10"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "lambda"
+                              "kind": "symbol",
+                              "text": "lambda"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "xs"
+                                  "kind": "symbol",
+                                  "text": "xs"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "if"
+                                  "kind": "symbol",
+                                  "text": "if"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "null?"
+                                      "kind": "symbol",
+                                      "text": "null?"
                                     },
                                     {
-                                      "atom": "xs"
+                                      "kind": "symbol",
+                                      "text": "xs"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "quote"
+                                      "kind": "symbol",
+                                      "text": "quote"
                                     },
                                     {
-                                      "atom": "nil"
+                                      "kind": "symbol",
+                                      "text": "nil"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "begin"
+                                      "kind": "symbol",
+                                      "text": "begin"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "let"
+                                          "kind": "symbol",
+                                          "text": "let"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "n"
+                                                  "kind": "symbol",
+                                                  "text": "n"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "car"
+                                                      "kind": "symbol",
+                                                      "text": "car"
                                                     },
                                                     {
-                                                      "atom": "xs"
+                                                      "kind": "symbol",
+                                                      "text": "xs"
                                                     }
                                                   ]
                                                 }
@@ -497,55 +654,73 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "begin"
+                                              "kind": "symbol",
+                                              "text": "begin"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "if"
+                                                  "kind": "symbol",
+                                                  "text": "if"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "equal?"
+                                                      "kind": "symbol",
+                                                      "text": "equal?"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "modulo"
+                                                          "kind": "symbol",
+                                                          "text": "modulo"
                                                         },
                                                         {
-                                                          "atom": "n"
+                                                          "kind": "symbol",
+                                                          "text": "n"
                                                         },
                                                         {
-                                                          "atom": "2"
+                                                          "kind": "number",
+                                                          "text": "2"
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "atom": "0"
+                                                      "kind": "number",
+                                                      "text": "0"
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "begin"
+                                                      "kind": "symbol",
+                                                      "text": "begin"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "loop10"
+                                                          "kind": "symbol",
+                                                          "text": "loop10"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cdr"
+                                                              "kind": "symbol",
+                                                              "text": "cdr"
                                                             },
                                                             {
-                                                              "atom": "xs"
+                                                              "kind": "symbol",
+                                                              "text": "xs"
                                                             }
                                                           ]
                                                         }
@@ -554,52 +729,68 @@
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quote"
+                                                      "kind": "symbol",
+                                                      "text": "quote"
                                                     },
                                                     {
-                                                      "atom": "nil"
+                                                      "kind": "symbol",
+                                                      "text": "nil"
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "if"
+                                                  "kind": "symbol",
+                                                  "text": "if"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "\u003e"
+                                                      "kind": "symbol",
+                                                      "text": "\u003e"
                                                     },
                                                     {
-                                                      "atom": "n"
+                                                      "kind": "symbol",
+                                                      "text": "n"
                                                     },
                                                     {
-                                                      "atom": "7"
+                                                      "kind": "number",
+                                                      "text": "7"
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "begin"
+                                                      "kind": "symbol",
+                                                      "text": "begin"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "break11"
+                                                          "kind": "symbol",
+                                                          "text": "break11"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "quote"
+                                                              "kind": "symbol",
+                                                              "text": "quote"
                                                             },
                                                             {
-                                                              "atom": "nil"
+                                                              "kind": "symbol",
+                                                              "text": "nil"
                                                             }
                                                           ]
                                                         }
@@ -608,65 +799,83 @@
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quote"
+                                                      "kind": "symbol",
+                                                      "text": "quote"
                                                     },
                                                     {
-                                                      "atom": "nil"
+                                                      "kind": "symbol",
+                                                      "text": "nil"
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "display"
+                                                  "kind": "symbol",
+                                                  "text": "display"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "to-str"
+                                                      "kind": "symbol",
+                                                      "text": "to-str"
                                                     },
                                                     {
-                                                      "atom": "odd number:"
+                                                      "kind": "string",
+                                                      "text": "\"odd number:\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "display"
+                                                  "kind": "symbol",
+                                                  "text": "display"
                                                 },
                                                 {
-                                                  "atom": " "
+                                                  "kind": "string",
+                                                  "text": "\" \""
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "display"
+                                                  "kind": "symbol",
+                                                  "text": "display"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "to-str"
+                                                      "kind": "symbol",
+                                                      "text": "to-str"
                                                     },
                                                     {
-                                                      "atom": "n"
+                                                      "kind": "symbol",
+                                                      "text": "n"
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "newline"
+                                                  "kind": "symbol",
+                                                  "text": "newline"
                                                 }
                                               ]
                                             }
@@ -675,17 +884,22 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "loop10"
+                                          "kind": "symbol",
+                                          "text": "loop10"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cdr"
+                                              "kind": "symbol",
+                                              "text": "cdr"
                                             },
                                             {
-                                              "atom": "xs"
+                                              "kind": "symbol",
+                                              "text": "xs"
                                             }
                                           ]
                                         }
@@ -702,12 +916,15 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "loop10"
+                      "kind": "symbol",
+                      "text": "loop10"
                     },
                     {
-                      "atom": "numbers"
+                      "kind": "symbol",
+                      "text": "numbers"
                     }
                   ]
                 }

--- a/tests/json-ast/x/scheme/cast_string_to_int.scheme.json
+++ b/tests/json-ast/x/scheme/cast_string_to_int.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,63 +393,84 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "let"
+                  "kind": "symbol",
+                  "text": "let"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "v12"
+                          "kind": "symbol",
+                          "text": "v12"
                         },
                         {
-                          "atom": "1995"
+                          "kind": "string",
+                          "text": "\"1995\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cond"
+                      "kind": "symbol",
+                      "text": "cond"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string?"
+                              "kind": "symbol",
+                              "text": "string?"
                             },
                             {
-                              "atom": "v12"
+                              "kind": "symbol",
+                              "text": "v12"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "inexact-\u003eexact"
+                              "kind": "symbol",
+                              "text": "inexact-\u003eexact"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "string-\u003enumber"
+                                  "kind": "symbol",
+                                  "text": "string-\u003enumber"
                                 },
                                 {
-                                  "atom": "v12"
+                                  "kind": "symbol",
+                                  "text": "v12"
                                 }
                               ]
                             }
@@ -365,47 +479,61 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "boolean?"
+                              "kind": "symbol",
+                              "text": "boolean?"
                             },
                             {
-                              "atom": "v12"
+                              "kind": "symbol",
+                              "text": "v12"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "if"
+                              "kind": "symbol",
+                              "text": "if"
                             },
                             {
-                              "atom": "v12"
+                              "kind": "symbol",
+                              "text": "v12"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             },
                             {
-                              "atom": "0"
+                              "kind": "number",
+                              "text": "0"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "else"
+                          "kind": "symbol",
+                          "text": "else"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "inexact-\u003eexact"
+                              "kind": "symbol",
+                              "text": "inexact-\u003eexact"
                             },
                             {
-                              "atom": "v12"
+                              "kind": "symbol",
+                              "text": "v12"
                             }
                           ]
                         }
@@ -420,9 +548,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/cast_struct.scheme.json
+++ b/tests/json-ast/x/scheme/cast_struct.scheme.json
@@ -1,198 +1,262 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -203,112 +267,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -317,33 +415,44 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "todo"
+          "kind": "symbol",
+          "text": "todo"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "title"
+                      "kind": "string",
+                      "text": "\"title\""
                     },
                     {
-                      "atom": "hi"
+                      "kind": "string",
+                      "text": "\"hi\""
                     }
                   ]
                 }
@@ -354,25 +463,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "hash-table-ref"
+                  "kind": "symbol",
+                  "text": "hash-table-ref"
                 },
                 {
-                  "atom": "todo"
+                  "kind": "symbol",
+                  "text": "todo"
                 },
                 {
-                  "atom": "title"
+                  "kind": "string",
+                  "text": "\"title\""
                 }
               ]
             }
@@ -381,9 +498,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/closure.scheme.json
+++ b/tests/json-ast/x/scheme/closure.scheme.json
@@ -1,237 +1,313 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "atom": "when"
+              "kind": "symbol",
+              "text": "when"
             },
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "list-set!"
+              "kind": "symbol",
+              "text": "list-set!"
             },
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "scheme"
+              "kind": "symbol",
+              "text": "scheme"
             },
             {
-              "atom": "time"
+              "kind": "symbol",
+              "text": "time"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -242,112 +318,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -356,64 +466,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "makeAdder"
+              "kind": "symbol",
+              "text": "makeAdder"
             },
             {
-              "atom": "n"
+              "kind": "symbol",
+              "text": "n"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "lambda"
+                  "kind": "symbol",
+                  "text": "lambda"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "ret13"
+                      "kind": "symbol",
+                      "text": "ret13"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "ret13"
+                      "kind": "symbol",
+                      "text": "ret13"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "+"
+                              "kind": "symbol",
+                              "text": "+"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             },
                             {
-                              "atom": "n"
+                              "kind": "symbol",
+                              "text": "n"
                             }
                           ]
                         }
@@ -428,42 +559,55 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "add10"
+          "kind": "symbol",
+          "text": "add10"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "makeAdder"
+              "kind": "symbol",
+              "text": "makeAdder"
             },
             {
-              "atom": "10"
+              "kind": "number",
+              "text": "10"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "add10"
+                  "kind": "symbol",
+                  "text": "add10"
                 },
                 {
-                  "atom": "7"
+                  "kind": "number",
+                  "text": "7"
                 }
               ]
             }
@@ -472,9 +616,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/count_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/count_builtin.scheme.json
@@ -1,446 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "else"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "number-\u003estring"
-                    },
-                    {
-                      "atom": "x"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "upper"
             },
             {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-upcase"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "fmod"
-            },
-            {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "-"
-            },
-            {
-              "atom": "a"
-            },
-            {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "list": [
-                        {
-                          "atom": "/"
-                        },
-                        {
-                          "atom": "a"
-                        },
-                        {
-                          "atom": "b"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "atom": "b"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "to-str"
-            },
-            {
-              "list": [
-                {
-                  "atom": "cond"
-                },
-                {
-                  "list": [
-                    {
-                      "list": [
-                        {
-                          "atom": "string?"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "list"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "string-length"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "list"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "list": [
-                        {
-                          "atom": "hash-table?"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "list"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "hash-table-size"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "list"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "else"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "length"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "list"
-                            },
-                            {
-                              "atom": "1"
-                            },
-                            {
-                              "atom": "2"
-                            },
-                            {
-                              "atom": "3"
-                            }
-                          ]
-                        }
-                      ]
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -451,9 +245,355 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "upper"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "string-upcase"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "lower"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "string-downcase"
+            },
+            {
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "*"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "floor"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "/"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "a"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "b"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "symbol",
+                  "text": "b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "to-str"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "cond"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "string?"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "list"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "string-length"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "list"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table?"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "list"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "hash-table-size"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "list"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "else"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "length"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "list"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "1"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "2"
+                            },
+                            {
+                              "kind": "number",
+                              "text": "3"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/cross_join_filter.scheme.json
+++ b/tests/json-ast/x/scheme/cross_join_filter.scheme.json
@@ -1,115 +1,155 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "letters"
+          "kind": "symbol",
+          "text": "letters"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "A"
+              "kind": "string",
+              "text": "\"A\""
             },
             {
-              "atom": "B"
+              "kind": "string",
+              "text": "\"B\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "pairs"
+          "kind": "symbol",
+          "text": "pairs"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res2"
+                      "kind": "symbol",
+                      "text": "res2"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -118,126 +158,169 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "n"
+                              "kind": "symbol",
+                              "text": "n"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "l"
+                                      "kind": "symbol",
+                                      "text": "l"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "modulo"
+                                              "kind": "symbol",
+                                              "text": "modulo"
                                             },
                                             {
-                                              "atom": "n"
+                                              "kind": "symbol",
+                                              "text": "n"
                                             },
                                             {
-                                              "atom": "2"
+                                              "kind": "number",
+                                              "text": "2"
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "0"
+                                          "kind": "number",
+                                          "text": "0"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "res2"
+                                          "kind": "symbol",
+                                          "text": "res2"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "append"
+                                              "kind": "symbol",
+                                              "text": "append"
                                             },
                                             {
-                                              "atom": "res2"
+                                              "kind": "symbol",
+                                              "text": "res2"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "alist-\u003ehash-table"
+                                                      "kind": "symbol",
+                                                      "text": "alist-\u003ehash-table"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "n"
+                                                              "kind": "string",
+                                                              "text": "\"n\""
                                                             },
                                                             {
-                                                              "atom": "n"
+                                                              "kind": "symbol",
+                                                              "text": "n"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "l"
+                                                              "kind": "string",
+                                                              "text": "\"l\""
                                                             },
                                                             {
-                                                              "atom": "l"
+                                                              "kind": "symbol",
+                                                              "text": "l"
                                                             }
                                                           ]
                                                         }
@@ -252,12 +335,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -266,19 +352,22 @@
                               ]
                             },
                             {
-                              "atom": "letters"
+                              "kind": "symbol",
+                              "text": "letters"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "nums"
+                      "kind": "symbol",
+                      "text": "nums"
                     }
                   ]
                 },
                 {
-                  "atom": "res2"
+                  "kind": "symbol",
+                  "text": "res2"
                 }
               ]
             }
@@ -287,98 +376,128 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Even pairs ---"
+          "kind": "string",
+          "text": "\"--- Even pairs ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "p"
+                  "kind": "symbol",
+                  "text": "p"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "p"
+                          "kind": "symbol",
+                          "text": "p"
                         },
                         {
-                          "atom": "n"
+                          "kind": "string",
+                          "text": "\"n\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "p"
+                          "kind": "symbol",
+                          "text": "p"
                         },
                         {
-                          "atom": "l"
+                          "kind": "string",
+                          "text": "\"l\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -387,7 +506,8 @@
           ]
         },
         {
-          "atom": "pairs"
+          "kind": "symbol",
+          "text": "pairs"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/cross_join_triple.scheme.json
+++ b/tests/json-ast/x/scheme/cross_join_triple.scheme.json
@@ -1,135 +1,181 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "letters"
+          "kind": "symbol",
+          "text": "letters"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "A"
+              "kind": "string",
+              "text": "\"A\""
             },
             {
-              "atom": "B"
+              "kind": "string",
+              "text": "\"B\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "bools"
+          "kind": "symbol",
+          "text": "bools"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "true"
+              "kind": "string",
+              "text": "\"true\""
             },
             {
-              "atom": "false"
+              "kind": "string",
+              "text": "\"false\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "combos"
+          "kind": "symbol",
+          "text": "combos"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res3"
+                      "kind": "symbol",
+                      "text": "res3"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -138,128 +184,172 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "n"
+                              "kind": "symbol",
+                              "text": "n"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "l"
+                                      "kind": "symbol",
+                                      "text": "l"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "b"
+                                              "kind": "symbol",
+                                              "text": "b"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "set!"
+                                              "kind": "symbol",
+                                              "text": "set!"
                                             },
                                             {
-                                              "atom": "res3"
+                                              "kind": "symbol",
+                                              "text": "res3"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "append"
+                                                  "kind": "symbol",
+                                                  "text": "append"
                                                 },
                                                 {
-                                                  "atom": "res3"
+                                                  "kind": "symbol",
+                                                  "text": "res3"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "alist-\u003ehash-table"
+                                                          "kind": "symbol",
+                                                          "text": "alist-\u003ehash-table"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "cons"
+                                                                  "kind": "symbol",
+                                                                  "text": "cons"
                                                                 },
                                                                 {
-                                                                  "atom": "n"
+                                                                  "kind": "string",
+                                                                  "text": "\"n\""
                                                                 },
                                                                 {
-                                                                  "atom": "n"
+                                                                  "kind": "symbol",
+                                                                  "text": "n"
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "cons"
+                                                                  "kind": "symbol",
+                                                                  "text": "cons"
                                                                 },
                                                                 {
-                                                                  "atom": "l"
+                                                                  "kind": "string",
+                                                                  "text": "\"l\""
                                                                 },
                                                                 {
-                                                                  "atom": "l"
+                                                                  "kind": "symbol",
+                                                                  "text": "l"
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "cons"
+                                                                  "kind": "symbol",
+                                                                  "text": "cons"
                                                                 },
                                                                 {
-                                                                  "atom": "b"
+                                                                  "kind": "string",
+                                                                  "text": "\"b\""
                                                                 },
                                                                 {
-                                                                  "atom": "b"
+                                                                  "kind": "symbol",
+                                                                  "text": "b"
                                                                 }
                                                               ]
                                                             }
@@ -276,26 +366,30 @@
                                       ]
                                     },
                                     {
-                                      "atom": "bools"
+                                      "kind": "symbol",
+                                      "text": "bools"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "atom": "letters"
+                              "kind": "symbol",
+                              "text": "letters"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "nums"
+                      "kind": "symbol",
+                      "text": "nums"
                     }
                   ]
                 },
                 {
-                  "atom": "res3"
+                  "kind": "symbol",
+                  "text": "res3"
                 }
               ]
             }
@@ -304,128 +398,167 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Cross Join of three lists ---"
+          "kind": "string",
+          "text": "\"--- Cross Join of three lists ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "c"
+                  "kind": "symbol",
+                  "text": "c"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "c"
+                          "kind": "symbol",
+                          "text": "c"
                         },
                         {
-                          "atom": "n"
+                          "kind": "string",
+                          "text": "\"n\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "c"
+                          "kind": "symbol",
+                          "text": "c"
                         },
                         {
-                          "atom": "l"
+                          "kind": "string",
+                          "text": "\"l\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "c"
+                          "kind": "symbol",
+                          "text": "c"
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -434,7 +567,8 @@
           ]
         },
         {
-          "atom": "combos"
+          "kind": "symbol",
+          "text": "combos"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/dataset_sort_take_limit.scheme.json
+++ b/tests/json-ast/x/scheme/dataset_sort_take_limit.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "products"
+          "kind": "symbol",
+          "text": "products"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Laptop"
+                          "kind": "string",
+                          "text": "\"Laptop\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "1500"
+                          "kind": "number",
+                          "text": "1500"
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Smartphone"
+                          "kind": "string",
+                          "text": "\"Smartphone\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "900"
+                          "kind": "number",
+                          "text": "900"
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Tablet"
+                          "kind": "string",
+                          "text": "\"Tablet\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "600"
+                          "kind": "number",
+                          "text": "600"
                         }
                       ]
                     }
@@ -171,38 +227,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Monitor"
+                          "kind": "string",
+                          "text": "\"Monitor\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "300"
+                          "kind": "number",
+                          "text": "300"
                         }
                       ]
                     }
@@ -211,38 +279,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Keyboard"
+                          "kind": "string",
+                          "text": "\"Keyboard\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "100"
+                          "kind": "number",
+                          "text": "100"
                         }
                       ]
                     }
@@ -251,38 +331,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Mouse"
+                          "kind": "string",
+                          "text": "\"Mouse\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "50"
+                          "kind": "number",
+                          "text": "50"
                         }
                       ]
                     }
@@ -291,38 +383,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Headphones"
+                          "kind": "string",
+                          "text": "\"Headphones\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         },
                         {
-                          "atom": "200"
+                          "kind": "number",
+                          "text": "200"
                         }
                       ]
                     }
@@ -335,29 +439,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "expensive"
+          "kind": "symbol",
+          "text": "expensive"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res4"
+                      "kind": "symbol",
+                      "text": "res4"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -366,50 +480,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "p"
+                              "kind": "symbol",
+                              "text": "p"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res4"
+                              "kind": "symbol",
+                              "text": "res4"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res4"
+                                  "kind": "symbol",
+                                  "text": "res4"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "atom": "p"
+                                      "kind": "symbol",
+                                      "text": "p"
                                     }
                                   ]
                                 }
@@ -420,12 +551,14 @@
                       ]
                     },
                     {
-                      "atom": "products"
+                      "kind": "symbol",
+                      "text": "products"
                     }
                   ]
                 },
                 {
-                  "atom": "res4"
+                  "kind": "symbol",
+                  "text": "res4"
                 }
               ]
             }
@@ -434,118 +567,154 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Top products (excluding most expensive)\n   ---"
+          "kind": "string",
+          "text": "\"--- Top products (excluding most expensive)\n   ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "item"
+                  "kind": "symbol",
+                  "text": "item"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "item"
+                          "kind": "symbol",
+                          "text": "item"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "costs $"
+                      "kind": "string",
+                      "text": "\"costs $\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "item"
+                          "kind": "symbol",
+                          "text": "item"
                         },
                         {
-                          "atom": "price"
+                          "kind": "string",
+                          "text": "\"price\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -554,7 +723,8 @@
           ]
         },
         {
-          "atom": "expensive"
+          "kind": "symbol",
+          "text": "expensive"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/dataset_where_filter.scheme.json
+++ b/tests/json-ast/x/scheme/dataset_where_filter.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "people"
+          "kind": "symbol",
+          "text": "people"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "30"
+                          "kind": "number",
+                          "text": "30"
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "15"
+                          "kind": "number",
+                          "text": "15"
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "65"
+                          "kind": "number",
+                          "text": "65"
                         }
                       ]
                     }
@@ -171,38 +227,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Diana"
+                          "kind": "string",
+                          "text": "\"Diana\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "45"
+                          "kind": "number",
+                          "text": "45"
                         }
                       ]
                     }
@@ -215,29 +283,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "adults"
+          "kind": "symbol",
+          "text": "adults"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res5"
+                      "kind": "symbol",
+                      "text": "res5"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -246,160 +324,213 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "person"
+                              "kind": "symbol",
+                              "text": "person"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "if"
+                              "kind": "symbol",
+                              "text": "if"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "\u003e="
+                                  "kind": "symbol",
+                                  "text": "\u003e="
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-ref"
+                                      "kind": "symbol",
+                                      "text": "hash-table-ref"
                                     },
                                     {
-                                      "atom": "person"
+                                      "kind": "symbol",
+                                      "text": "person"
                                     },
                                     {
-                                      "atom": "age"
+                                      "kind": "string",
+                                      "text": "\"age\""
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "18"
+                                  "kind": "number",
+                                  "text": "18"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "set!"
+                                  "kind": "symbol",
+                                  "text": "set!"
                                 },
                                 {
-                                  "atom": "res5"
+                                  "kind": "symbol",
+                                  "text": "res5"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "append"
+                                      "kind": "symbol",
+                                      "text": "append"
                                     },
                                     {
-                                      "atom": "res5"
+                                      "kind": "symbol",
+                                      "text": "res5"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "list"
+                                          "kind": "symbol",
+                                          "text": "list"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "alist-\u003ehash-table"
+                                              "kind": "symbol",
+                                              "text": "alist-\u003ehash-table"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "cons"
+                                                      "kind": "symbol",
+                                                      "text": "cons"
                                                     },
                                                     {
-                                                      "atom": "name"
+                                                      "kind": "string",
+                                                      "text": "\"name\""
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "person"
+                                                          "kind": "symbol",
+                                                          "text": "person"
                                                         },
                                                         {
-                                                          "atom": "name"
+                                                          "kind": "string",
+                                                          "text": "\"name\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "cons"
+                                                      "kind": "symbol",
+                                                      "text": "cons"
                                                     },
                                                     {
-                                                      "atom": "age"
+                                                      "kind": "string",
+                                                      "text": "\"age\""
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "person"
+                                                          "kind": "symbol",
+                                                          "text": "person"
                                                         },
                                                         {
-                                                          "atom": "age"
+                                                          "kind": "string",
+                                                          "text": "\"age\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "cons"
+                                                      "kind": "symbol",
+                                                      "text": "cons"
                                                     },
                                                     {
-                                                      "atom": "is_senior"
+                                                      "kind": "string",
+                                                      "text": "\"is_senior\""
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "\u003e="
+                                                          "kind": "symbol",
+                                                          "text": "\u003e="
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "hash-table-ref"
+                                                              "kind": "symbol",
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
-                                                              "atom": "person"
+                                                              "kind": "symbol",
+                                                              "text": "person"
                                                             },
                                                             {
-                                                              "atom": "age"
+                                                              "kind": "string",
+                                                              "text": "\"age\""
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "atom": "60"
+                                                          "kind": "number",
+                                                          "text": "60"
                                                         }
                                                       ]
                                                     }
@@ -416,12 +547,15 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "quote"
+                                  "kind": "symbol",
+                                  "text": "quote"
                                 },
                                 {
-                                  "atom": "nil"
+                                  "kind": "symbol",
+                                  "text": "nil"
                                 }
                               ]
                             }
@@ -430,12 +564,14 @@
                       ]
                     },
                     {
-                      "atom": "people"
+                      "kind": "symbol",
+                      "text": "people"
                     }
                   ]
                 },
                 {
-                  "atom": "res5"
+                  "kind": "symbol",
+                  "text": "res5"
                 }
               ]
             }
@@ -444,159 +580,210 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Adults ---"
+          "kind": "string",
+          "text": "\"--- Adults ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "person"
+                  "kind": "symbol",
+                  "text": "person"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "person"
+                          "kind": "symbol",
+                          "text": "person"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "is"
+                      "kind": "string",
+                      "text": "\"is\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "person"
+                          "kind": "symbol",
+                          "text": "person"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-ref"
+                              "kind": "symbol",
+                              "text": "hash-table-ref"
                             },
                             {
-                              "atom": "person"
+                              "kind": "symbol",
+                              "text": "person"
                             },
                             {
-                              "atom": "is_senior"
+                              "kind": "string",
+                              "text": "\"is_senior\""
                             }
                           ]
                         },
                         {
-                          "atom": " (senior)\n          "
+                          "kind": "string",
+                          "text": "\" (senior)\n          \""
                         },
-                        {}
+                        {
+                          "kind": "string",
+                          "text": "\"\""
+                        }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -605,7 +792,8 @@
           ]
         },
         {
-          "atom": "adults"
+          "kind": "symbol",
+          "text": "adults"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/exists_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/exists_builtin.scheme.json
@@ -1,99 +1,135 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "data"
+          "kind": "symbol",
+          "text": "data"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "flag"
+          "kind": "symbol",
+          "text": "flag"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "null?"
+                  "kind": "symbol",
+                  "text": "null?"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "let"
+                      "kind": "symbol",
+                      "text": "let"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "res6"
+                              "kind": "symbol",
+                              "text": "res6"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "list"
+                                  "kind": "symbol",
+                                  "text": "list"
                                 }
                               ]
                             }
@@ -102,68 +138,91 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "x"
+                                      "kind": "symbol",
+                                      "text": "x"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "atom": "x"
+                                          "kind": "symbol",
+                                          "text": "x"
                                         },
                                         {
-                                          "atom": "1"
+                                          "kind": "number",
+                                          "text": "1"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "res6"
+                                          "kind": "symbol",
+                                          "text": "res6"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "append"
+                                              "kind": "symbol",
+                                              "text": "append"
                                             },
                                             {
-                                              "atom": "res6"
+                                              "kind": "symbol",
+                                              "text": "res6"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "atom": "x"
+                                                  "kind": "symbol",
+                                                  "text": "x"
                                                 }
                                               ]
                                             }
@@ -172,12 +231,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -186,12 +248,14 @@
                               ]
                             },
                             {
-                              "atom": "data"
+                              "kind": "symbol",
+                              "text": "data"
                             }
                           ]
                         },
                         {
-                          "atom": "res6"
+                          "kind": "symbol",
+                          "text": "res6"
                         }
                       ]
                     }
@@ -200,42 +264,53 @@
               ]
             },
             {
-              "atom": "false"
+              "kind": "string",
+              "text": "\"false\""
             },
             {
-              "atom": "true"
+              "kind": "string",
+              "text": "\"true\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "atom": "flag"
+              "kind": "symbol",
+              "text": "flag"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/for_list_collection.scheme.json
+++ b/tests/json-ast/x/scheme/for_list_collection.scheme.json
@@ -1,78 +1,106 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "n"
+                  "kind": "symbol",
+                  "text": "n"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "n"
+                      "kind": "symbol",
+                      "text": "n"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -81,18 +109,23 @@
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }

--- a/tests/json-ast/x/scheme/for_loop.scheme.json
+++ b/tests/json-ast/x/scheme/for_loop.scheme.json
@@ -1,78 +1,106 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "i"
+                  "kind": "symbol",
+                  "text": "i"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "i"
+                      "kind": "symbol",
+                      "text": "i"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -81,7 +109,8 @@
           ]
         },
         {
-          "atom": "1"
+          "kind": "number",
+          "text": "1"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/for_map_collection.scheme.json
+++ b/tests/json-ast/x/scheme/for_map_collection.scheme.json
@@ -1,83 +1,113 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
@@ -88,41 +118,54 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "k"
+                  "kind": "symbol",
+                  "text": "k"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "k"
+                      "kind": "symbol",
+                      "text": "k"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -131,12 +174,15 @@
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-keys"
+              "kind": "symbol",
+              "text": "hash-table-keys"
             },
             {
-              "atom": "m"
+              "kind": "symbol",
+              "text": "m"
             }
           ]
         }

--- a/tests/json-ast/x/scheme/fun_call.scheme.json
+++ b/tests/json-ast/x/scheme/fun_call.scheme.json
@@ -1,99 +1,132 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "add"
+              "kind": "symbol",
+              "text": "add"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "b"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "add"
-            },
-            {
-              "atom": "2"
-            },
-            {
-              "atom": "3"
+              "kind": "symbol",
+              "text": "b"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "add"
+            },
+            {
+              "kind": "number",
+              "text": "2"
+            },
+            {
+              "kind": "number",
+              "text": "3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/fun_expr_in_let.scheme.json
+++ b/tests/json-ast/x/scheme/fun_expr_in_let.scheme.json
@@ -1,134 +1,179 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 09:24 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "true"
+                      "kind": "string",
+                      "text": "\"true\""
                     },
                     {
-                      "atom": "false"
+                      "kind": "string",
+                      "text": "\"false\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -139,59 +184,46 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "square"
+          "kind": "symbol",
+          "text": "square"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 },
                 {
-                  "atom": "x"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "to-str"
-            },
-            {
-              "list": [
-                {
-                  "atom": "square"
-                },
-                {
-                  "atom": "6"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             }
@@ -200,9 +232,42 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "to-str"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "square"
+                },
+                {
+                  "kind": "number",
+                  "text": "6"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/fun_three_args.scheme.json
+++ b/tests/json-ast/x/scheme/fun_three_args.scheme.json
@@ -1,115 +1,153 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "sum3"
+              "kind": "symbol",
+              "text": "sum3"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "b"
             },
             {
-              "atom": "c"
+              "kind": "symbol",
+              "text": "c"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "atom": "a"
+                  "kind": "symbol",
+                  "text": "a"
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             },
             {
-              "atom": "c"
+              "kind": "symbol",
+              "text": "c"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "sum3"
+              "kind": "symbol",
+              "text": "sum3"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by.scheme.json
+++ b/tests/json-ast/x/scheme/group_by.scheme.json
@@ -1,101 +1,137 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "people"
+          "kind": "symbol",
+          "text": "people"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "30"
+                          "kind": "number",
+                          "text": "30"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Paris"
+                          "kind": "string",
+                          "text": "\"Paris\""
                         }
                       ]
                     }
@@ -104,51 +140,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "15"
+                          "kind": "number",
+                          "text": "15"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Hanoi"
+                          "kind": "string",
+                          "text": "\"Hanoi\""
                         }
                       ]
                     }
@@ -157,51 +209,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "65"
+                          "kind": "number",
+                          "text": "65"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Paris"
+                          "kind": "string",
+                          "text": "\"Paris\""
                         }
                       ]
                     }
@@ -210,51 +278,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Diana"
+                          "kind": "string",
+                          "text": "\"Diana\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "45"
+                          "kind": "number",
+                          "text": "45"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Hanoi"
+                          "kind": "string",
+                          "text": "\"Hanoi\""
                         }
                       ]
                     }
@@ -263,51 +347,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Eve"
+                          "kind": "string",
+                          "text": "\"Eve\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "70"
+                          "kind": "number",
+                          "text": "70"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Paris"
+                          "kind": "string",
+                          "text": "\"Paris\""
                         }
                       ]
                     }
@@ -316,51 +416,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Frank"
+                          "kind": "string",
+                          "text": "\"Frank\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "age"
+                          "kind": "string",
+                          "text": "\"age\""
                         },
                         {
-                          "atom": "22"
+                          "kind": "number",
+                          "text": "22"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         },
                         {
-                          "atom": "Hanoi"
+                          "kind": "string",
+                          "text": "\"Hanoi\""
                         }
                       ]
                     }
@@ -373,43 +489,57 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "stats"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "groups8"
+                      "kind": "symbol",
+                      "text": "groups8"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "make-hash-table"
+                          "kind": "symbol",
+                          "text": "make-hash-table"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res11"
+                      "kind": "symbol",
+                      "text": "res11"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -418,72 +548,92 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "person"
+                              "kind": "symbol",
+                              "text": "person"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "let*"
+                              "kind": "symbol",
+                              "text": "let*"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "k10"
+                                      "kind": "symbol",
+                                      "text": "k10"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "atom": "person"
+                                          "kind": "symbol",
+                                          "text": "person"
                                         },
                                         {
-                                          "atom": "city"
+                                          "kind": "string",
+                                          "text": "\"city\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "g9"
+                                      "kind": "symbol",
+                                      "text": "g9"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref/default"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref/default"
                                         },
                                         {
-                                          "atom": "groups8"
+                                          "kind": "symbol",
+                                          "text": "groups8"
                                         },
                                         {
-                                          "atom": "k10"
-                                        },
-                                        {
-                                          "atom": "#f"
+                                          "kind": "symbol",
+                                          "text": "k10"
                                         }
                                       ]
                                     }
@@ -492,73 +642,98 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "not"
+                                          "kind": "symbol",
+                                          "text": "not"
                                         },
                                         {
-                                          "atom": "g9"
+                                          "kind": "symbol",
+                                          "text": "g9"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "begin"
+                                          "kind": "symbol",
+                                          "text": "begin"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "set!"
+                                              "kind": "symbol",
+                                              "text": "set!"
                                             },
                                             {
-                                              "atom": "g9"
+                                              "kind": "symbol",
+                                              "text": "g9"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "alist-\u003ehash-table"
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "key"
+                                                          "kind": "string",
+                                                          "text": "\"key\""
                                                         },
                                                         {
-                                                          "atom": "k10"
+                                                          "kind": "symbol",
+                                                          "text": "k10"
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             }
                                                           ]
                                                         }
@@ -571,89 +746,117 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-set!"
+                                              "kind": "symbol",
+                                              "text": "hash-table-set!"
                                             },
                                             {
-                                              "atom": "groups8"
+                                              "kind": "symbol",
+                                              "text": "groups8"
                                             },
                                             {
-                                              "atom": "k10"
+                                              "kind": "symbol",
+                                              "text": "k10"
                                             },
                                             {
-                                              "atom": "g9"
+                                              "kind": "symbol",
+                                              "text": "g9"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-set!"
+                                      "kind": "symbol",
+                                      "text": "hash-table-set!"
                                     },
                                     {
-                                      "atom": "g9"
+                                      "kind": "symbol",
+                                      "text": "g9"
                                     },
                                     {
-                                      "atom": "items"
+                                      "kind": "string",
+                                      "text": "\"items\""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "append"
+                                          "kind": "symbol",
+                                          "text": "append"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "g9"
+                                              "kind": "symbol",
+                                              "text": "g9"
                                             },
                                             {
-                                              "atom": "items"
+                                              "kind": "string",
+                                              "text": "\"items\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "alist-\u003ehash-table"
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "person"
+                                                          "kind": "string",
+                                                          "text": "\"person\""
                                                         },
                                                         {
-                                                          "atom": "person"
+                                                          "kind": "symbol",
+                                                          "text": "person"
                                                         }
                                                       ]
                                                     }
@@ -674,104 +877,139 @@
                       ]
                     },
                     {
-                      "atom": "people"
+                      "kind": "symbol",
+                      "text": "people"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res11"
+                              "kind": "symbol",
+                              "text": "res11"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res11"
+                                  "kind": "symbol",
+                                  "text": "res11"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "city"
+                                                  "kind": "string",
+                                                  "text": "\"city\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "count"
+                                                  "kind": "string",
+                                                  "text": "\"count\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "length"
+                                                      "kind": "symbol",
+                                                      "text": "length"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "g"
+                                                          "kind": "symbol",
+                                                          "text": "g"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     }
@@ -780,41 +1018,56 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "avg_age"
+                                                  "kind": "string",
+                                                  "text": "\"avg_age\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "let"
+                                                      "kind": "symbol",
+                                                      "text": "let"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "xs"
+                                                              "kind": "symbol",
+                                                              "text": "xs"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "let"
+                                                                  "kind": "symbol",
+                                                                  "text": "let"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "res7"
+                                                                          "kind": "symbol",
+                                                                          "text": "res7"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "list"
+                                                                              "kind": "symbol",
+                                                                              "text": "list"
                                                                             }
                                                                           ]
                                                                         }
@@ -823,58 +1076,78 @@
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "begin"
+                                                                      "kind": "symbol",
+                                                                      "text": "begin"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "for-each"
+                                                                          "kind": "symbol",
+                                                                          "text": "for-each"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "lambda"
+                                                                              "kind": "symbol",
+                                                                              "text": "lambda"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "p"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "p"
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "set!"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "set!"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "res7"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res7"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "append"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "append"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "res7"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "res7"
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "list"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "list"
                                                                                         },
                                                                                         {
-                                                                                          "list": [
+                                                                                          "kind": "list",
+                                                                                          "children": [
                                                                                             {
-                                                                                              "atom": "hash-table-ref"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "p"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "p"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "age"
+                                                                                              "kind": "string",
+                                                                                              "text": "\"age\""
                                                                                             }
                                                                                           ]
                                                                                         }
@@ -887,22 +1160,27 @@
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "g"
+                                                                              "kind": "symbol",
+                                                                              "text": "g"
                                                                             },
                                                                             {
-                                                                              "atom": "items"
+                                                                              "kind": "string",
+                                                                              "text": "\"items\""
                                                                             }
                                                                           ]
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "atom": "res7"
+                                                                      "kind": "symbol",
+                                                                      "text": "res7"
                                                                     }
                                                                   ]
                                                                 }
@@ -913,35 +1191,46 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "exact-\u003einexact"
+                                                          "kind": "symbol",
+                                                          "text": "exact-\u003einexact"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "/"
+                                                              "kind": "symbol",
+                                                              "text": "/"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "apply"
+                                                                  "kind": "symbol",
+                                                                  "text": "apply"
                                                                 },
                                                                 {
-                                                                  "atom": "+"
+                                                                  "kind": "symbol",
+                                                                  "text": "+"
                                                                 },
                                                                 {
-                                                                  "atom": "xs"
+                                                                  "kind": "symbol",
+                                                                  "text": "xs"
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "length"
+                                                                  "kind": "symbol",
+                                                                  "text": "length"
                                                                 },
                                                                 {
-                                                                  "atom": "xs"
+                                                                  "kind": "symbol",
+                                                                  "text": "xs"
                                                                 }
                                                               ]
                                                             }
@@ -966,19 +1255,23 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups8"
+                          "kind": "symbol",
+                          "text": "groups8"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res11"
+                  "kind": "symbol",
+                  "text": "res11"
                 }
               ]
             }
@@ -987,168 +1280,219 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- People grouped by city ---"
+          "kind": "string",
+          "text": "\"--- People grouped by city ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "s"
+                  "kind": "symbol",
+                  "text": "s"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "city"
+                          "kind": "string",
+                          "text": "\"city\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": ": count ="
+                      "kind": "string",
+                      "text": "\": count =\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "count"
+                          "kind": "string",
+                          "text": "\"count\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": ", avg_age ="
+                      "kind": "string",
+                      "text": "\", avg_age =\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "avg_age"
+                          "kind": "string",
+                          "text": "\"avg_age\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -1157,7 +1501,8 @@
           ]
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "stats"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_conditional_sum.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_conditional_sum.scheme.json
@@ -1,101 +1,137 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "items"
+          "kind": "symbol",
+          "text": "items"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "10"
+                          "kind": "number",
+                          "text": "10"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "flag"
+                          "kind": "string",
+                          "text": "\"flag\""
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         }
                       ]
                     }
@@ -104,51 +140,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "5"
+                          "kind": "number",
+                          "text": "5"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "flag"
+                          "kind": "string",
+                          "text": "\"flag\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -157,51 +209,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "20"
+                          "kind": "number",
+                          "text": "20"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "flag"
+                          "kind": "string",
+                          "text": "\"flag\""
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         }
                       ]
                     }
@@ -214,29 +282,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res14"
+                      "kind": "symbol",
+                      "text": "res14"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -245,118 +323,160 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "i"
+                              "kind": "symbol",
+                              "text": "i"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res14"
+                              "kind": "symbol",
+                              "text": "res14"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res14"
+                                  "kind": "symbol",
+                                  "text": "res14"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "cat"
+                                                  "kind": "string",
+                                                  "text": "\"cat\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "share"
+                                                  "kind": "string",
+                                                  "text": "\"share\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quotient"
+                                                      "kind": "symbol",
+                                                      "text": "quotient"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "apply"
+                                                          "kind": "symbol",
+                                                          "text": "apply"
                                                         },
                                                         {
-                                                          "atom": "+"
+                                                          "kind": "symbol",
+                                                          "text": "+"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "let"
+                                                              "kind": "symbol",
+                                                              "text": "let"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "res12"
+                                                                      "kind": "symbol",
+                                                                      "text": "res12"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         }
                                                                       ]
                                                                     }
@@ -365,81 +485,108 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "begin"
+                                                                  "kind": "symbol",
+                                                                  "text": "begin"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "for-each"
+                                                                      "kind": "symbol",
+                                                                      "text": "for-each"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "lambda"
+                                                                          "kind": "symbol",
+                                                                          "text": "lambda"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "x"
+                                                                              "kind": "symbol",
+                                                                              "text": "x"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "set!"
+                                                                              "kind": "symbol",
+                                                                              "text": "set!"
                                                                             },
                                                                             {
-                                                                              "atom": "res12"
+                                                                              "kind": "symbol",
+                                                                              "text": "res12"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "append"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "append"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "res12"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res12"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "list"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "list"
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "if"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "if"
                                                                                         },
                                                                                         {
-                                                                                          "list": [
+                                                                                          "kind": "list",
+                                                                                          "children": [
                                                                                             {
-                                                                                              "atom": "hash-table-ref"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "x"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "x"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "flag"
+                                                                                              "kind": "string",
+                                                                                              "text": "\"flag\""
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
-                                                                                          "list": [
+                                                                                          "kind": "list",
+                                                                                          "children": [
                                                                                             {
-                                                                                              "atom": "hash-table-ref"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "x"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "x"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "val"
+                                                                                              "kind": "string",
+                                                                                              "text": "\"val\""
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
-                                                                                          "atom": "0"
+                                                                                          "kind": "number",
+                                                                                          "text": "0"
                                                                                         }
                                                                                       ]
                                                                                     }
@@ -452,12 +599,14 @@
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "atom": "g"
+                                                                      "kind": "string",
+                                                                      "text": "\"g\""
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "atom": "res12"
+                                                                  "kind": "symbol",
+                                                                  "text": "res12"
                                                                 }
                                                               ]
                                                             }
@@ -466,29 +615,39 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "apply"
+                                                          "kind": "symbol",
+                                                          "text": "apply"
                                                         },
                                                         {
-                                                          "atom": "+"
+                                                          "kind": "symbol",
+                                                          "text": "+"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "let"
+                                                              "kind": "symbol",
+                                                              "text": "let"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "res13"
+                                                                      "kind": "symbol",
+                                                                      "text": "res13"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         }
                                                                       ]
                                                                     }
@@ -497,58 +656,78 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "begin"
+                                                                  "kind": "symbol",
+                                                                  "text": "begin"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "for-each"
+                                                                      "kind": "symbol",
+                                                                      "text": "for-each"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "lambda"
+                                                                          "kind": "symbol",
+                                                                          "text": "lambda"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "x"
+                                                                              "kind": "symbol",
+                                                                              "text": "x"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "set!"
+                                                                              "kind": "symbol",
+                                                                              "text": "set!"
                                                                             },
                                                                             {
-                                                                              "atom": "res13"
+                                                                              "kind": "symbol",
+                                                                              "text": "res13"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "append"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "append"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "res13"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res13"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "list"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "list"
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "hash-table-ref"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "hash-table-ref"
                                                                                         },
                                                                                         {
-                                                                                          "atom": "x"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "x"
                                                                                         },
                                                                                         {
-                                                                                          "atom": "val"
+                                                                                          "kind": "string",
+                                                                                          "text": "\"val\""
                                                                                         }
                                                                                       ]
                                                                                     }
@@ -561,12 +740,14 @@
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "atom": "g"
+                                                                      "kind": "string",
+                                                                      "text": "\"g\""
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "atom": "res13"
+                                                                  "kind": "symbol",
+                                                                  "text": "res13"
                                                                 }
                                                               ]
                                                             }
@@ -591,12 +772,14 @@
                       ]
                     },
                     {
-                      "atom": "items"
+                      "kind": "symbol",
+                      "text": "items"
                     }
                   ]
                 },
                 {
-                  "atom": "res14"
+                  "kind": "symbol",
+                  "text": "res14"
                 }
               ]
             }
@@ -605,19 +788,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_join.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,175 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "102"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -272,43 +179,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
-                    {
-                      "atom": "groups19"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "make-hash-table"
-                        }
-                      ]
-                    }
-                  ]
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res22"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -317,127 +249,332 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "102"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "stats"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "groups19"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "make-hash-table"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res22"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "o"
+                                              "kind": "symbol",
+                                              "text": "o"
                                             },
                                             {
-                                              "atom": "customerId"
+                                              "kind": "string",
+                                              "text": "\"customerId\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             },
                                             {
-                                              "atom": "id"
+                                              "kind": "string",
+                                              "text": "\"id\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "let*"
+                                          "kind": "symbol",
+                                          "text": "let*"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "k21"
+                                                  "kind": "symbol",
+                                                  "text": "k21"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "c"
+                                                      "kind": "symbol",
+                                                      "text": "c"
                                                     },
                                                     {
-                                                      "atom": "name"
+                                                      "kind": "string",
+                                                      "text": "\"name\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "g20"
+                                                  "kind": "symbol",
+                                                  "text": "g20"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref/default"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref/default"
                                                     },
                                                     {
-                                                      "atom": "groups19"
+                                                      "kind": "symbol",
+                                                      "text": "groups19"
                                                     },
                                                     {
-                                                      "atom": "k21"
-                                                    },
-                                                    {
-                                                      "atom": "#f"
+                                                      "kind": "symbol",
+                                                      "text": "k21"
                                                     }
                                                   ]
                                                 }
@@ -446,73 +583,98 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "begin"
+                                              "kind": "symbol",
+                                              "text": "begin"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "if"
+                                                  "kind": "symbol",
+                                                  "text": "if"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "not"
+                                                      "kind": "symbol",
+                                                      "text": "not"
                                                     },
                                                     {
-                                                      "atom": "g20"
+                                                      "kind": "symbol",
+                                                      "text": "g20"
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "begin"
+                                                      "kind": "symbol",
+                                                      "text": "begin"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "set!"
+                                                          "kind": "symbol",
+                                                          "text": "set!"
                                                         },
                                                         {
-                                                          "atom": "g20"
+                                                          "kind": "symbol",
+                                                          "text": "g20"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "key"
+                                                                      "kind": "string",
+                                                                      "text": "\"key\""
                                                                     },
                                                                     {
-                                                                      "atom": "k21"
+                                                                      "kind": "symbol",
+                                                                      "text": "k21"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "items"
+                                                                      "kind": "string",
+                                                                      "text": "\"items\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         }
                                                                       ]
                                                                     }
@@ -525,102 +687,134 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-set!"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-set!"
                                                         },
                                                         {
-                                                          "atom": "groups19"
+                                                          "kind": "symbol",
+                                                          "text": "groups19"
                                                         },
                                                         {
-                                                          "atom": "k21"
+                                                          "kind": "symbol",
+                                                          "text": "k21"
                                                         },
                                                         {
-                                                          "atom": "g20"
+                                                          "kind": "symbol",
+                                                          "text": "g20"
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quote"
+                                                      "kind": "symbol",
+                                                      "text": "quote"
                                                     },
                                                     {
-                                                      "atom": "nil"
+                                                      "kind": "symbol",
+                                                      "text": "nil"
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-set!"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-set!"
                                                 },
                                                 {
-                                                  "atom": "g20"
+                                                  "kind": "symbol",
+                                                  "text": "g20"
                                                 },
                                                 {
-                                                  "atom": "items"
+                                                  "kind": "string",
+                                                  "text": "\"items\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "append"
+                                                      "kind": "symbol",
+                                                      "text": "append"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "g20"
+                                                          "kind": "symbol",
+                                                          "text": "g20"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "o"
+                                                                      "kind": "string",
+                                                                      "text": "\"o\""
                                                                     },
                                                                     {
-                                                                      "atom": "o"
+                                                                      "kind": "symbol",
+                                                                      "text": "o"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "c"
+                                                                      "kind": "string",
+                                                                      "text": "\"c\""
                                                                     },
                                                                     {
-                                                                      "atom": "c"
+                                                                      "kind": "symbol",
+                                                                      "text": "c"
                                                                     }
                                                                   ]
                                                                 }
@@ -639,12 +833,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -653,111 +850,147 @@
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res22"
+                              "kind": "symbol",
+                              "text": "res22"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res22"
+                                  "kind": "symbol",
+                                  "text": "res22"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "name"
+                                                  "kind": "string",
+                                                  "text": "\"name\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "count"
+                                                  "kind": "string",
+                                                  "text": "\"count\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "length"
+                                                      "kind": "symbol",
+                                                      "text": "length"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "g"
+                                                          "kind": "symbol",
+                                                          "text": "g"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     }
@@ -778,19 +1011,23 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups19"
+                          "kind": "symbol",
+                          "text": "groups19"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res22"
+                  "kind": "symbol",
+                  "text": "res22"
                 }
               ]
             }
@@ -799,118 +1036,154 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Orders per customer ---"
+          "kind": "string",
+          "text": "\"--- Orders per customer ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "s"
+                  "kind": "symbol",
+                  "text": "s"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "orders:"
+                      "kind": "string",
+                      "text": "\"orders:\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "count"
+                          "kind": "string",
+                          "text": "\"count\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -919,7 +1192,8 @@
           ]
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "stats"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_left_join.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_left_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -131,175 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "102"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     }
@@ -312,43 +231,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
-                    {
-                      "atom": "groups24"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "make-hash-table"
-                        }
-                      ]
-                    }
-                  ]
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res27"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -357,127 +301,332 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "102"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "stats"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "groups24"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "make-hash-table"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res27"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "c"
+                              "kind": "symbol",
+                              "text": "c"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "o"
+                                      "kind": "symbol",
+                                      "text": "o"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "o"
+                                              "kind": "symbol",
+                                              "text": "o"
                                             },
                                             {
-                                              "atom": "customerId"
+                                              "kind": "string",
+                                              "text": "\"customerId\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             },
                                             {
-                                              "atom": "id"
+                                              "kind": "string",
+                                              "text": "\"id\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "let*"
+                                          "kind": "symbol",
+                                          "text": "let*"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "k26"
+                                                  "kind": "symbol",
+                                                  "text": "k26"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "c"
+                                                      "kind": "symbol",
+                                                      "text": "c"
                                                     },
                                                     {
-                                                      "atom": "name"
+                                                      "kind": "string",
+                                                      "text": "\"name\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "g25"
+                                                  "kind": "symbol",
+                                                  "text": "g25"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref/default"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref/default"
                                                     },
                                                     {
-                                                      "atom": "groups24"
+                                                      "kind": "symbol",
+                                                      "text": "groups24"
                                                     },
                                                     {
-                                                      "atom": "k26"
-                                                    },
-                                                    {
-                                                      "atom": "#f"
+                                                      "kind": "symbol",
+                                                      "text": "k26"
                                                     }
                                                   ]
                                                 }
@@ -486,73 +635,98 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "begin"
+                                              "kind": "symbol",
+                                              "text": "begin"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "if"
+                                                  "kind": "symbol",
+                                                  "text": "if"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "not"
+                                                      "kind": "symbol",
+                                                      "text": "not"
                                                     },
                                                     {
-                                                      "atom": "g25"
+                                                      "kind": "symbol",
+                                                      "text": "g25"
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "begin"
+                                                      "kind": "symbol",
+                                                      "text": "begin"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "set!"
+                                                          "kind": "symbol",
+                                                          "text": "set!"
                                                         },
                                                         {
-                                                          "atom": "g25"
+                                                          "kind": "symbol",
+                                                          "text": "g25"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "key"
+                                                                      "kind": "string",
+                                                                      "text": "\"key\""
                                                                     },
                                                                     {
-                                                                      "atom": "k26"
+                                                                      "kind": "symbol",
+                                                                      "text": "k26"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "items"
+                                                                      "kind": "string",
+                                                                      "text": "\"items\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         }
                                                                       ]
                                                                     }
@@ -565,102 +739,134 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-set!"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-set!"
                                                         },
                                                         {
-                                                          "atom": "groups24"
+                                                          "kind": "symbol",
+                                                          "text": "groups24"
                                                         },
                                                         {
-                                                          "atom": "k26"
+                                                          "kind": "symbol",
+                                                          "text": "k26"
                                                         },
                                                         {
-                                                          "atom": "g25"
+                                                          "kind": "symbol",
+                                                          "text": "g25"
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quote"
+                                                      "kind": "symbol",
+                                                      "text": "quote"
                                                     },
                                                     {
-                                                      "atom": "nil"
+                                                      "kind": "symbol",
+                                                      "text": "nil"
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-set!"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-set!"
                                                 },
                                                 {
-                                                  "atom": "g25"
+                                                  "kind": "symbol",
+                                                  "text": "g25"
                                                 },
                                                 {
-                                                  "atom": "items"
+                                                  "kind": "string",
+                                                  "text": "\"items\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "append"
+                                                      "kind": "symbol",
+                                                      "text": "append"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "g25"
+                                                          "kind": "symbol",
+                                                          "text": "g25"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "c"
+                                                                      "kind": "string",
+                                                                      "text": "\"c\""
                                                                     },
                                                                     {
-                                                                      "atom": "c"
+                                                                      "kind": "symbol",
+                                                                      "text": "c"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "o"
+                                                                      "kind": "string",
+                                                                      "text": "\"o\""
                                                                     },
                                                                     {
-                                                                      "atom": "o"
+                                                                      "kind": "symbol",
+                                                                      "text": "o"
                                                                     }
                                                                   ]
                                                                 }
@@ -679,12 +885,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -693,117 +902,156 @@
                               ]
                             },
                             {
-                              "atom": "orders"
+                              "kind": "symbol",
+                              "text": "orders"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "customers"
+                      "kind": "symbol",
+                      "text": "customers"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res27"
+                              "kind": "symbol",
+                              "text": "res27"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res27"
+                                  "kind": "symbol",
+                                  "text": "res27"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "name"
+                                                  "kind": "string",
+                                                  "text": "\"name\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "count"
+                                                  "kind": "string",
+                                                  "text": "\"count\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "length"
+                                                      "kind": "symbol",
+                                                      "text": "length"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "let"
+                                                          "kind": "symbol",
+                                                          "text": "let"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "res23"
+                                                                  "kind": "symbol",
+                                                                  "text": "res23"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     }
                                                                   ]
                                                                 }
@@ -812,68 +1060,91 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "begin"
+                                                              "kind": "symbol",
+                                                              "text": "begin"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "for-each"
+                                                                  "kind": "symbol",
+                                                                  "text": "for-each"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "lambda"
+                                                                      "kind": "symbol",
+                                                                      "text": "lambda"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "r"
+                                                                          "kind": "symbol",
+                                                                          "text": "r"
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "if"
+                                                                          "kind": "symbol",
+                                                                          "text": "if"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "r"
+                                                                              "kind": "symbol",
+                                                                              "text": "r"
                                                                             },
                                                                             {
-                                                                              "atom": "o"
+                                                                              "kind": "string",
+                                                                              "text": "\"o\""
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "set!"
+                                                                              "kind": "symbol",
+                                                                              "text": "set!"
                                                                             },
                                                                             {
-                                                                              "atom": "res23"
+                                                                              "kind": "symbol",
+                                                                              "text": "res23"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "append"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "append"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "res23"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "res23"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "list"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "list"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "r"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "r"
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -882,12 +1153,15 @@
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "quote"
+                                                                              "kind": "symbol",
+                                                                              "text": "quote"
                                                                             },
                                                                             {
-                                                                              "atom": "nil"
+                                                                              "kind": "symbol",
+                                                                              "text": "nil"
                                                                             }
                                                                           ]
                                                                         }
@@ -896,22 +1170,27 @@
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref"
                                                                     },
                                                                     {
-                                                                      "atom": "g"
+                                                                      "kind": "symbol",
+                                                                      "text": "g"
                                                                     },
                                                                     {
-                                                                      "atom": "items"
+                                                                      "kind": "string",
+                                                                      "text": "\"items\""
                                                                     }
                                                                   ]
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "atom": "res23"
+                                                              "kind": "symbol",
+                                                              "text": "res23"
                                                             }
                                                           ]
                                                         }
@@ -934,19 +1213,23 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups24"
+                          "kind": "symbol",
+                          "text": "groups24"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res27"
+                  "kind": "symbol",
+                  "text": "res27"
                 }
               ]
             }
@@ -955,118 +1238,154 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Group Left Join ---"
+          "kind": "string",
+          "text": "\"--- Group Left Join ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "s"
+                  "kind": "symbol",
+                  "text": "s"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "orders:"
+                      "kind": "string",
+                      "text": "\"orders:\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         },
                         {
-                          "atom": "count"
+                          "kind": "string",
+                          "text": "\"count\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -1075,7 +1394,8 @@
           ]
         },
         {
-          "atom": "stats"
+          "kind": "symbol",
+          "text": "stats"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_multi_join.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_multi_join.scheme.json
@@ -1,145 +1,196 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 19:10 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "scheme"
+              "kind": "symbol",
+              "text": "scheme"
             },
             {
-              "atom": "sort"
+              "kind": "symbol",
+              "text": "sort"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "hash-table?"
+                      "kind": "symbol",
+                      "text": "hash-table?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "let*"
+                      "kind": "symbol",
+                      "text": "let*"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "pairs"
+                              "kind": "symbol",
+                              "text": "pairs"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-\u003ealist"
+                                  "kind": "symbol",
+                                  "text": "hash-table-\u003ealist"
                                 },
                                 {
-                                  "atom": "x"
+                                  "kind": "symbol",
+                                  "text": "x"
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "pairs"
+                              "kind": "symbol",
+                              "text": "pairs"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "list-sort"
+                                  "kind": "symbol",
+                                  "text": "list-sort"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "lambda"
+                                      "kind": "symbol",
+                                      "text": "lambda"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "a"
+                                          "kind": "symbol",
+                                          "text": "a"
                                         },
                                         {
-                                          "atom": "b"
+                                          "kind": "symbol",
+                                          "text": "b"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "string\u003c?"
+                                          "kind": "symbol",
+                                          "text": "string\u003c?"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "car"
+                                              "kind": "symbol",
+                                              "text": "car"
                                             },
                                             {
-                                              "atom": "a"
+                                              "kind": "symbol",
+                                              "text": "a"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "car"
+                                              "kind": "symbol",
+                                              "text": "car"
                                             },
                                             {
-                                              "atom": "b"
+                                              "kind": "symbol",
+                                              "text": "b"
                                             }
                                           ]
                                         }
@@ -148,7 +199,8 @@
                                   ]
                                 },
                                 {
-                                  "atom": "pairs"
+                                  "kind": "symbol",
+                                  "text": "pairs"
                                 }
                               ]
                             }
@@ -157,68 +209,91 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-append"
+                          "kind": "symbol",
+                          "text": "string-append"
                         },
                         {
-                          "atom": "{"
+                          "kind": "string",
+                          "text": "\"{\""
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-join"
+                              "kind": "symbol",
+                              "text": "string-join"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "map"
+                                  "kind": "symbol",
+                                  "text": "map"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "lambda"
+                                      "kind": "symbol",
+                                      "text": "lambda"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "kv"
+                                          "kind": "symbol",
+                                          "text": "kv"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "string-append"
+                                          "kind": "symbol",
+                                          "text": "string-append"
                                         },
                                         {
-                                          "atom": "'"
+                                          "kind": "string",
+                                          "text": "\"'\""
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "car"
+                                              "kind": "symbol",
+                                              "text": "car"
                                             },
                                             {
-                                              "atom": "kv"
+                                              "kind": "symbol",
+                                              "text": "kv"
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "': "
+                                          "kind": "string",
+                                          "text": "\"': \""
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "to-str"
+                                              "kind": "symbol",
+                                              "text": "to-str"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cdr"
+                                                  "kind": "symbol",
+                                                  "text": "cdr"
                                                 },
                                                 {
-                                                  "atom": "kv"
+                                                  "kind": "symbol",
+                                                  "text": "kv"
                                                 }
                                               ]
                                             }
@@ -229,17 +304,20 @@
                                   ]
                                 },
                                 {
-                                  "atom": "pairs"
+                                  "kind": "symbol",
+                                  "text": "pairs"
                                 }
                               ]
                             },
                             {
-                              "atom": ", "
+                              "kind": "string",
+                              "text": "\", \""
                             }
                           ]
                         },
                         {
-                          "atom": "}"
+                          "kind": "string",
+                          "text": "\"}\""
                         }
                       ]
                     }
@@ -248,194 +326,118 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list?"
+                      "kind": "symbol",
+                      "text": "list?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "\""
-                    },
-                    {
-                      "atom": "x"
-                    },
-                    {
-                      "atom": "\""
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "else"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "number-\u003estring"
-                    },
-                    {
-                      "atom": "x"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "nations"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "name"
-                        },
-                        {
-                          "atom": "A"
-                        }
-                      ]
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "2"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "name"
-                        },
-                        {
-                          "atom": "B"
-                        }
-                      ]
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -446,51 +448,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "suppliers"
+          "kind": "symbol",
+          "text": "nations"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "nation"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "string",
+                          "text": "\"A\""
                         }
                       ]
                     }
@@ -499,38 +518,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "nation"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "string",
+                          "text": "\"B\""
                         }
                       ]
                     }
@@ -543,77 +574,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "partsupp"
+          "kind": "symbol",
+          "text": "suppliers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "part"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "100"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "supplier"
+                          "kind": "string",
+                          "text": "\"nation\""
                         },
                         {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "cost"
-                        },
-                        {
-                          "atom": "10.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "qty"
-                        },
-                        {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -622,130 +644,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "part"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "100"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "supplier"
+                          "kind": "string",
+                          "text": "\"nation\""
                         },
                         {
-                          "atom": "2"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "cost"
-                        },
-                        {
-                          "atom": "20.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "qty"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "part"
-                        },
-                        {
-                          "atom": "200"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "supplier"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "cost"
-                        },
-                        {
-                          "atom": "5.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "qty"
-                        },
-                        {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -758,29 +700,102 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "filtered"
+          "kind": "symbol",
+          "text": "partsupp"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res1"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"part\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"supplier\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cost\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "10.0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"qty\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -789,127 +804,387 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"part\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"supplier\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cost\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "20.0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"qty\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"part\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "200"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"supplier\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"cost\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "5.0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"qty\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "3"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "filtered"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res1"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "ps"
+                              "kind": "symbol",
+                              "text": "ps"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "s"
+                                      "kind": "symbol",
+                                      "text": "s"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "n"
+                                              "kind": "symbol",
+                                              "text": "n"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "if"
+                                              "kind": "symbol",
+                                              "text": "if"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "and"
+                                                  "kind": "symbol",
+                                                  "text": "and"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "and"
+                                                      "kind": "symbol",
+                                                      "text": "and"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "string=?"
+                                                          "kind": "symbol",
+                                                          "text": "string=?"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "hash-table-ref"
+                                                              "kind": "symbol",
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
-                                                              "atom": "n"
+                                                              "kind": "symbol",
+                                                              "text": "n"
                                                             },
                                                             {
-                                                              "atom": "name"
+                                                              "kind": "string",
+                                                              "text": "\"name\""
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "atom": "A"
+                                                          "kind": "string",
+                                                          "text": "\"A\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "="
+                                                          "kind": "symbol",
+                                                          "text": "="
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "hash-table-ref"
+                                                              "kind": "symbol",
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
-                                                              "atom": "s"
+                                                              "kind": "symbol",
+                                                              "text": "s"
                                                             },
                                                             {
-                                                              "atom": "id"
+                                                              "kind": "string",
+                                                              "text": "\"id\""
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "hash-table-ref"
+                                                              "kind": "symbol",
+                                                              "text": "hash-table-ref"
                                                             },
                                                             {
-                                                              "atom": "ps"
+                                                              "kind": "symbol",
+                                                              "text": "ps"
                                                             },
                                                             {
-                                                              "atom": "supplier"
+                                                              "kind": "string",
+                                                              "text": "\"supplier\""
                                                             }
                                                           ]
                                                         }
@@ -918,33 +1193,43 @@
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "="
+                                                      "kind": "symbol",
+                                                      "text": "="
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "n"
+                                                          "kind": "symbol",
+                                                          "text": "n"
                                                         },
                                                         {
-                                                          "atom": "id"
+                                                          "kind": "string",
+                                                          "text": "\"id\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "s"
+                                                          "kind": "symbol",
+                                                          "text": "s"
                                                         },
                                                         {
-                                                          "atom": "nation"
+                                                          "kind": "string",
+                                                          "text": "\"nation\""
                                                         }
                                                       ]
                                                     }
@@ -953,95 +1238,127 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "set!"
+                                                  "kind": "symbol",
+                                                  "text": "set!"
                                                 },
                                                 {
-                                                  "atom": "res1"
+                                                  "kind": "symbol",
+                                                  "text": "res1"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "append"
+                                                      "kind": "symbol",
+                                                      "text": "append"
                                                     },
                                                     {
-                                                      "atom": "res1"
+                                                      "kind": "symbol",
+                                                      "text": "res1"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "part"
+                                                                      "kind": "string",
+                                                                      "text": "\"part\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "ps"
+                                                                          "kind": "symbol",
+                                                                          "text": "ps"
                                                                         },
                                                                         {
-                                                                          "atom": "part"
+                                                                          "kind": "string",
+                                                                          "text": "\"part\""
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "value"
+                                                                      "kind": "string",
+                                                                      "text": "\"value\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "*"
+                                                                          "kind": "symbol",
+                                                                          "text": "*"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "ps"
+                                                                              "kind": "symbol",
+                                                                              "text": "ps"
                                                                             },
                                                                             {
-                                                                              "atom": "cost"
+                                                                              "kind": "string",
+                                                                              "text": "\"cost\""
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "ps"
+                                                                              "kind": "symbol",
+                                                                              "text": "ps"
                                                                             },
                                                                             {
-                                                                              "atom": "qty"
+                                                                              "kind": "string",
+                                                                              "text": "\"qty\""
                                                                             }
                                                                           ]
                                                                         }
@@ -1060,12 +1377,15 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "quote"
+                                                  "kind": "symbol",
+                                                  "text": "quote"
                                                 },
                                                 {
-                                                  "atom": "nil"
+                                                  "kind": "symbol",
+                                                  "text": "nil"
                                                 }
                                               ]
                                             }
@@ -1074,26 +1394,30 @@
                                       ]
                                     },
                                     {
-                                      "atom": "nations"
+                                      "kind": "symbol",
+                                      "text": "nations"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "atom": "suppliers"
+                              "kind": "symbol",
+                              "text": "suppliers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "partsupp"
+                      "kind": "symbol",
+                      "text": "partsupp"
                     }
                   ]
                 },
                 {
-                  "atom": "res1"
+                  "kind": "symbol",
+                  "text": "res1"
                 }
               ]
             }
@@ -1102,43 +1426,57 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "grouped"
+          "kind": "symbol",
+          "text": "grouped"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "groups3"
+                      "kind": "symbol",
+                      "text": "groups3"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "make-hash-table"
+                          "kind": "symbol",
+                          "text": "make-hash-table"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res6"
+                      "kind": "symbol",
+                      "text": "res6"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -1147,72 +1485,92 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "let*"
+                              "kind": "symbol",
+                              "text": "let*"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "k5"
+                                      "kind": "symbol",
+                                      "text": "k5"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "atom": "x"
+                                          "kind": "symbol",
+                                          "text": "x"
                                         },
                                         {
-                                          "atom": "part"
+                                          "kind": "string",
+                                          "text": "\"part\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "g4"
+                                      "kind": "symbol",
+                                      "text": "g4"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref/default"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref/default"
                                         },
                                         {
-                                          "atom": "groups3"
+                                          "kind": "symbol",
+                                          "text": "groups3"
                                         },
                                         {
-                                          "atom": "k5"
-                                        },
-                                        {
-                                          "atom": "#f"
+                                          "kind": "symbol",
+                                          "text": "k5"
                                         }
                                       ]
                                     }
@@ -1221,73 +1579,98 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "not"
+                                          "kind": "symbol",
+                                          "text": "not"
                                         },
                                         {
-                                          "atom": "g4"
+                                          "kind": "symbol",
+                                          "text": "g4"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "begin"
+                                          "kind": "symbol",
+                                          "text": "begin"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "set!"
+                                              "kind": "symbol",
+                                              "text": "set!"
                                             },
                                             {
-                                              "atom": "g4"
+                                              "kind": "symbol",
+                                              "text": "g4"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "alist-\u003ehash-table"
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "key"
+                                                          "kind": "string",
+                                                          "text": "\"key\""
                                                         },
                                                         {
-                                                          "atom": "k5"
+                                                          "kind": "symbol",
+                                                          "text": "k5"
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             }
                                                           ]
                                                         }
@@ -1300,71 +1683,92 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-set!"
+                                              "kind": "symbol",
+                                              "text": "hash-table-set!"
                                             },
                                             {
-                                              "atom": "groups3"
+                                              "kind": "symbol",
+                                              "text": "groups3"
                                             },
                                             {
-                                              "atom": "k5"
+                                              "kind": "symbol",
+                                              "text": "k5"
                                             },
                                             {
-                                              "atom": "g4"
+                                              "kind": "symbol",
+                                              "text": "g4"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-set!"
+                                      "kind": "symbol",
+                                      "text": "hash-table-set!"
                                     },
                                     {
-                                      "atom": "g4"
+                                      "kind": "symbol",
+                                      "text": "g4"
                                     },
                                     {
-                                      "atom": "items"
+                                      "kind": "string",
+                                      "text": "\"items\""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "append"
+                                          "kind": "symbol",
+                                          "text": "append"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "g4"
+                                              "kind": "symbol",
+                                              "text": "g4"
                                             },
                                             {
-                                              "atom": "items"
+                                              "kind": "string",
+                                              "text": "\"items\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "atom": "x"
+                                              "kind": "symbol",
+                                              "text": "x"
                                             }
                                           ]
                                         }
@@ -1379,113 +1783,152 @@
                       ]
                     },
                     {
-                      "atom": "filtered"
+                      "kind": "symbol",
+                      "text": "filtered"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res6"
+                              "kind": "symbol",
+                              "text": "res6"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res6"
+                                  "kind": "symbol",
+                                  "text": "res6"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "part"
+                                                  "kind": "string",
+                                                  "text": "\"part\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "total"
+                                                  "kind": "string",
+                                                  "text": "\"total\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "apply"
+                                                      "kind": "symbol",
+                                                      "text": "apply"
                                                     },
                                                     {
-                                                      "atom": "+"
+                                                      "kind": "symbol",
+                                                      "text": "+"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "let"
+                                                          "kind": "symbol",
+                                                          "text": "let"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "res2"
+                                                                  "kind": "symbol",
+                                                                  "text": "res2"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     }
                                                                   ]
                                                                 }
@@ -1494,58 +1937,78 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "begin"
+                                                              "kind": "symbol",
+                                                              "text": "begin"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "for-each"
+                                                                  "kind": "symbol",
+                                                                  "text": "for-each"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "lambda"
+                                                                      "kind": "symbol",
+                                                                      "text": "lambda"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "r"
+                                                                          "kind": "symbol",
+                                                                          "text": "r"
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "set!"
+                                                                          "kind": "symbol",
+                                                                          "text": "set!"
                                                                         },
                                                                         {
-                                                                          "atom": "res2"
+                                                                          "kind": "symbol",
+                                                                          "text": "res2"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "append"
+                                                                              "kind": "symbol",
+                                                                              "text": "append"
                                                                             },
                                                                             {
-                                                                              "atom": "res2"
+                                                                              "kind": "symbol",
+                                                                              "text": "res2"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "list"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "list"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "hash-table-ref"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "hash-table-ref"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "r"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "r"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "value"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"value\""
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -1558,22 +2021,27 @@
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref"
                                                                     },
                                                                     {
-                                                                      "atom": "g"
+                                                                      "kind": "symbol",
+                                                                      "text": "g"
                                                                     },
                                                                     {
-                                                                      "atom": "items"
+                                                                      "kind": "string",
+                                                                      "text": "\"items\""
                                                                     }
                                                                   ]
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "atom": "res2"
+                                                              "kind": "symbol",
+                                                              "text": "res2"
                                                             }
                                                           ]
                                                         }
@@ -1596,19 +2064,23 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups3"
+                          "kind": "symbol",
+                          "text": "groups3"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res6"
+                  "kind": "symbol",
+                  "text": "res6"
                 }
               ]
             }
@@ -1617,26 +2089,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "grouped"
+              "kind": "symbol",
+              "text": "grouped"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_multi_join_sort.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_multi_join_sort.scheme.json
@@ -1,66 +1,90 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 21:13 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "begin"
+          "kind": "symbol",
+          "text": "begin"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "current-error-port"
+              "kind": "symbol",
+              "text": "current-error-port"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "open-output-string"
+                  "kind": "symbol",
+                  "text": "open-output-string"
                 }
               ]
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "import"
+              "kind": "symbol",
+              "text": "import"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "srfi"
+                  "kind": "symbol",
+                  "text": "srfi"
                 },
                 {
-                  "atom": "69"
+                  "kind": "number",
+                  "text": "69"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "sort"
+                  "kind": "symbol",
+                  "text": "sort"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "chibi"
+                  "kind": "symbol",
+                  "text": "chibi"
                 },
                 {
-                  "atom": "string"
+                  "kind": "symbol",
+                  "text": "string"
                 }
               ]
             }
@@ -69,86 +93,114 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "and"
+                      "kind": "symbol",
+                      "text": "and"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list?"
+                          "kind": "symbol",
+                          "text": "list?"
                         },
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "pair?"
+                          "kind": "symbol",
+                          "text": "pair?"
                         },
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "pair?"
+                          "kind": "symbol",
+                          "text": "pair?"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "car"
+                              "kind": "symbol",
+                              "text": "car"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "car"
+                              "kind": "symbol",
+                              "text": "car"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "car"
+                                  "kind": "symbol",
+                                  "text": "car"
                                 },
                                 {
-                                  "atom": "x"
+                                  "kind": "symbol",
+                                  "text": "x"
                                 }
                               ]
                             }
@@ -159,68 +211,91 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "{"
+                      "kind": "string",
+                      "text": "\"{\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "kv"
+                                      "kind": "symbol",
+                                      "text": "kv"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "string-append"
+                                      "kind": "symbol",
+                                      "text": "string-append"
                                     },
                                     {
-                                      "atom": "'"
+                                      "kind": "string",
+                                      "text": "\"'\""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "car"
+                                          "kind": "symbol",
+                                          "text": "car"
                                         },
                                         {
-                                          "atom": "kv"
+                                          "kind": "symbol",
+                                          "text": "kv"
                                         }
                                       ]
                                     },
                                     {
-                                      "atom": "': "
+                                      "kind": "string",
+                                      "text": "\"': \""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "to-str"
+                                          "kind": "symbol",
+                                          "text": "to-str"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cdr"
+                                              "kind": "symbol",
+                                              "text": "cdr"
                                             },
                                             {
-                                              "atom": "kv"
+                                              "kind": "symbol",
+                                              "text": "kv"
                                             }
                                           ]
                                         }
@@ -231,53 +306,68 @@
                               ]
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "}"
+                      "kind": "string",
+                      "text": "\"}\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "hash-table?"
+                      "kind": "symbol",
+                      "text": "hash-table?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "let"
+                      "kind": "symbol",
+                      "text": "let"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "pairs"
+                              "kind": "symbol",
+                              "text": "pairs"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-\u003ealist"
+                                  "kind": "symbol",
+                                  "text": "hash-table-\u003ealist"
                                 },
                                 {
-                                  "atom": "x"
+                                  "kind": "symbol",
+                                  "text": "x"
                                 }
                               ]
                             }
@@ -286,68 +376,91 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-append"
+                          "kind": "symbol",
+                          "text": "string-append"
                         },
                         {
-                          "atom": "{"
+                          "kind": "string",
+                          "text": "\"{\""
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-join"
+                              "kind": "symbol",
+                              "text": "string-join"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "map"
+                                  "kind": "symbol",
+                                  "text": "map"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "lambda"
+                                      "kind": "symbol",
+                                      "text": "lambda"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "kv"
+                                          "kind": "symbol",
+                                          "text": "kv"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "string-append"
+                                          "kind": "symbol",
+                                          "text": "string-append"
                                         },
                                         {
-                                          "atom": "'"
+                                          "kind": "string",
+                                          "text": "\"'\""
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "car"
+                                              "kind": "symbol",
+                                              "text": "car"
                                             },
                                             {
-                                              "atom": "kv"
+                                              "kind": "symbol",
+                                              "text": "kv"
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "': "
+                                          "kind": "string",
+                                          "text": "\"': \""
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "to-str"
+                                              "kind": "symbol",
+                                              "text": "to-str"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cdr"
+                                                  "kind": "symbol",
+                                                  "text": "cdr"
                                                 },
                                                 {
-                                                  "atom": "kv"
+                                                  "kind": "symbol",
+                                                  "text": "kv"
                                                 }
                                               ]
                                             }
@@ -358,17 +471,20 @@
                                   ]
                                 },
                                 {
-                                  "atom": "pairs"
+                                  "kind": "symbol",
+                                  "text": "pairs"
                                 }
                               ]
                             },
                             {
-                              "atom": ", "
+                              "kind": "string",
+                              "text": "\", \""
                             }
                           ]
                         },
                         {
-                          "atom": "}"
+                          "kind": "string",
+                          "text": "\"}\""
                         }
                       ]
                     }
@@ -377,154 +493,126 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list?"
+                      "kind": "symbol",
+                      "text": "list?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "'"
+                      "kind": "string",
+                      "text": "\"'\""
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "'"
+                      "kind": "string",
+                      "text": "\"'\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "nation"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "n_nationkey"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "n_name"
-                        },
-                        {
-                          "atom": "BRAZIL"
-                        }
-                      ]
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -535,116 +623,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customer"
+          "kind": "symbol",
+          "text": "nation"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "c_custkey"
+                          "kind": "string",
+                          "text": "\"n_nationkey\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "c_name"
+                          "kind": "string",
+                          "text": "\"n_name\""
                         },
                         {
-                          "atom": "Alice"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "c_acctbal"
-                        },
-                        {
-                          "atom": "100.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "c_nationkey"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "c_address"
-                        },
-                        {
-                          "atom": "123 St"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "c_phone"
-                        },
-                        {
-                          "atom": "123-456"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "c_comment"
-                        },
-                        {
-                          "atom": "Loyal"
+                          "kind": "string",
+                          "text": "\"BRAZIL\""
                         }
                       ]
                     }
@@ -657,266 +697,153 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "orders"
+          "kind": "symbol",
+          "text": "customer"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "o_orderkey"
+                          "kind": "string",
+                          "text": "\"c_custkey\""
                         },
                         {
-                          "atom": "1000"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "o_custkey"
+                          "kind": "string",
+                          "text": "\"c_name\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "o_orderdate"
+                          "kind": "string",
+                          "text": "\"c_acctbal\""
                         },
                         {
-                          "atom": "1993-10-15"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "o_orderkey"
-                        },
-                        {
-                          "atom": "2000"
+                          "kind": "number",
+                          "text": "100.0"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "o_custkey"
+                          "kind": "string",
+                          "text": "\"c_nationkey\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "o_orderdate"
+                          "kind": "string",
+                          "text": "\"c_address\""
                         },
                         {
-                          "atom": "1994-01-02"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "lineitem"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_orderkey"
-                        },
-                        {
-                          "atom": "1000"
+                          "kind": "string",
+                          "text": "\"123 St\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "l_returnflag"
+                          "kind": "string",
+                          "text": "\"c_phone\""
                         },
                         {
-                          "atom": "R"
+                          "kind": "string",
+                          "text": "\"123-456\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "l_extendedprice"
+                          "kind": "string",
+                          "text": "\"c_comment\""
                         },
                         {
-                          "atom": "1000.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_discount"
-                        },
-                        {
-                          "atom": "0.1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_orderkey"
-                        },
-                        {
-                          "atom": "2000"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_returnflag"
-                        },
-                        {
-                          "atom": "N"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_extendedprice"
-                        },
-                        {
-                          "atom": "500.0"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "l_discount"
-                        },
-                        {
-                          "atom": "0.0"
+                          "kind": "string",
+                          "text": "\"Loyal\""
                         }
                       ]
                     }
@@ -929,69 +856,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "start_date"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "atom": "1993-10-01"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "end_date"
-        },
-        {
-          "atom": "1994-01-01"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "result"
-        },
-        {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
-                    {
-                      "atom": "groups3"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "make-hash-table"
-                        }
-                      ]
-                    }
-                  ]
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res6"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"o_orderkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1000"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"o_custkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"o_orderdate\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"1993-10-15\""
                         }
                       ]
                     }
@@ -1000,209 +943,638 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"o_orderkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2000"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"o_custkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"o_orderdate\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"1994-01-02\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "lineitem"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_orderkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1000"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_returnflag\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"R\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_extendedprice\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1000.0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_discount\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "0.1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_orderkey\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2000"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_returnflag\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"N\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_extendedprice\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "500.0"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"l_discount\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "0.0"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "start_date"
+        },
+        {
+          "kind": "string",
+          "text": "\"1993-10-01\""
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "end_date"
+        },
+        {
+          "kind": "string",
+          "text": "\"1994-01-01\""
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "groups3"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "make-hash-table"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res6"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "c"
+                              "kind": "symbol",
+                              "text": "c"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "o"
+                                      "kind": "symbol",
+                                      "text": "o"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "l"
+                                              "kind": "symbol",
+                                              "text": "l"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "for-each"
+                                              "kind": "symbol",
+                                              "text": "for-each"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "lambda"
+                                                  "kind": "symbol",
+                                                  "text": "lambda"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "n"
+                                                      "kind": "symbol",
+                                                      "text": "n"
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "if"
+                                                      "kind": "symbol",
+                                                      "text": "if"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "and"
+                                                          "kind": "symbol",
+                                                          "text": "and"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "and"
+                                                              "kind": "symbol",
+                                                              "text": "and"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "and"
+                                                                  "kind": "symbol",
+                                                                  "text": "and"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "and"
+                                                                      "kind": "symbol",
+                                                                      "text": "and"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "and"
+                                                                          "kind": "symbol",
+                                                                          "text": "and"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "string\u003e=?"
+                                                                              "kind": "symbol",
+                                                                              "text": "string\u003e=?"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "o"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "o"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "o_orderdate"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"o_orderdate\""
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
-                                                                              "atom": "start_date"
+                                                                              "kind": "symbol",
+                                                                              "text": "start_date"
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "string\u003c?"
+                                                                              "kind": "symbol",
+                                                                              "text": "string\u003c?"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "o"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "o"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "o_orderdate"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"o_orderdate\""
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
-                                                                              "atom": "end_date"
+                                                                              "kind": "symbol",
+                                                                              "text": "end_date"
                                                                             }
                                                                           ]
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "string=?"
+                                                                          "kind": "symbol",
+                                                                          "text": "string=?"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "l"
+                                                                              "kind": "symbol",
+                                                                              "text": "l"
                                                                             },
                                                                             {
-                                                                              "atom": "l_returnflag"
+                                                                              "kind": "string",
+                                                                              "text": "\"l_returnflag\""
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "atom": "R"
+                                                                          "kind": "string",
+                                                                          "text": "\"R\""
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "="
+                                                                      "kind": "symbol",
+                                                                      "text": "="
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "o"
+                                                                          "kind": "symbol",
+                                                                          "text": "o"
                                                                         },
                                                                         {
-                                                                          "atom": "o_custkey"
+                                                                          "kind": "string",
+                                                                          "text": "\"o_custkey\""
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "c"
+                                                                          "kind": "symbol",
+                                                                          "text": "c"
                                                                         },
                                                                         {
-                                                                          "atom": "c_custkey"
+                                                                          "kind": "string",
+                                                                          "text": "\"c_custkey\""
                                                                         }
                                                                       ]
                                                                     }
@@ -1211,33 +1583,43 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "="
+                                                                  "kind": "symbol",
+                                                                  "text": "="
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref"
                                                                     },
                                                                     {
-                                                                      "atom": "l"
+                                                                      "kind": "symbol",
+                                                                      "text": "l"
                                                                     },
                                                                     {
-                                                                      "atom": "l_orderkey"
+                                                                      "kind": "string",
+                                                                      "text": "\"l_orderkey\""
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref"
                                                                     },
                                                                     {
-                                                                      "atom": "o"
+                                                                      "kind": "symbol",
+                                                                      "text": "o"
                                                                     },
                                                                     {
-                                                                      "atom": "o_orderkey"
+                                                                      "kind": "string",
+                                                                      "text": "\"o_orderkey\""
                                                                     }
                                                                   ]
                                                                 }
@@ -1246,33 +1628,43 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "="
+                                                              "kind": "symbol",
+                                                              "text": "="
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "n"
+                                                                  "kind": "symbol",
+                                                                  "text": "n"
                                                                 },
                                                                 {
-                                                                  "atom": "n_nationkey"
+                                                                  "kind": "string",
+                                                                  "text": "\"n_nationkey\""
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "c"
+                                                                  "kind": "symbol",
+                                                                  "text": "c"
                                                                 },
                                                                 {
-                                                                  "atom": "c_nationkey"
+                                                                  "kind": "string",
+                                                                  "text": "\"c_nationkey\""
                                                                 }
                                                               ]
                                                             }
@@ -1281,183 +1673,241 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "let*"
+                                                          "kind": "symbol",
+                                                          "text": "let*"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "k5"
+                                                                  "kind": "symbol",
+                                                                  "text": "k5"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "alist-\u003ehash-table"
+                                                                      "kind": "symbol",
+                                                                      "text": "alist-\u003ehash-table"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_custkey"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_custkey\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_custkey"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_custkey\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_name"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_name\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_name"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_name\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_acctbal"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_acctbal\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_acctbal"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_acctbal\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_address"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_address\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_address"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_address\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_phone"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_phone\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_phone"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_phone\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "c_comment"
+                                                                              "kind": "string",
+                                                                              "text": "\"c_comment\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "c"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "c_comment"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"c_comment\""
                                                                                 }
                                                                               ]
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "cons"
+                                                                              "kind": "symbol",
+                                                                              "text": "cons"
                                                                             },
                                                                             {
-                                                                              "atom": "n_name"
+                                                                              "kind": "string",
+                                                                              "text": "\"n_name\""
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "n"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "n"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "n_name"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"n_name\""
                                                                                 }
                                                                               ]
                                                                             }
@@ -1470,23 +1920,26 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "g4"
+                                                                  "kind": "symbol",
+                                                                  "text": "g4"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref/default"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref/default"
                                                                     },
                                                                     {
-                                                                      "atom": "groups3"
+                                                                      "kind": "symbol",
+                                                                      "text": "groups3"
                                                                     },
                                                                     {
-                                                                      "atom": "k5"
-                                                                    },
-                                                                    {
-                                                                      "atom": "#f"
+                                                                      "kind": "symbol",
+                                                                      "text": "k5"
                                                                     }
                                                                   ]
                                                                 }
@@ -1495,73 +1948,98 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "begin"
+                                                              "kind": "symbol",
+                                                              "text": "begin"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "if"
+                                                                  "kind": "symbol",
+                                                                  "text": "if"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "not"
+                                                                      "kind": "symbol",
+                                                                      "text": "not"
                                                                     },
                                                                     {
-                                                                      "atom": "g4"
+                                                                      "kind": "symbol",
+                                                                      "text": "g4"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "begin"
+                                                                      "kind": "symbol",
+                                                                      "text": "begin"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "set!"
+                                                                          "kind": "symbol",
+                                                                          "text": "set!"
                                                                         },
                                                                         {
-                                                                          "atom": "g4"
+                                                                          "kind": "symbol",
+                                                                          "text": "g4"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "alist-\u003ehash-table"
+                                                                              "kind": "symbol",
+                                                                              "text": "alist-\u003ehash-table"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "list"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "list"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "key"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"key\""
                                                                                     },
                                                                                     {
-                                                                                      "atom": "k5"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "k5"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "items"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"items\""
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "list"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "list"
                                                                                         }
                                                                                       ]
                                                                                     }
@@ -1574,128 +2052,168 @@
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-set!"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-set!"
                                                                         },
                                                                         {
-                                                                          "atom": "groups3"
+                                                                          "kind": "symbol",
+                                                                          "text": "groups3"
                                                                         },
                                                                         {
-                                                                          "atom": "k5"
+                                                                          "kind": "symbol",
+                                                                          "text": "k5"
                                                                         },
                                                                         {
-                                                                          "atom": "g4"
+                                                                          "kind": "symbol",
+                                                                          "text": "g4"
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "quote"
+                                                                      "kind": "symbol",
+                                                                      "text": "quote"
                                                                     },
                                                                     {
-                                                                      "atom": "nil"
+                                                                      "kind": "symbol",
+                                                                      "text": "nil"
                                                                     }
                                                                   ]
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-set!"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-set!"
                                                                 },
                                                                 {
-                                                                  "atom": "g4"
+                                                                  "kind": "symbol",
+                                                                  "text": "g4"
                                                                 },
                                                                 {
-                                                                  "atom": "items"
+                                                                  "kind": "string",
+                                                                  "text": "\"items\""
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "append"
+                                                                      "kind": "symbol",
+                                                                      "text": "append"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "g4"
+                                                                          "kind": "symbol",
+                                                                          "text": "g4"
                                                                         },
                                                                         {
-                                                                          "atom": "items"
+                                                                          "kind": "string",
+                                                                          "text": "\"items\""
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "list"
+                                                                          "kind": "symbol",
+                                                                          "text": "list"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "alist-\u003ehash-table"
+                                                                              "kind": "symbol",
+                                                                              "text": "alist-\u003ehash-table"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "list"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "list"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "c"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"c\""
                                                                                     },
                                                                                     {
-                                                                                      "atom": "c"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "c"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "o"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"o\""
                                                                                     },
                                                                                     {
-                                                                                      "atom": "o"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "o"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "l"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"l\""
                                                                                     },
                                                                                     {
-                                                                                      "atom": "l"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "l"
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "cons"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "cons"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "n"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"n\""
                                                                                     },
                                                                                     {
-                                                                                      "atom": "n"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "n"
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -1714,12 +2232,15 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "quote"
+                                                          "kind": "symbol",
+                                                          "text": "quote"
                                                         },
                                                         {
-                                                          "atom": "nil"
+                                                          "kind": "symbol",
+                                                          "text": "nil"
                                                         }
                                                       ]
                                                     }
@@ -1728,172 +2249,225 @@
                                               ]
                                             },
                                             {
-                                              "atom": "nation"
+                                              "kind": "symbol",
+                                              "text": "nation"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "atom": "lineitem"
+                                      "kind": "symbol",
+                                      "text": "lineitem"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "atom": "orders"
+                              "kind": "symbol",
+                              "text": "orders"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "customer"
+                      "kind": "symbol",
+                      "text": "customer"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res6"
+                              "kind": "symbol",
+                              "text": "res6"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res6"
+                                  "kind": "symbol",
+                                  "text": "res6"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "list"
+                                          "kind": "symbol",
+                                          "text": "list"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_custkey"
+                                              "kind": "string",
+                                              "text": "\"c_custkey\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_custkey"
+                                                  "kind": "string",
+                                                  "text": "\"c_custkey\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_name"
+                                              "kind": "string",
+                                              "text": "\"c_name\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_name"
+                                                  "kind": "string",
+                                                  "text": "\"c_name\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "revenue"
+                                              "kind": "string",
+                                              "text": "\"revenue\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "apply"
+                                                  "kind": "symbol",
+                                                  "text": "apply"
                                                 },
                                                 {
-                                                  "atom": "+"
+                                                  "kind": "symbol",
+                                                  "text": "+"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "let"
+                                                      "kind": "symbol",
+                                                      "text": "let"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "res1"
+                                                              "kind": "symbol",
+                                                              "text": "res1"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 }
                                                               ]
                                                             }
@@ -1902,104 +2476,139 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "begin"
+                                                          "kind": "symbol",
+                                                          "text": "begin"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "for-each"
+                                                              "kind": "symbol",
+                                                              "text": "for-each"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "lambda"
+                                                                  "kind": "symbol",
+                                                                  "text": "lambda"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "x"
+                                                                      "kind": "symbol",
+                                                                      "text": "x"
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "set!"
+                                                                      "kind": "symbol",
+                                                                      "text": "set!"
                                                                     },
                                                                     {
-                                                                      "atom": "res1"
+                                                                      "kind": "symbol",
+                                                                      "text": "res1"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "append"
+                                                                          "kind": "symbol",
+                                                                          "text": "append"
                                                                         },
                                                                         {
-                                                                          "atom": "res1"
+                                                                          "kind": "symbol",
+                                                                          "text": "res1"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "list"
+                                                                              "kind": "symbol",
+                                                                              "text": "list"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "*"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "*"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "hash-table-ref"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "hash-table-ref"
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "hash-table-ref"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "hash-table-ref"
                                                                                         },
                                                                                         {
-                                                                                          "atom": "x"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "x"
                                                                                         },
                                                                                         {
-                                                                                          "atom": "l"
+                                                                                          "kind": "string",
+                                                                                          "text": "\"l\""
                                                                                         }
                                                                                       ]
                                                                                     },
                                                                                     {
-                                                                                      "atom": "l_extendedprice"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"l_extendedprice\""
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "-"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "-"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "1"
+                                                                                      "kind": "number",
+                                                                                      "text": "1"
                                                                                     },
                                                                                     {
-                                                                                      "list": [
+                                                                                      "kind": "list",
+                                                                                      "children": [
                                                                                         {
-                                                                                          "atom": "hash-table-ref"
+                                                                                          "kind": "symbol",
+                                                                                          "text": "hash-table-ref"
                                                                                         },
                                                                                         {
-                                                                                          "list": [
+                                                                                          "kind": "list",
+                                                                                          "children": [
                                                                                             {
-                                                                                              "atom": "hash-table-ref"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "hash-table-ref"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "x"
+                                                                                              "kind": "symbol",
+                                                                                              "text": "x"
                                                                                             },
                                                                                             {
-                                                                                              "atom": "l"
+                                                                                              "kind": "string",
+                                                                                              "text": "\"l\""
                                                                                             }
                                                                                           ]
                                                                                         },
                                                                                         {
-                                                                                          "atom": "l_discount"
+                                                                                          "kind": "string",
+                                                                                          "text": "\"l_discount\""
                                                                                         }
                                                                                       ]
                                                                                     }
@@ -2016,22 +2625,27 @@
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "g"
+                                                                  "kind": "symbol",
+                                                                  "text": "g"
                                                                 },
                                                                 {
-                                                                  "atom": "items"
+                                                                  "kind": "string",
+                                                                  "text": "\"items\""
                                                                 }
                                                               ]
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "atom": "res1"
+                                                          "kind": "symbol",
+                                                          "text": "res1"
                                                         }
                                                       ]
                                                     }
@@ -2042,165 +2656,215 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_acctbal"
+                                              "kind": "string",
+                                              "text": "\"c_acctbal\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_acctbal"
+                                                  "kind": "string",
+                                                  "text": "\"c_acctbal\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "n_name"
+                                              "kind": "string",
+                                              "text": "\"n_name\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "n_name"
+                                                  "kind": "string",
+                                                  "text": "\"n_name\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_address"
+                                              "kind": "string",
+                                              "text": "\"c_address\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_address"
+                                                  "kind": "string",
+                                                  "text": "\"c_address\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_phone"
+                                              "kind": "string",
+                                              "text": "\"c_phone\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_phone"
+                                                  "kind": "string",
+                                                  "text": "\"c_phone\""
                                                 }
                                               ]
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cons"
+                                              "kind": "symbol",
+                                              "text": "cons"
                                             },
                                             {
-                                              "atom": "c_comment"
+                                              "kind": "string",
+                                              "text": "\"c_comment\""
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "hash-table-ref"
+                                                  "kind": "symbol",
+                                                  "text": "hash-table-ref"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "c_comment"
+                                                  "kind": "string",
+                                                  "text": "\"c_comment\""
                                                 }
                                               ]
                                             }
@@ -2217,79 +2881,106 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups3"
+                          "kind": "symbol",
+                          "text": "groups3"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "set!"
+                      "kind": "symbol",
+                      "text": "set!"
                     },
                     {
-                      "atom": "res6"
+                      "kind": "symbol",
+                      "text": "res6"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list-sort"
+                          "kind": "symbol",
+                          "text": "list-sort"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "lambda"
+                              "kind": "symbol",
+                              "text": "lambda"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "a7"
+                                  "kind": "symbol",
+                                  "text": "a7"
                                 },
                                 {
-                                  "atom": "b8"
+                                  "kind": "symbol",
+                                  "text": "b8"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "\u003c"
+                                  "kind": "symbol",
+                                  "text": "\u003c"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "-"
+                                      "kind": "symbol",
+                                      "text": "-"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "apply"
+                                          "kind": "symbol",
+                                          "text": "apply"
                                         },
                                         {
-                                          "atom": "+"
+                                          "kind": "symbol",
+                                          "text": "+"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "let"
+                                              "kind": "symbol",
+                                              "text": "let"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "res2"
+                                                      "kind": "symbol",
+                                                      "text": "res2"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         }
                                                       ]
                                                     }
@@ -2298,104 +2989,139 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "begin"
+                                                  "kind": "symbol",
+                                                  "text": "begin"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "for-each"
+                                                      "kind": "symbol",
+                                                      "text": "for-each"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "lambda"
+                                                          "kind": "symbol",
+                                                          "text": "lambda"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "x"
+                                                              "kind": "symbol",
+                                                              "text": "x"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "set!"
+                                                              "kind": "symbol",
+                                                              "text": "set!"
                                                             },
                                                             {
-                                                              "atom": "res2"
+                                                              "kind": "symbol",
+                                                              "text": "res2"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "append"
+                                                                  "kind": "symbol",
+                                                                  "text": "append"
                                                                 },
                                                                 {
-                                                                  "atom": "res2"
+                                                                  "kind": "symbol",
+                                                                  "text": "res2"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "*"
+                                                                          "kind": "symbol",
+                                                                          "text": "*"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "x"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "x"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "l"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"l\""
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
-                                                                              "atom": "l_extendedprice"
+                                                                              "kind": "string",
+                                                                              "text": "\"l_extendedprice\""
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "-"
+                                                                              "kind": "symbol",
+                                                                              "text": "-"
                                                                             },
                                                                             {
-                                                                              "atom": "1"
+                                                                              "kind": "number",
+                                                                              "text": "1"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "hash-table-ref"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "hash-table-ref"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "x"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "x"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "l"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"l\""
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "atom": "l_discount"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"l_discount\""
                                                                                 }
                                                                               ]
                                                                             }
@@ -2412,22 +3138,27 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "a7"
+                                                          "kind": "symbol",
+                                                          "text": "a7"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "res2"
+                                                  "kind": "symbol",
+                                                  "text": "res2"
                                                 }
                                               ]
                                             }
@@ -2438,34 +3169,46 @@
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "-"
+                                      "kind": "symbol",
+                                      "text": "-"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "apply"
+                                          "kind": "symbol",
+                                          "text": "apply"
                                         },
                                         {
-                                          "atom": "+"
+                                          "kind": "symbol",
+                                          "text": "+"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "let"
+                                              "kind": "symbol",
+                                              "text": "let"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "res2"
+                                                      "kind": "symbol",
+                                                      "text": "res2"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         }
                                                       ]
                                                     }
@@ -2474,104 +3217,139 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "begin"
+                                                  "kind": "symbol",
+                                                  "text": "begin"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "for-each"
+                                                      "kind": "symbol",
+                                                      "text": "for-each"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "lambda"
+                                                          "kind": "symbol",
+                                                          "text": "lambda"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "x"
+                                                              "kind": "symbol",
+                                                              "text": "x"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "set!"
+                                                              "kind": "symbol",
+                                                              "text": "set!"
                                                             },
                                                             {
-                                                              "atom": "res2"
+                                                              "kind": "symbol",
+                                                              "text": "res2"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "append"
+                                                                  "kind": "symbol",
+                                                                  "text": "append"
                                                                 },
                                                                 {
-                                                                  "atom": "res2"
+                                                                  "kind": "symbol",
+                                                                  "text": "res2"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "*"
+                                                                          "kind": "symbol",
+                                                                          "text": "*"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "x"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "x"
                                                                                 },
                                                                                 {
-                                                                                  "atom": "l"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"l\""
                                                                                 }
                                                                               ]
                                                                             },
                                                                             {
-                                                                              "atom": "l_extendedprice"
+                                                                              "kind": "string",
+                                                                              "text": "\"l_extendedprice\""
                                                                             }
                                                                           ]
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "-"
+                                                                              "kind": "symbol",
+                                                                              "text": "-"
                                                                             },
                                                                             {
-                                                                              "atom": "1"
+                                                                              "kind": "number",
+                                                                              "text": "1"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "hash-table-ref"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "hash-table-ref"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "hash-table-ref"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "hash-table-ref"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "x"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "x"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "l"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"l\""
                                                                                     }
                                                                                   ]
                                                                                 },
                                                                                 {
-                                                                                  "atom": "l_discount"
+                                                                                  "kind": "string",
+                                                                                  "text": "\"l_discount\""
                                                                                 }
                                                                               ]
                                                                             }
@@ -2588,22 +3366,27 @@
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "b8"
+                                                          "kind": "symbol",
+                                                          "text": "b8"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "atom": "res2"
+                                                  "kind": "symbol",
+                                                  "text": "res2"
                                                 }
                                               ]
                                             }
@@ -2618,14 +3401,16 @@
                           ]
                         },
                         {
-                          "atom": "res6"
+                          "kind": "symbol",
+                          "text": "res6"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res6"
+                  "kind": "symbol",
+                  "text": "res6"
                 }
               ]
             }
@@ -2634,26 +3419,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "result"
+              "kind": "symbol",
+              "text": "result"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_by_sort.scheme.json
+++ b/tests/json-ast/x/scheme/group_by_sort.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "items"
+          "kind": "symbol",
+          "text": "items"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "5"
+                          "kind": "number",
+                          "text": "5"
                         }
                       ]
                     }
@@ -171,38 +227,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "cat"
+                          "kind": "string",
+                          "text": "\"cat\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -215,29 +283,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "grouped"
+          "kind": "symbol",
+          "text": "grouped"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res29"
+                      "kind": "symbol",
+                      "text": "res29"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -246,113 +324,153 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "i"
+                              "kind": "symbol",
+                              "text": "i"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res29"
+                              "kind": "symbol",
+                              "text": "res29"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res29"
+                                  "kind": "symbol",
+                                  "text": "res29"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "alist-\u003ehash-table"
+                                          "kind": "symbol",
+                                          "text": "alist-\u003ehash-table"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "cat"
+                                                  "kind": "string",
+                                                  "text": "\"cat\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "g"
+                                                      "kind": "symbol",
+                                                      "text": "g"
                                                     },
                                                     {
-                                                      "atom": "key"
+                                                      "kind": "string",
+                                                      "text": "\"key\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cons"
+                                                  "kind": "symbol",
+                                                  "text": "cons"
                                                 },
                                                 {
-                                                  "atom": "total"
+                                                  "kind": "string",
+                                                  "text": "\"total\""
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "apply"
+                                                      "kind": "symbol",
+                                                      "text": "apply"
                                                     },
                                                     {
-                                                      "atom": "+"
+                                                      "kind": "symbol",
+                                                      "text": "+"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "let"
+                                                          "kind": "symbol",
+                                                          "text": "let"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "res28"
+                                                                  "kind": "symbol",
+                                                                  "text": "res28"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     }
                                                                   ]
                                                                 }
@@ -361,58 +479,78 @@
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "begin"
+                                                              "kind": "symbol",
+                                                              "text": "begin"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "for-each"
+                                                                  "kind": "symbol",
+                                                                  "text": "for-each"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "lambda"
+                                                                      "kind": "symbol",
+                                                                      "text": "lambda"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "x"
+                                                                          "kind": "symbol",
+                                                                          "text": "x"
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "set!"
+                                                                          "kind": "symbol",
+                                                                          "text": "set!"
                                                                         },
                                                                         {
-                                                                          "atom": "res28"
+                                                                          "kind": "symbol",
+                                                                          "text": "res28"
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "append"
+                                                                              "kind": "symbol",
+                                                                              "text": "append"
                                                                             },
                                                                             {
-                                                                              "atom": "res28"
+                                                                              "kind": "symbol",
+                                                                              "text": "res28"
                                                                             },
                                                                             {
-                                                                              "list": [
+                                                                              "kind": "list",
+                                                                              "children": [
                                                                                 {
-                                                                                  "atom": "list"
+                                                                                  "kind": "symbol",
+                                                                                  "text": "list"
                                                                                 },
                                                                                 {
-                                                                                  "list": [
+                                                                                  "kind": "list",
+                                                                                  "children": [
                                                                                     {
-                                                                                      "atom": "hash-table-ref"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "hash-table-ref"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "x"
+                                                                                      "kind": "symbol",
+                                                                                      "text": "x"
                                                                                     },
                                                                                     {
-                                                                                      "atom": "val"
+                                                                                      "kind": "string",
+                                                                                      "text": "\"val\""
                                                                                     }
                                                                                   ]
                                                                                 }
@@ -425,12 +563,14 @@
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "atom": "g"
+                                                                  "kind": "string",
+                                                                  "text": "\"g\""
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "atom": "res28"
+                                                              "kind": "symbol",
+                                                              "text": "res28"
                                                             }
                                                           ]
                                                         }
@@ -453,12 +593,14 @@
                       ]
                     },
                     {
-                      "atom": "items"
+                      "kind": "symbol",
+                      "text": "items"
                     }
                   ]
                 },
                 {
-                  "atom": "res29"
+                  "kind": "symbol",
+                  "text": "res29"
                 }
               ]
             }
@@ -467,19 +609,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "grouped"
+          "kind": "symbol",
+          "text": "grouped"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/group_items_iteration.scheme.json
+++ b/tests/json-ast/x/scheme/group_items_iteration.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "data"
+          "kind": "symbol",
+          "text": "data"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "tag"
+                          "kind": "string",
+                          "text": "\"tag\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "tag"
+                          "kind": "string",
+                          "text": "\"tag\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "tag"
+                          "kind": "string",
+                          "text": "\"tag\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "val"
+                          "kind": "string",
+                          "text": "\"val\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     }
@@ -175,43 +231,57 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "groups"
+          "kind": "symbol",
+          "text": "groups"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "groups30"
+                      "kind": "symbol",
+                      "text": "groups30"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "make-hash-table"
+                          "kind": "symbol",
+                          "text": "make-hash-table"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res33"
+                      "kind": "symbol",
+                      "text": "res33"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -220,72 +290,92 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "d"
+                              "kind": "symbol",
+                              "text": "d"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "let*"
+                              "kind": "symbol",
+                              "text": "let*"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "k32"
+                                      "kind": "symbol",
+                                      "text": "k32"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "atom": "d"
+                                          "kind": "symbol",
+                                          "text": "d"
                                         },
                                         {
-                                          "atom": "tag"
+                                          "kind": "string",
+                                          "text": "\"tag\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "g31"
+                                      "kind": "symbol",
+                                      "text": "g31"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref/default"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref/default"
                                         },
                                         {
-                                          "atom": "groups30"
+                                          "kind": "symbol",
+                                          "text": "groups30"
                                         },
                                         {
-                                          "atom": "k32"
-                                        },
-                                        {
-                                          "atom": "#f"
+                                          "kind": "symbol",
+                                          "text": "k32"
                                         }
                                       ]
                                     }
@@ -294,73 +384,98 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "not"
+                                          "kind": "symbol",
+                                          "text": "not"
                                         },
                                         {
-                                          "atom": "g31"
+                                          "kind": "symbol",
+                                          "text": "g31"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "begin"
+                                          "kind": "symbol",
+                                          "text": "begin"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "set!"
+                                              "kind": "symbol",
+                                              "text": "set!"
                                             },
                                             {
-                                              "atom": "g31"
+                                              "kind": "symbol",
+                                              "text": "g31"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "alist-\u003ehash-table"
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "key"
+                                                          "kind": "string",
+                                                          "text": "\"key\""
                                                         },
                                                         {
-                                                          "atom": "k32"
+                                                          "kind": "symbol",
+                                                          "text": "k32"
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "items"
+                                                          "kind": "string",
+                                                          "text": "\"items\""
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             }
                                                           ]
                                                         }
@@ -373,89 +488,117 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-set!"
+                                              "kind": "symbol",
+                                              "text": "hash-table-set!"
                                             },
                                             {
-                                              "atom": "groups30"
+                                              "kind": "symbol",
+                                              "text": "groups30"
                                             },
                                             {
-                                              "atom": "k32"
+                                              "kind": "symbol",
+                                              "text": "k32"
                                             },
                                             {
-                                              "atom": "g31"
+                                              "kind": "symbol",
+                                              "text": "g31"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-set!"
+                                      "kind": "symbol",
+                                      "text": "hash-table-set!"
                                     },
                                     {
-                                      "atom": "g31"
+                                      "kind": "symbol",
+                                      "text": "g31"
                                     },
                                     {
-                                      "atom": "items"
+                                      "kind": "string",
+                                      "text": "\"items\""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "append"
+                                          "kind": "symbol",
+                                          "text": "append"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "g31"
+                                              "kind": "symbol",
+                                              "text": "g31"
                                             },
                                             {
-                                              "atom": "items"
+                                              "kind": "string",
+                                              "text": "\"items\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "list"
+                                              "kind": "symbol",
+                                              "text": "list"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "alist-\u003ehash-table"
+                                                  "kind": "symbol",
+                                                  "text": "alist-\u003ehash-table"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "cons"
+                                                          "kind": "symbol",
+                                                          "text": "cons"
                                                         },
                                                         {
-                                                          "atom": "d"
+                                                          "kind": "string",
+                                                          "text": "\"d\""
                                                         },
                                                         {
-                                                          "atom": "d"
+                                                          "kind": "symbol",
+                                                          "text": "d"
                                                         }
                                                       ]
                                                     }
@@ -476,50 +619,66 @@
                       ]
                     },
                     {
-                      "atom": "data"
+                      "kind": "symbol",
+                      "text": "data"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "g"
+                              "kind": "symbol",
+                              "text": "g"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res33"
+                              "kind": "symbol",
+                              "text": "res33"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res33"
+                                  "kind": "symbol",
+                                  "text": "res33"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "atom": "g"
+                                      "kind": "symbol",
+                                      "text": "g"
                                     }
                                   ]
                                 }
@@ -530,19 +689,23 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-values"
+                          "kind": "symbol",
+                          "text": "hash-table-values"
                         },
                         {
-                          "atom": "groups30"
+                          "kind": "symbol",
+                          "text": "groups30"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "res33"
+                  "kind": "symbol",
+                  "text": "res33"
                 }
               ]
             }
@@ -551,105 +714,140 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "tmp"
+          "kind": "symbol",
+          "text": "tmp"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "g"
+                  "kind": "symbol",
+                  "text": "g"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "define"
+                      "kind": "symbol",
+                      "text": "define"
                     },
                     {
-                      "atom": "total"
+                      "kind": "symbol",
+                      "text": "total"
                     },
                     {
-                      "atom": "0"
+                      "kind": "number",
+                      "text": "0"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "begin"
+                              "kind": "symbol",
+                              "text": "begin"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "set!"
+                                  "kind": "symbol",
+                                  "text": "set!"
                                 },
                                 {
-                                  "atom": "total"
+                                  "kind": "symbol",
+                                  "text": "total"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "string-append"
+                                      "kind": "symbol",
+                                      "text": "string-append"
                                     },
                                     {
-                                      "atom": "total"
+                                      "kind": "string",
+                                      "text": "\"total\""
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "atom": "x"
+                                          "kind": "symbol",
+                                          "text": "x"
                                         },
                                         {
-                                          "atom": "val"
+                                          "kind": "string",
+                                          "text": "\"val\""
                                         }
                                       ]
                                     }
@@ -662,84 +860,111 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "g"
+                          "kind": "symbol",
+                          "text": "g"
                         },
                         {
-                          "atom": "items"
+                          "kind": "string",
+                          "text": "\"items\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "set!"
+                      "kind": "symbol",
+                      "text": "set!"
                     },
                     {
-                      "atom": "tmp"
+                      "kind": "symbol",
+                      "text": "tmp"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "append"
+                          "kind": "symbol",
+                          "text": "append"
                         },
                         {
-                          "atom": "tmp"
+                          "kind": "symbol",
+                          "text": "tmp"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "list"
+                              "kind": "symbol",
+                              "text": "list"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "alist-\u003ehash-table"
+                                  "kind": "symbol",
+                                  "text": "alist-\u003ehash-table"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "cons"
+                                          "kind": "symbol",
+                                          "text": "cons"
                                         },
                                         {
-                                          "atom": "tag"
+                                          "kind": "string",
+                                          "text": "\"tag\""
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "g"
+                                              "kind": "symbol",
+                                              "text": "g"
                                             },
                                             {
-                                              "atom": "key"
+                                              "kind": "string",
+                                              "text": "\"key\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "cons"
+                                          "kind": "symbol",
+                                          "text": "cons"
                                         },
                                         {
-                                          "atom": "total"
+                                          "kind": "string",
+                                          "text": "\"total\""
                                         },
                                         {
-                                          "atom": "total"
+                                          "kind": "string",
+                                          "text": "\"total\""
                                         }
                                       ]
                                     }
@@ -758,34 +983,45 @@
           ]
         },
         {
-          "atom": "groups"
+          "kind": "symbol",
+          "text": "groups"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res34"
+                      "kind": "symbol",
+                      "text": "res34"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -794,50 +1030,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "r"
+                              "kind": "symbol",
+                              "text": "r"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res34"
+                              "kind": "symbol",
+                              "text": "res34"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res34"
+                                  "kind": "symbol",
+                                  "text": "res34"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "atom": "r"
+                                      "kind": "symbol",
+                                      "text": "r"
                                     }
                                   ]
                                 }
@@ -848,12 +1101,14 @@
                       ]
                     },
                     {
-                      "atom": "tmp"
+                      "kind": "symbol",
+                      "text": "tmp"
                     }
                   ]
                 },
                 {
-                  "atom": "res34"
+                  "kind": "symbol",
+                  "text": "res34"
                 }
               ]
             }
@@ -862,19 +1117,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/if_else.scheme.json
+++ b/tests/json-ast/x/scheme/if_else.scheme.json
@@ -1,116 +1,155 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "5"
+          "kind": "number",
+          "text": "5"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "if"
+          "kind": "symbol",
+          "text": "if"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "\u003e"
+              "kind": "symbol",
+              "text": "\u003e"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "display"
+                  "kind": "symbol",
+                  "text": "display"
                 },
                 {
-                  "atom": "big"
+                  "kind": "string",
+                  "text": "\"big\""
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "newline"
+                  "kind": "symbol",
+                  "text": "newline"
                 }
               ]
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "display"
+                  "kind": "symbol",
+                  "text": "display"
                 },
                 {
-                  "atom": "small"
+                  "kind": "string",
+                  "text": "\"small\""
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "newline"
+                  "kind": "symbol",
+                  "text": "newline"
                 }
               ]
             }

--- a/tests/json-ast/x/scheme/if_then_else.scheme.json
+++ b/tests/json-ast/x/scheme/if_then_else.scheme.json
@@ -1,105 +1,140 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "12"
+          "kind": "number",
+          "text": "12"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "msg"
+          "kind": "symbol",
+          "text": "msg"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "\u003e"
+                  "kind": "symbol",
+                  "text": "\u003e"
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 },
                 {
-                  "atom": "10"
+                  "kind": "number",
+                  "text": "10"
                 }
               ]
             },
             {
-              "atom": "yes"
+              "kind": "string",
+              "text": "\"yes\""
             },
             {
-              "atom": "no"
+              "kind": "string",
+              "text": "\"no\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "msg"
+          "kind": "symbol",
+          "text": "msg"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/if_then_else_nested.scheme.json
+++ b/tests/json-ast/x/scheme/if_then_else_nested.scheme.json
@@ -1,107 +1,144 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "8"
+          "kind": "number",
+          "text": "8"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "msg"
+          "kind": "symbol",
+          "text": "msg"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "\u003e"
+                  "kind": "symbol",
+                  "text": "\u003e"
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 },
                 {
-                  "atom": "10"
+                  "kind": "number",
+                  "text": "10"
                 }
               ]
             },
             {
-              "atom": "big"
+              "kind": "string",
+              "text": "\"big\""
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "\u003e"
+                      "kind": "symbol",
+                      "text": "\u003e"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "5"
+                      "kind": "number",
+                      "text": "5"
                     }
                   ]
                 },
                 {
-                  "atom": "medium"
+                  "kind": "string",
+                  "text": "\"medium\""
                 },
                 {
-                  "atom": "small"
+                  "kind": "string",
+                  "text": "\"small\""
                 }
               ]
             }
@@ -110,19 +147,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "msg"
+          "kind": "symbol",
+          "text": "msg"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/in_operator.scheme.json
+++ b/tests/json-ast/x/scheme/in_operator.scheme.json
@@ -1,345 +1,254 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "xs"
+          "kind": "symbol",
+          "text": "xs"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "xs"
+                          "kind": "symbol",
+                          "text": "xs"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "xs"
+                              "kind": "symbol",
+                              "text": "xs"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "xs"
+                          "kind": "symbol",
+                          "text": "xs"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "xs"
+                              "kind": "symbol",
+                              "text": "xs"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             },
                             {
-                              "atom": "xs"
+                              "kind": "symbol",
+                              "text": "xs"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "atom": "1"
-            },
-            {
-              "atom": "0"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "newline"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "if"
-            },
-            {
-              "list": [
-                {
-                  "atom": "not"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "cond"
-                    },
-                    {
-                      "list": [
-                        {
-                          "list": [
-                            {
-                              "atom": "string?"
-                            },
-                            {
-                              "atom": "xs"
-                            }
-                          ]
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "if"
-                            },
-                            {
-                              "list": [
-                                {
-                                  "atom": "string-contains"
-                                },
-                                {
-                                  "atom": "xs"
-                                },
-                                {
-                                  "atom": "5"
-                                }
-                              ]
-                            },
-                            {
-                              "atom": "true"
-                            },
-                            {
-                              "atom": "false"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "list": [
-                            {
-                              "atom": "hash-table?"
-                            },
-                            {
-                              "atom": "xs"
-                            }
-                          ]
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "if"
-                            },
-                            {
-                              "list": [
-                                {
-                                  "atom": "hash-table-exists?"
-                                },
-                                {
-                                  "atom": "xs"
-                                },
-                                {
-                                  "atom": "5"
-                                }
-                              ]
-                            },
-                            {
-                              "atom": "true"
-                            },
-                            {
-                              "atom": "false"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "else"
-                        },
-                        {
-                          "list": [
-                            {
-                              "atom": "if"
-                            },
-                            {
-                              "list": [
-                                {
-                                  "atom": "member"
-                                },
-                                {
-                                  "atom": "5"
-                                },
-                                {
-                                  "atom": "xs"
-                                }
-                              ]
-                            },
-                            {
-                              "atom": "true"
-                            },
-                            {
-                              "atom": "false"
-                            }
-                          ]
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -348,19 +257,223 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "if"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "not"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "cond"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "string?"
+                            },
+                            {
+                              "kind": "symbol",
+                              "text": "xs"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "if"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "string-contains"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "xs"
+                                },
+                                {
+                                  "kind": "number",
+                                  "text": "5"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"true\""
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"false\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "hash-table?"
+                            },
+                            {
+                              "kind": "symbol",
+                              "text": "xs"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "if"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "hash-table-exists?"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "xs"
+                                },
+                                {
+                                  "kind": "number",
+                                  "text": "5"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"true\""
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"false\""
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "else"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
+                            {
+                              "kind": "symbol",
+                              "text": "if"
+                            },
+                            {
+                              "kind": "list",
+                              "children": [
+                                {
+                                  "kind": "symbol",
+                                  "text": "member"
+                                },
+                                {
+                                  "kind": "number",
+                                  "text": "5"
+                                },
+                                {
+                                  "kind": "symbol",
+                                  "text": "xs"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"true\""
+                            },
+                            {
+                              "kind": "string",
+                              "text": "\"false\""
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "number",
+              "text": "1"
+            },
+            {
+              "kind": "number",
+              "text": "0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/in_operator_extended.scheme.json
+++ b/tests/json-ast/x/scheme/in_operator_extended.scheme.json
@@ -1,92 +1,125 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "xs"
+          "kind": "symbol",
+          "text": "xs"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "ys"
+          "kind": "symbol",
+          "text": "ys"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res35"
+                      "kind": "symbol",
+                      "text": "res35"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -95,78 +128,104 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "if"
+                              "kind": "symbol",
+                              "text": "if"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "="
+                                  "kind": "symbol",
+                                  "text": "="
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "modulo"
+                                      "kind": "symbol",
+                                      "text": "modulo"
                                     },
                                     {
-                                      "atom": "x"
+                                      "kind": "symbol",
+                                      "text": "x"
                                     },
                                     {
-                                      "atom": "2"
+                                      "kind": "number",
+                                      "text": "2"
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "1"
+                                  "kind": "number",
+                                  "text": "1"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "set!"
+                                  "kind": "symbol",
+                                  "text": "set!"
                                 },
                                 {
-                                  "atom": "res35"
+                                  "kind": "symbol",
+                                  "text": "res35"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "append"
+                                      "kind": "symbol",
+                                      "text": "append"
                                     },
                                     {
-                                      "atom": "res35"
+                                      "kind": "symbol",
+                                      "text": "res35"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "list"
+                                          "kind": "symbol",
+                                          "text": "list"
                                         },
                                         {
-                                          "atom": "x"
+                                          "kind": "symbol",
+                                          "text": "x"
                                         }
                                       ]
                                     }
@@ -175,12 +234,15 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "quote"
+                                  "kind": "symbol",
+                                  "text": "quote"
                                 },
                                 {
-                                  "atom": "nil"
+                                  "kind": "symbol",
+                                  "text": "nil"
                                 }
                               ]
                             }
@@ -189,12 +251,14 @@
                       ]
                     },
                     {
-                      "atom": "xs"
+                      "kind": "symbol",
+                      "text": "xs"
                     }
                   ]
                 },
                 {
-                  "atom": "res35"
+                  "kind": "symbol",
+                  "text": "res35"
                 }
               ]
             }
@@ -203,128 +267,168 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "ys"
+                          "kind": "symbol",
+                          "text": "ys"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "ys"
+                          "kind": "symbol",
+                          "text": "ys"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -333,145 +437,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "ys"
+                          "kind": "symbol",
+                          "text": "ys"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "ys"
+                          "kind": "symbol",
+                          "text": "ys"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             },
                             {
-                              "atom": "ys"
+                              "kind": "symbol",
+                              "text": "ys"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -480,50 +628,65 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 }
@@ -534,128 +697,168 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -664,145 +867,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "b"
+                              "kind": "string",
+                              "text": "\"b\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "b"
+                              "kind": "string",
+                              "text": "\"b\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "b"
+                              "kind": "string",
+                              "text": "\"b\""
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -811,158 +1058,206 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s"
+          "kind": "symbol",
+          "text": "s"
         },
         {
-          "atom": "hello"
+          "kind": "string",
+          "text": "\"hello\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "ell"
+                              "kind": "string",
+                              "text": "\"ell\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "ell"
+                              "kind": "string",
+                              "text": "\"ell\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "ell"
+                              "kind": "string",
+                              "text": "\"ell\""
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -971,145 +1266,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "foo"
+                              "kind": "string",
+                              "text": "\"foo\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "foo"
+                              "kind": "string",
+                              "text": "\"foo\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "foo"
+                              "kind": "string",
+                              "text": "\"foo\""
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -1118,19 +1457,23 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/inner_join.scheme.json
+++ b/tests/json-ast/x/scheme/inner_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -131,267 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "250"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "125"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "102"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "300"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "103"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "4"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "80"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     }
@@ -404,29 +231,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res36"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "250"
                         }
                       ]
                     }
@@ -435,177 +318,488 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "125"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "102"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "300"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "103"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "4"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "80"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res36"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "o"
+                                              "kind": "symbol",
+                                              "text": "o"
                                             },
                                             {
-                                              "atom": "customerId"
+                                              "kind": "string",
+                                              "text": "\"customerId\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             },
                                             {
-                                              "atom": "id"
+                                              "kind": "string",
+                                              "text": "\"id\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "res36"
+                                          "kind": "symbol",
+                                          "text": "res36"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "append"
+                                              "kind": "symbol",
+                                              "text": "append"
                                             },
                                             {
-                                              "atom": "res36"
+                                              "kind": "symbol",
+                                              "text": "res36"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "alist-\u003ehash-table"
+                                                      "kind": "symbol",
+                                                      "text": "alist-\u003ehash-table"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "orderId"
+                                                              "kind": "string",
+                                                              "text": "\"orderId\""
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "o"
+                                                                  "kind": "symbol",
+                                                                  "text": "o"
                                                                 },
                                                                 {
-                                                                  "atom": "id"
+                                                                  "kind": "string",
+                                                                  "text": "\"id\""
                                                                 }
                                                               ]
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "customerName"
+                                                              "kind": "string",
+                                                              "text": "\"customerName\""
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "c"
+                                                                  "kind": "symbol",
+                                                                  "text": "c"
                                                                 },
                                                                 {
-                                                                  "atom": "name"
+                                                                  "kind": "string",
+                                                                  "text": "\"name\""
                                                                 }
                                                               ]
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "total"
+                                                              "kind": "string",
+                                                              "text": "\"total\""
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "o"
+                                                                  "kind": "symbol",
+                                                                  "text": "o"
                                                                 },
                                                                 {
-                                                                  "atom": "total"
+                                                                  "kind": "string",
+                                                                  "text": "\"total\""
                                                                 }
                                                               ]
                                                             }
@@ -622,12 +816,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -636,19 +833,22 @@
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res36"
+                  "kind": "symbol",
+                  "text": "res36"
                 }
               ]
             }
@@ -657,188 +857,245 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Orders with customer info ---"
+          "kind": "string",
+          "text": "\"--- Orders with customer info ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "entry"
+                  "kind": "symbol",
+                  "text": "entry"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "Order"
+                      "kind": "string",
+                      "text": "\"Order\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"orderId\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "by"
+                      "kind": "string",
+                      "text": "\"by\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "customerName"
+                          "kind": "string",
+                          "text": "\"customerName\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "- $"
+                      "kind": "string",
+                      "text": "\"- $\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "total"
+                          "kind": "string",
+                          "text": "\"total\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -847,7 +1104,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/join_multi.scheme.json
+++ b/tests/json-ast/x/scheme/join_multi.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,135 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -232,51 +179,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "items"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "100"
+                          "kind": "number",
+                          "text": "100"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "sku"
+                          "kind": "string",
+                          "text": "\"customerId\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -285,38 +249,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "101"
+                          "kind": "number",
+                          "text": "101"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "sku"
+                          "kind": "string",
+                          "text": "\"customerId\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -329,29 +305,68 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "items"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res37"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"orderId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"sku\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     }
@@ -360,132 +375,273 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"orderId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"sku\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"b\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res37"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "i"
+                                              "kind": "symbol",
+                                              "text": "i"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "if"
+                                              "kind": "symbol",
+                                              "text": "if"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "and"
+                                                  "kind": "symbol",
+                                                  "text": "and"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "="
+                                                      "kind": "symbol",
+                                                      "text": "="
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "o"
+                                                          "kind": "symbol",
+                                                          "text": "o"
                                                         },
                                                         {
-                                                          "atom": "customerId"
+                                                          "kind": "string",
+                                                          "text": "\"customerId\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "c"
+                                                          "kind": "symbol",
+                                                          "text": "c"
                                                         },
                                                         {
-                                                          "atom": "id"
+                                                          "kind": "string",
+                                                          "text": "\"id\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "="
+                                                      "kind": "symbol",
+                                                      "text": "="
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "o"
+                                                          "kind": "symbol",
+                                                          "text": "o"
                                                         },
                                                         {
-                                                          "atom": "id"
+                                                          "kind": "string",
+                                                          "text": "\"id\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "i"
+                                                          "kind": "symbol",
+                                                          "text": "i"
                                                         },
                                                         {
-                                                          "atom": "orderId"
+                                                          "kind": "string",
+                                                          "text": "\"orderId\""
                                                         }
                                                       ]
                                                     }
@@ -494,77 +650,103 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "set!"
+                                                  "kind": "symbol",
+                                                  "text": "set!"
                                                 },
                                                 {
-                                                  "atom": "res37"
+                                                  "kind": "symbol",
+                                                  "text": "res37"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "append"
+                                                      "kind": "symbol",
+                                                      "text": "append"
                                                     },
                                                     {
-                                                      "atom": "res37"
+                                                      "kind": "symbol",
+                                                      "text": "res37"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "name"
+                                                                      "kind": "string",
+                                                                      "text": "\"name\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "c"
+                                                                          "kind": "symbol",
+                                                                          "text": "c"
                                                                         },
                                                                         {
-                                                                          "atom": "name"
+                                                                          "kind": "string",
+                                                                          "text": "\"name\""
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "sku"
+                                                                      "kind": "string",
+                                                                      "text": "\"sku\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "i"
+                                                                          "kind": "symbol",
+                                                                          "text": "i"
                                                                         },
                                                                         {
-                                                                          "atom": "sku"
+                                                                          "kind": "string",
+                                                                          "text": "\"sku\""
                                                                         }
                                                                       ]
                                                                     }
@@ -581,12 +763,15 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "quote"
+                                                  "kind": "symbol",
+                                                  "text": "quote"
                                                 },
                                                 {
-                                                  "atom": "nil"
+                                                  "kind": "symbol",
+                                                  "text": "nil"
                                                 }
                                               ]
                                             }
@@ -595,26 +780,30 @@
                                       ]
                                     },
                                     {
-                                      "atom": "items"
+                                      "kind": "symbol",
+                                      "text": "items"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res37"
+                  "kind": "symbol",
+                  "text": "res37"
                 }
               ]
             }
@@ -623,118 +812,154 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Multi Join ---"
+          "kind": "string",
+          "text": "\"--- Multi Join ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "r"
+                  "kind": "symbol",
+                  "text": "r"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "r"
+                          "kind": "symbol",
+                          "text": "r"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "bought item"
+                      "kind": "string",
+                      "text": "\"bought item\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "r"
+                          "kind": "symbol",
+                          "text": "r"
                         },
                         {
-                          "atom": "sku"
+                          "kind": "string",
+                          "text": "\"sku\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -743,7 +968,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/left_join.scheme.json
+++ b/tests/json-ast/x/scheme/left_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,161 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "250"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "3"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "80"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -258,29 +179,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res38"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "250"
                         }
                       ]
                     }
@@ -289,167 +266,337 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "3"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "80"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res38"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "o"
+                                              "kind": "symbol",
+                                              "text": "o"
                                             },
                                             {
-                                              "atom": "customerId"
+                                              "kind": "string",
+                                              "text": "\"customerId\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             },
                                             {
-                                              "atom": "id"
+                                              "kind": "string",
+                                              "text": "\"id\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "res38"
+                                          "kind": "symbol",
+                                          "text": "res38"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "append"
+                                              "kind": "symbol",
+                                              "text": "append"
                                             },
                                             {
-                                              "atom": "res38"
+                                              "kind": "symbol",
+                                              "text": "res38"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "alist-\u003ehash-table"
+                                                      "kind": "symbol",
+                                                      "text": "alist-\u003ehash-table"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "orderId"
+                                                              "kind": "string",
+                                                              "text": "\"orderId\""
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "o"
+                                                                  "kind": "symbol",
+                                                                  "text": "o"
                                                                 },
                                                                 {
-                                                                  "atom": "id"
+                                                                  "kind": "string",
+                                                                  "text": "\"id\""
                                                                 }
                                                               ]
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "customer"
+                                                              "kind": "string",
+                                                              "text": "\"customer\""
                                                             },
                                                             {
-                                                              "atom": "c"
+                                                              "kind": "symbol",
+                                                              "text": "c"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "total"
+                                                              "kind": "string",
+                                                              "text": "\"total\""
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "hash-table-ref"
+                                                                  "kind": "symbol",
+                                                                  "text": "hash-table-ref"
                                                                 },
                                                                 {
-                                                                  "atom": "o"
+                                                                  "kind": "symbol",
+                                                                  "text": "o"
                                                                 },
                                                                 {
-                                                                  "atom": "total"
+                                                                  "kind": "string",
+                                                                  "text": "\"total\""
                                                                 }
                                                               ]
                                                             }
@@ -466,12 +613,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -480,19 +630,22 @@
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res38"
+                  "kind": "symbol",
+                  "text": "res38"
                 }
               ]
             }
@@ -501,188 +654,245 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Left Join ---"
+          "kind": "string",
+          "text": "\"--- Left Join ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "entry"
+                  "kind": "symbol",
+                  "text": "entry"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "Order"
+                      "kind": "string",
+                      "text": "\"Order\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"orderId\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "customer"
+                      "kind": "string",
+                      "text": "\"customer\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "customer"
+                          "kind": "string",
+                          "text": "\"customer\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": "total"
+                      "kind": "string",
+                      "text": "\"total\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "total"
+                          "kind": "string",
+                          "text": "\"total\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -691,7 +901,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/left_join_multi.scheme.json
+++ b/tests/json-ast/x/scheme/left_join_multi.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,135 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -232,51 +179,120 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "items"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "100"
+                          "kind": "number",
+                          "text": "100"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "sku"
+                          "kind": "string",
+                          "text": "\"customerId\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -289,29 +305,113 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "items"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res39"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"orderId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"sku\""
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"a\""
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res39"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -320,132 +420,176 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "i"
+                                              "kind": "symbol",
+                                              "text": "i"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "if"
+                                              "kind": "symbol",
+                                              "text": "if"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "and"
+                                                  "kind": "symbol",
+                                                  "text": "and"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "="
+                                                      "kind": "symbol",
+                                                      "text": "="
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "o"
+                                                          "kind": "symbol",
+                                                          "text": "o"
                                                         },
                                                         {
-                                                          "atom": "customerId"
+                                                          "kind": "string",
+                                                          "text": "\"customerId\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "c"
+                                                          "kind": "symbol",
+                                                          "text": "c"
                                                         },
                                                         {
-                                                          "atom": "id"
+                                                          "kind": "string",
+                                                          "text": "\"id\""
                                                         }
                                                       ]
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "="
+                                                      "kind": "symbol",
+                                                      "text": "="
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "o"
+                                                          "kind": "symbol",
+                                                          "text": "o"
                                                         },
                                                         {
-                                                          "atom": "id"
+                                                          "kind": "string",
+                                                          "text": "\"id\""
                                                         }
                                                       ]
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "hash-table-ref"
+                                                          "kind": "symbol",
+                                                          "text": "hash-table-ref"
                                                         },
                                                         {
-                                                          "atom": "i"
+                                                          "kind": "symbol",
+                                                          "text": "i"
                                                         },
                                                         {
-                                                          "atom": "orderId"
+                                                          "kind": "string",
+                                                          "text": "\"orderId\""
                                                         }
                                                       ]
                                                     }
@@ -454,92 +598,122 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "set!"
+                                                  "kind": "symbol",
+                                                  "text": "set!"
                                                 },
                                                 {
-                                                  "atom": "res39"
+                                                  "kind": "symbol",
+                                                  "text": "res39"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "append"
+                                                      "kind": "symbol",
+                                                      "text": "append"
                                                     },
                                                     {
-                                                      "atom": "res39"
+                                                      "kind": "symbol",
+                                                      "text": "res39"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "alist-\u003ehash-table"
+                                                              "kind": "symbol",
+                                                              "text": "alist-\u003ehash-table"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "list"
+                                                                  "kind": "symbol",
+                                                                  "text": "list"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "orderId"
+                                                                      "kind": "string",
+                                                                      "text": "\"orderId\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "o"
+                                                                          "kind": "symbol",
+                                                                          "text": "o"
                                                                         },
                                                                         {
-                                                                          "atom": "id"
+                                                                          "kind": "string",
+                                                                          "text": "\"id\""
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "name"
+                                                                      "kind": "string",
+                                                                      "text": "\"name\""
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "hash-table-ref"
+                                                                          "kind": "symbol",
+                                                                          "text": "hash-table-ref"
                                                                         },
                                                                         {
-                                                                          "atom": "c"
+                                                                          "kind": "symbol",
+                                                                          "text": "c"
                                                                         },
                                                                         {
-                                                                          "atom": "name"
+                                                                          "kind": "string",
+                                                                          "text": "\"name\""
                                                                         }
                                                                       ]
                                                                     }
                                                                   ]
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "cons"
+                                                                      "kind": "symbol",
+                                                                      "text": "cons"
                                                                     },
                                                                     {
-                                                                      "atom": "item"
+                                                                      "kind": "string",
+                                                                      "text": "\"item\""
                                                                     },
                                                                     {
-                                                                      "atom": "i"
+                                                                      "kind": "symbol",
+                                                                      "text": "i"
                                                                     }
                                                                   ]
                                                                 }
@@ -554,12 +728,15 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "quote"
+                                                  "kind": "symbol",
+                                                  "text": "quote"
                                                 },
                                                 {
-                                                  "atom": "nil"
+                                                  "kind": "symbol",
+                                                  "text": "nil"
                                                 }
                                               ]
                                             }
@@ -568,26 +745,30 @@
                                       ]
                                     },
                                     {
-                                      "atom": "items"
+                                      "kind": "symbol",
+                                      "text": "items"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res39"
+                  "kind": "symbol",
+                  "text": "res39"
                 }
               ]
             }
@@ -596,128 +777,167 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Left Join Multi ---"
+          "kind": "string",
+          "text": "\"--- Left Join Multi ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "r"
+                  "kind": "symbol",
+                  "text": "r"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "r"
+                          "kind": "symbol",
+                          "text": "r"
                         },
                         {
-                          "atom": "orderId"
+                          "kind": "string",
+                          "text": "\"orderId\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "r"
+                          "kind": "symbol",
+                          "text": "r"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "atom": " "
+                      "kind": "string",
+                      "text": "\" \""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "display"
+                      "kind": "symbol",
+                      "text": "display"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "r"
+                          "kind": "symbol",
+                          "text": "r"
                         },
                         {
-                          "atom": "item"
+                          "kind": "string",
+                          "text": "\"item\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "newline"
+                      "kind": "symbol",
+                      "text": "newline"
                     }
                   ]
                 }
@@ -726,7 +946,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/len_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/len_builtin.scheme.json
@@ -1,65 +1,89 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "length"
+              "kind": "symbol",
+              "text": "length"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 }
               ]
             }
@@ -68,9 +92,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/len_map.scheme.json
+++ b/tests/json-ast/x/scheme/len_map.scheme.json
@@ -1,85 +1,116 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-size"
+              "kind": "symbol",
+              "text": "hash-table-size"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -92,9 +123,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/len_string.scheme.json
+++ b/tests/json-ast/x/scheme/len_string.scheme.json
@@ -1,63 +1,85 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-length"
+              "kind": "symbol",
+              "text": "string-length"
             },
             {
-              "atom": "mochi"
+              "kind": "string",
+              "text": "\"mochi\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/let_and_print.scheme.json
+++ b/tests/json-ast/x/scheme/let_and_print.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,51 +393,67 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "a"
+          "kind": "symbol",
+          "text": "a"
         },
         {
-          "atom": "10"
+          "kind": "number",
+          "text": "10"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "b"
+          "kind": "symbol",
+          "text": "b"
         },
         {
-          "atom": "20"
+          "kind": "number",
+          "text": "20"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "atom": "a"
+                  "kind": "symbol",
+                  "text": "a"
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -353,9 +462,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/list_assign.scheme.json
+++ b/tests/json-ast/x/scheme/list_assign.scheme.json
@@ -1,105 +1,140 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "list-set!"
+          "kind": "symbol",
+          "text": "list-set!"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "atom": "1"
+          "kind": "number",
+          "text": "1"
         },
         {
-          "atom": "3"
+          "kind": "number",
+          "text": "3"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "nums"
+              "kind": "symbol",
+              "text": "nums"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/list_index.scheme.json
+++ b/tests/json-ast/x/scheme/list_index.scheme.json
@@ -1,92 +1,123 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "xs"
+          "kind": "symbol",
+          "text": "xs"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "10"
+              "kind": "number",
+              "text": "10"
             },
             {
-              "atom": "20"
+              "kind": "number",
+              "text": "20"
             },
             {
-              "atom": "30"
+              "kind": "number",
+              "text": "30"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list-ref"
+              "kind": "symbol",
+              "text": "list-ref"
             },
             {
-              "atom": "xs"
+              "kind": "symbol",
+              "text": "xs"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/list_nested_assign.scheme.json
+++ b/tests/json-ast/x/scheme/list_nested_assign.scheme.json
@@ -1,242 +1,106 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "matrix"
+          "kind": "symbol",
+          "text": "matrix"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 },
                 {
-                  "atom": "4"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "list-set!"
-        },
-        {
-          "list": [
-            {
-              "atom": "list-ref"
-            },
-            {
-              "atom": "matrix"
-            },
-            {
-              "atom": "1"
-            }
-          ]
-        },
-        {
-          "atom": "0"
-        },
-        {
-          "atom": "5"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "cond"
-            },
-            {
-              "list": [
-                {
-                  "list": [
-                    {
-                      "atom": "string?"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "list-ref"
-                        },
-                        {
-                          "atom": "matrix"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "string-ref"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "list-ref"
-                        },
-                        {
-                          "atom": "matrix"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "list": [
-                    {
-                      "atom": "hash-table?"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "list-ref"
-                        },
-                        {
-                          "atom": "matrix"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "hash-table-ref"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "list-ref"
-                        },
-                        {
-                          "atom": "matrix"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "0"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "else"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list-ref"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "list-ref"
-                        },
-                        {
-                          "atom": "matrix"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "0"
-                    }
-                  ]
+                  "kind": "number",
+                  "text": "4"
                 }
               ]
             }
@@ -245,9 +109,224 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "list-set!"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "list-ref"
+            },
+            {
+              "kind": "symbol",
+              "text": "matrix"
+            },
+            {
+              "kind": "number",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "number",
+          "text": "0"
+        },
+        {
+          "kind": "number",
+          "text": "5"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "cond"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "string?"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "matrix"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "string-ref"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "matrix"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "number",
+                      "text": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "hash-table?"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "matrix"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "hash-table-ref"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "matrix"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "number",
+                      "text": "0"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "else"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list-ref"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list-ref"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "matrix"
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "number",
+                      "text": "0"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/list_set_ops.scheme.json
+++ b/tests/json-ast/x/scheme/list_set_ops.scheme.json
@@ -1,134 +1,179 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 09:24 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "true"
+                      "kind": "string",
+                      "text": "\"true\""
                     },
                     {
-                      "atom": "false"
+                      "kind": "string",
+                      "text": "\"false\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -139,48 +184,64 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "delete-duplicates"
+                  "kind": "symbol",
+                  "text": "delete-duplicates"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "append"
+                      "kind": "symbol",
+                      "text": "append"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     }
@@ -193,59 +254,79 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "filter"
+                  "kind": "symbol",
+                  "text": "filter"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "lambda"
+                      "kind": "symbol",
+                      "text": "lambda"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "not"
+                          "kind": "symbol",
+                          "text": "not"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "list"
+                                  "kind": "symbol",
+                                  "text": "list"
                                 },
                                 {
-                                  "atom": "2"
+                                  "kind": "number",
+                                  "text": "2"
                                 }
                               ]
                             }
@@ -256,18 +337,23 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 }
@@ -278,57 +364,76 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "filter"
+                  "kind": "symbol",
+                  "text": "filter"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "lambda"
+                      "kind": "symbol",
+                      "text": "lambda"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "member"
+                          "kind": "symbol",
+                          "text": "member"
                         },
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "list"
+                              "kind": "symbol",
+                              "text": "list"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             },
                             {
-                              "atom": "4"
+                              "kind": "number",
+                              "text": "4"
                             }
                           ]
                         }
@@ -337,18 +442,23 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 }
@@ -359,55 +469,73 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "length"
+                  "kind": "symbol",
+                  "text": "length"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "append"
+                      "kind": "symbol",
+                      "text": "append"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     }
@@ -420,9 +548,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_assign.scheme.json
+++ b/tests/json-ast/x/scheme/map_assign.scheme.json
@@ -1,70 +1,96 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "scores"
+          "kind": "symbol",
+          "text": "scores"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "alice"
+                      "kind": "string",
+                      "text": "\"alice\""
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 }
@@ -75,45 +101,58 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "hash-table-set!"
+          "kind": "symbol",
+          "text": "hash-table-set!"
         },
         {
-          "atom": "scores"
+          "kind": "symbol",
+          "text": "scores"
         },
         {
-          "atom": "bob"
+          "kind": "string",
+          "text": "\"bob\""
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "scores"
+              "kind": "symbol",
+              "text": "scores"
             },
             {
-              "atom": "bob"
+              "kind": "string",
+              "text": "\"bob\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_in_operator.scheme.json
+++ b/tests/json-ast/x/scheme/map_in_operator.scheme.json
@@ -1,83 +1,113 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     }
                   ]
                 }
@@ -88,128 +118,168 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "1"
+                              "kind": "number",
+                              "text": "1"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -218,145 +288,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "3"
+                              "kind": "number",
+                              "text": "3"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "3"
+                              "kind": "number",
+                              "text": "3"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "3"
+                              "kind": "number",
+                              "text": "3"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -365,19 +479,23 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_index.scheme.json
+++ b/tests/json-ast/x/scheme/map_index.scheme.json
@@ -1,83 +1,113 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
@@ -88,29 +118,37 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "m"
+              "kind": "symbol",
+              "text": "m"
             },
             {
-              "atom": "b"
+              "kind": "string",
+              "text": "\"b\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_int_key.scheme.json
+++ b/tests/json-ast/x/scheme/map_int_key.scheme.json
@@ -1,83 +1,113 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     }
                   ]
                 }
@@ -88,29 +118,37 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "m"
+              "kind": "symbol",
+              "text": "m"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_literal_dynamic.scheme.json
+++ b/tests/json-ast/x/scheme/map_literal_dynamic.scheme.json
@@ -1,109 +1,147 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "3"
+          "kind": "number",
+          "text": "3"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "y"
+          "kind": "symbol",
+          "text": "y"
         },
         {
-          "atom": "4"
+          "kind": "number",
+          "text": "4"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "y"
+                      "kind": "symbol",
+                      "text": "y"
                     }
                   ]
                 }
@@ -114,59 +152,76 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "m"
+              "kind": "symbol",
+              "text": "m"
             },
             {
-              "atom": "a"
+              "kind": "string",
+              "text": "\"a\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": " "
+          "kind": "string",
+          "text": "\" \""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "m"
+              "kind": "symbol",
+              "text": "m"
             },
             {
-              "atom": "b"
+              "kind": "string",
+              "text": "\"b\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_membership.scheme.json
+++ b/tests/json-ast/x/scheme/map_membership.scheme.json
@@ -1,83 +1,113 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "m"
+          "kind": "symbol",
+          "text": "m"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
@@ -88,128 +118,168 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "a"
+                              "kind": "string",
+                              "text": "\"a\""
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -218,145 +288,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "c"
+                              "kind": "string",
+                              "text": "\"c\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "m"
+                          "kind": "symbol",
+                          "text": "m"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             },
                             {
-                              "atom": "c"
+                              "kind": "string",
+                              "text": "\"c\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "c"
+                              "kind": "string",
+                              "text": "\"c\""
                             },
                             {
-                              "atom": "m"
+                              "kind": "symbol",
+                              "text": "m"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -365,19 +479,23 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/map_nested_assign.scheme.json
+++ b/tests/json-ast/x/scheme/map_nested_assign.scheme.json
@@ -1,88 +1,121 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "data"
+          "kind": "symbol",
+          "text": "data"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "alist-\u003ehash-table"
+              "kind": "symbol",
+              "text": "alist-\u003ehash-table"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "cons"
+                      "kind": "symbol",
+                      "text": "cons"
                     },
                     {
-                      "atom": "outer"
+                      "kind": "string",
+                      "text": "\"outer\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "alist-\u003ehash-table"
+                          "kind": "symbol",
+                          "text": "alist-\u003ehash-table"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "list"
+                              "kind": "symbol",
+                              "text": "list"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "cons"
+                                  "kind": "symbol",
+                                  "text": "cons"
                                 },
                                 {
-                                  "atom": "inner"
+                                  "kind": "string",
+                                  "text": "\"inner\""
                                 },
                                 {
-                                  "atom": "1"
+                                  "kind": "number",
+                                  "text": "1"
                                 }
                               ]
                             }
@@ -99,160 +132,209 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "hash-table-set!"
+          "kind": "symbol",
+          "text": "hash-table-set!"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "hash-table-ref"
+              "kind": "symbol",
+              "text": "hash-table-ref"
             },
             {
-              "atom": "data"
+              "kind": "symbol",
+              "text": "data"
             },
             {
-              "atom": "outer"
+              "kind": "string",
+              "text": "\"outer\""
             }
           ]
         },
         {
-          "atom": "inner"
+          "kind": "string",
+          "text": "\"inner\""
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "data"
+                          "kind": "symbol",
+                          "text": "data"
                         },
                         {
-                          "atom": "outer"
+                          "kind": "string",
+                          "text": "\"outer\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-ref"
+                      "kind": "symbol",
+                      "text": "string-ref"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "data"
+                          "kind": "symbol",
+                          "text": "data"
                         },
                         {
-                          "atom": "outer"
+                          "kind": "string",
+                          "text": "\"outer\""
                         }
                       ]
                     },
                     {
-                      "atom": "inner"
+                      "kind": "string",
+                      "text": "\"inner\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "hash-table?"
+                      "kind": "symbol",
+                      "text": "hash-table?"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "data"
+                          "kind": "symbol",
+                          "text": "data"
                         },
                         {
-                          "atom": "outer"
+                          "kind": "string",
+                          "text": "\"outer\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "hash-table-ref"
+                      "kind": "symbol",
+                      "text": "hash-table-ref"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "data"
+                          "kind": "symbol",
+                          "text": "data"
                         },
                         {
-                          "atom": "outer"
+                          "kind": "string",
+                          "text": "\"outer\""
                         }
                       ]
                     },
                     {
-                      "atom": "inner"
+                      "kind": "string",
+                      "text": "\"inner\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list-ref"
+                      "kind": "symbol",
+                      "text": "list-ref"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "data"
+                          "kind": "symbol",
+                          "text": "data"
                         },
                         {
-                          "atom": "outer"
+                          "kind": "string",
+                          "text": "\"outer\""
                         }
                       ]
                     },
                     {
-                      "atom": "inner"
+                      "kind": "string",
+                      "text": "\"inner\""
                     }
                   ]
                 }
@@ -263,9 +345,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/match_expr.scheme.json
+++ b/tests/json-ast/x/scheme/match_expr.scheme.json
@@ -1,134 +1,179 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 09:24 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "true"
+                      "kind": "string",
+                      "text": "\"true\""
                     },
                     {
-                      "atom": "false"
+                      "kind": "string",
+                      "text": "\"false\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -139,117 +184,153 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "label"
+          "kind": "symbol",
+          "text": "label"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "match1"
+                      "kind": "symbol",
+                      "text": "match1"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "atom": "one"
+                      "kind": "string",
+                      "text": "\"one\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "atom": "two"
+                      "kind": "string",
+                      "text": "\"two\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "atom": "three"
+                      "kind": "string",
+                      "text": "\"three\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "atom": "unknown"
+                      "kind": "string",
+                      "text": "\"unknown\""
                     }
                   ]
                 }
@@ -260,26 +341,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "label"
+              "kind": "symbol",
+              "text": "label"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/match_full.scheme.json
+++ b/tests/json-ast/x/scheme/match_full.scheme.json
@@ -1,134 +1,179 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 09:24 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "true"
+                      "kind": "string",
+                      "text": "\"true\""
                     },
                     {
-                      "atom": "false"
+                      "kind": "string",
+                      "text": "\"false\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -139,262 +184,153 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "label"
+          "kind": "symbol",
+          "text": "label"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "match1"
+                      "kind": "symbol",
+                      "text": "match1"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "atom": "one"
+                      "kind": "string",
+                      "text": "\"one\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "atom": "two"
+                      "kind": "string",
+                      "text": "\"two\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match1"
+                          "kind": "symbol",
+                          "text": "match1"
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "atom": "three"
+                      "kind": "string",
+                      "text": "\"three\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "atom": "unknown"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "to-str"
-            },
-            {
-              "atom": "label"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "newline"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "day"
-        },
-        {
-          "atom": "sun"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "mood"
-        },
-        {
-          "list": [
-            {
-              "atom": "let"
-            },
-            {
-              "list": [
-                {
-                  "list": [
-                    {
-                      "atom": "match2"
-                    },
-                    {
-                      "atom": "day"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "cond"
-                },
-                {
-                  "list": [
-                    {
-                      "list": [
-                        {
-                          "atom": "equal?"
-                        },
-                        {
-                          "atom": "match2"
-                        },
-                        {
-                          "atom": "mon"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "tired"
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "list": [
-                        {
-                          "atom": "equal?"
-                        },
-                        {
-                          "atom": "match2"
-                        },
-                        {
-                          "atom": "fri"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "excited"
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "list": [
-                        {
-                          "atom": "equal?"
-                        },
-                        {
-                          "atom": "match2"
-                        },
-                        {
-                          "atom": "sun"
-                        }
-                      ]
-                    },
-                    {
-                      "atom": "relaxed"
-                    }
-                  ]
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "else"
-                    },
-                    {
-                      "atom": "normal"
+                      "kind": "string",
+                      "text": "\"unknown\""
                     }
                   ]
                 }
@@ -405,126 +341,353 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "mood"
+              "kind": "symbol",
+              "text": "label"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "ok"
+          "kind": "symbol",
+          "text": "day"
         },
         {
-          "atom": "true"
+          "kind": "string",
+          "text": "\"sun\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "status"
+          "kind": "symbol",
+          "text": "mood"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "match3"
+                      "kind": "symbol",
+                      "text": "match2"
                     },
                     {
-                      "atom": "ok"
+                      "kind": "symbol",
+                      "text": "day"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match3"
+                          "kind": "symbol",
+                          "text": "match2"
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"mon\""
                         }
                       ]
                     },
                     {
-                      "atom": "confirmed"
+                      "kind": "string",
+                      "text": "\"tired\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match3"
+                          "kind": "symbol",
+                          "text": "match2"
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"fri\""
                         }
                       ]
                     },
                     {
-                      "atom": "denied"
+                      "kind": "string",
+                      "text": "\"excited\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
-                    },
-                    {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "quote"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "nil"
+                          "kind": "symbol",
+                          "text": "match2"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"sun\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\"relaxed\""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "else"
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\"normal\""
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "to-str"
+            },
+            {
+              "kind": "symbol",
+              "text": "mood"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "ok"
+        },
+        {
+          "kind": "string",
+          "text": "\"true\""
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "status"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "match3"
+                    },
+                    {
+                      "kind": "symbol",
+                      "text": "ok"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "cond"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "equal?"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "match3"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"true\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\"confirmed\""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "equal?"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "match3"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"false\""
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "string",
+                      "text": "\"denied\""
+                    }
+                  ]
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "else"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "quote"
+                        },
+                        {
+                          "kind": "symbol",
+                          "text": "nil"
                         }
                       ]
                     }
@@ -537,115 +700,150 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "status"
+              "kind": "symbol",
+              "text": "status"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "classify"
+              "kind": "symbol",
+              "text": "classify"
             },
             {
-              "atom": "n"
+              "kind": "symbol",
+              "text": "n"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "match4"
+                      "kind": "symbol",
+                      "text": "match4"
                     },
                     {
-                      "atom": "n"
+                      "kind": "symbol",
+                      "text": "n"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match4"
+                          "kind": "symbol",
+                          "text": "match4"
                         },
                         {
-                          "atom": "0"
+                          "kind": "number",
+                          "text": "0"
                         }
                       ]
                     },
                     {
-                      "atom": "zero"
+                      "kind": "string",
+                      "text": "\"zero\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "equal?"
+                          "kind": "symbol",
+                          "text": "equal?"
                         },
                         {
-                          "atom": "match4"
+                          "kind": "symbol",
+                          "text": "match4"
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "atom": "one"
+                      "kind": "string",
+                      "text": "\"one\""
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "atom": "many"
+                      "kind": "string",
+                      "text": "\"many\""
                     }
                   ]
                 }
@@ -656,22 +854,29 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "classify"
+                  "kind": "symbol",
+                  "text": "classify"
                 },
                 {
-                  "atom": "0"
+                  "kind": "number",
+                  "text": "0"
                 }
               ]
             }
@@ -680,29 +885,38 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "classify"
+                  "kind": "symbol",
+                  "text": "classify"
                 },
                 {
-                  "atom": "5"
+                  "kind": "number",
+                  "text": "5"
                 }
               ]
             }
@@ -711,9 +925,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/math_ops.scheme.json
+++ b/tests/json-ast/x/scheme/math_ops.scheme.json
@@ -1,120 +1,159 @@
 {
   "forms": [
     {
-      "list": [
-        {
-          "atom": "import"
-        },
-        {
-          "list": [
-            {
-              "atom": "srfi"
-            },
-            {
-              "atom": "1"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "srfi"
-            },
-            {
-              "atom": "69"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "chibi"
-            },
-            {
-              "atom": "string"
-            }
-          ]
-        }
-      ]
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "*"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "6"
+              "kind": "number",
+              "text": "1"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "7"
+              "kind": "number",
+              "text": "69"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "chibi"
+            },
+            {
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "quotient"
+              "kind": "symbol",
+              "text": "*"
             },
             {
-              "atom": "7"
+              "kind": "number",
+              "text": "6"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "7"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "modulo"
+              "kind": "symbol",
+              "text": "quotient"
             },
             {
-              "atom": "7"
+              "kind": "number",
+              "text": "7"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "modulo"
+            },
+            {
+              "kind": "number",
+              "text": "7"
+            },
+            {
+              "kind": "number",
+              "text": "2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/membership.scheme.json
+++ b/tests/json-ast/x/scheme/membership.scheme.json
@@ -1,191 +1,254 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "nums"
+                          "kind": "symbol",
+                          "text": "nums"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "nums"
+                          "kind": "symbol",
+                          "text": "nums"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "2"
+                              "kind": "number",
+                              "text": "2"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -194,145 +257,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "nums"
+                          "kind": "symbol",
+                          "text": "nums"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             },
                             {
-                              "atom": "4"
+                              "kind": "number",
+                              "text": "4"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "nums"
+                          "kind": "symbol",
+                          "text": "nums"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             },
                             {
-                              "atom": "4"
+                              "kind": "number",
+                              "text": "4"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "4"
+                              "kind": "number",
+                              "text": "4"
                             },
                             {
-                              "atom": "nums"
+                              "kind": "symbol",
+                              "text": "nums"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -341,19 +448,23 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/min_max_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/min_max_builtin.scheme.json
@@ -1,119 +1,158 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "4"
+              "kind": "number",
+              "text": "4"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "apply"
+              "kind": "symbol",
+              "text": "apply"
             },
             {
-              "atom": "min"
+              "kind": "symbol",
+              "text": "min"
             },
             {
-              "atom": "nums"
+              "kind": "symbol",
+              "text": "nums"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "apply"
+              "kind": "symbol",
+              "text": "apply"
             },
             {
-              "atom": "max"
+              "kind": "symbol",
+              "text": "max"
             },
             {
-              "atom": "nums"
+              "kind": "symbol",
+              "text": "nums"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/nested_function.scheme.json
+++ b/tests/json-ast/x/scheme/nested_function.scheme.json
@@ -1,99 +1,133 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "outer"
+              "kind": "symbol",
+              "text": "outer"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "define"
+                  "kind": "symbol",
+                  "text": "define"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "inner"
+                      "kind": "symbol",
+                      "text": "inner"
                     },
                     {
-                      "atom": "y"
+                      "kind": "symbol",
+                      "text": "y"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "+"
+                      "kind": "symbol",
+                      "text": "+"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "y"
+                      "kind": "symbol",
+                      "text": "y"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "inner"
+                  "kind": "symbol",
+                  "text": "inner"
                 },
                 {
-                  "atom": "5"
+                  "kind": "number",
+                  "text": "5"
                 }
               ]
             }
@@ -102,26 +136,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "outer"
+              "kind": "symbol",
+              "text": "outer"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/order_by_map.scheme.json
+++ b/tests/json-ast/x/scheme/order_by_map.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "data"
+          "kind": "symbol",
+          "text": "data"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         },
                         {
-                          "atom": "0"
+                          "kind": "number",
+                          "text": "0"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         },
                         {
-                          "atom": "5"
+                          "kind": "number",
+                          "text": "5"
                         }
                       ]
                     }
@@ -175,29 +231,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "sorted"
+          "kind": "symbol",
+          "text": "sorted"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res40"
+                      "kind": "symbol",
+                      "text": "res40"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -206,50 +272,67 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res40"
+                              "kind": "symbol",
+                              "text": "res40"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res40"
+                                  "kind": "symbol",
+                                  "text": "res40"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "atom": "x"
+                                      "kind": "symbol",
+                                      "text": "x"
                                     }
                                   ]
                                 }
@@ -260,12 +343,14 @@
                       ]
                     },
                     {
-                      "atom": "data"
+                      "kind": "symbol",
+                      "text": "data"
                     }
                   ]
                 },
                 {
-                  "atom": "res40"
+                  "kind": "symbol",
+                  "text": "res40"
                 }
               ]
             }
@@ -274,19 +359,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "sorted"
+          "kind": "symbol",
+          "text": "sorted"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/outer_join.scheme.json
+++ b/tests/json-ast/x/scheme/outer_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     }
@@ -171,267 +227,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "4"
+                          "kind": "number",
+                          "text": "4"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Diana"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "250"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "125"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "102"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "300"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "103"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "5"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "80"
+                          "kind": "string",
+                          "text": "\"Diana\""
                         }
                       ]
                     }
@@ -444,29 +283,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res41"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "250"
                         }
                       ]
                     }
@@ -475,136 +370,434 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "125"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "102"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "300"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "103"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "5"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "80"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res41"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "for-each"
+                              "kind": "symbol",
+                              "text": "for-each"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "c"
+                                      "kind": "symbol",
+                                      "text": "c"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "="
+                                          "kind": "symbol",
+                                          "text": "="
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "o"
+                                              "kind": "symbol",
+                                              "text": "o"
                                             },
                                             {
-                                              "atom": "customerId"
+                                              "kind": "string",
+                                              "text": "\"customerId\""
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             },
                                             {
-                                              "atom": "id"
+                                              "kind": "string",
+                                              "text": "\"id\""
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "res41"
+                                          "kind": "symbol",
+                                          "text": "res41"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "append"
+                                              "kind": "symbol",
+                                              "text": "append"
                                             },
                                             {
-                                              "atom": "res41"
+                                              "kind": "symbol",
+                                              "text": "res41"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "list"
+                                                  "kind": "symbol",
+                                                  "text": "list"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "alist-\u003ehash-table"
+                                                      "kind": "symbol",
+                                                      "text": "alist-\u003ehash-table"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "list"
+                                                          "kind": "symbol",
+                                                          "text": "list"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "order"
+                                                              "kind": "string",
+                                                              "text": "\"order\""
                                                             },
                                                             {
-                                                              "atom": "o"
+                                                              "kind": "symbol",
+                                                              "text": "o"
                                                             }
                                                           ]
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "cons"
+                                                              "kind": "symbol",
+                                                              "text": "cons"
                                                             },
                                                             {
-                                                              "atom": "customer"
+                                                              "kind": "string",
+                                                              "text": "\"customer\""
                                                             },
                                                             {
-                                                              "atom": "c"
+                                                              "kind": "symbol",
+                                                              "text": "c"
                                                             }
                                                           ]
                                                         }
@@ -619,12 +812,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -633,19 +829,22 @@
                               ]
                             },
                             {
-                              "atom": "customers"
+                              "kind": "symbol",
+                              "text": "customers"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res41"
+                  "kind": "symbol",
+                  "text": "res41"
                 }
               ]
             }
@@ -654,428 +853,559 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Outer Join using syntax ---"
+          "kind": "string",
+          "text": "\"--- Outer Join using syntax ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "row"
+                  "kind": "symbol",
+                  "text": "row"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "row"
+                          "kind": "symbol",
+                          "text": "row"
                         },
                         {
-                          "atom": "order"
+                          "kind": "string",
+                          "text": "\"order\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "if"
+                              "kind": "symbol",
+                              "text": "if"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "atom": "row"
+                                  "kind": "symbol",
+                                  "text": "row"
                                 },
                                 {
-                                  "atom": "customer"
+                                  "kind": "string",
+                                  "text": "\"customer\""
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "Order"
+                                      "kind": "string",
+                                      "text": "\"Order\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "row"
+                                              "kind": "symbol",
+                                              "text": "row"
                                             },
                                             {
-                                              "atom": "order"
+                                              "kind": "string",
+                                              "text": "\"order\""
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "id"
+                                          "kind": "string",
+                                          "text": "\"id\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "by"
+                                      "kind": "string",
+                                      "text": "\"by\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "row"
+                                              "kind": "symbol",
+                                              "text": "row"
                                             },
                                             {
-                                              "atom": "customer"
+                                              "kind": "string",
+                                              "text": "\"customer\""
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "name"
+                                          "kind": "string",
+                                          "text": "\"name\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "- $"
+                                      "kind": "string",
+                                      "text": "\"- $\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "row"
+                                              "kind": "symbol",
+                                              "text": "row"
                                             },
                                             {
-                                              "atom": "order"
+                                              "kind": "string",
+                                              "text": "\"order\""
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "total"
+                                          "kind": "string",
+                                          "text": "\"total\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "newline"
+                                      "kind": "symbol",
+                                      "text": "newline"
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "Order"
+                                      "kind": "string",
+                                      "text": "\"Order\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "row"
+                                              "kind": "symbol",
+                                              "text": "row"
                                             },
                                             {
-                                              "atom": "order"
+                                              "kind": "string",
+                                              "text": "\"order\""
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "id"
+                                          "kind": "string",
+                                          "text": "\"id\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "by"
+                                      "kind": "string",
+                                      "text": "\"by\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "Unknown"
+                                      "kind": "string",
+                                      "text": "\"Unknown\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": "- $"
+                                      "kind": "string",
+                                      "text": "\"- $\""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "atom": " "
+                                      "kind": "string",
+                                      "text": "\" \""
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "display"
+                                      "kind": "symbol",
+                                      "text": "display"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "hash-table-ref"
+                                              "kind": "symbol",
+                                              "text": "hash-table-ref"
                                             },
                                             {
-                                              "atom": "row"
+                                              "kind": "symbol",
+                                              "text": "row"
                                             },
                                             {
-                                              "atom": "order"
+                                              "kind": "string",
+                                              "text": "\"order\""
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "total"
+                                          "kind": "string",
+                                          "text": "\"total\""
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "newline"
+                                      "kind": "symbol",
+                                      "text": "newline"
                                     }
                                   ]
                                 }
@@ -1086,84 +1416,109 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "Customer"
+                              "kind": "string",
+                              "text": "\"Customer\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-ref"
+                                      "kind": "symbol",
+                                      "text": "hash-table-ref"
                                     },
                                     {
-                                      "atom": "row"
+                                      "kind": "symbol",
+                                      "text": "row"
                                     },
                                     {
-                                      "atom": "customer"
+                                      "kind": "string",
+                                      "text": "\"customer\""
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "name"
+                                  "kind": "string",
+                                  "text": "\"name\""
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "has no orders"
+                              "kind": "string",
+                              "text": "\"has no orders\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "newline"
+                              "kind": "symbol",
+                              "text": "newline"
                             }
                           ]
                         }
@@ -1176,7 +1531,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/partial_application.scheme.json
+++ b/tests/json-ast/x/scheme/partial_application.scheme.json
@@ -1,116 +1,154 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "add"
+              "kind": "symbol",
+              "text": "add"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "b"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "add5"
-        },
-        {
-          "list": [
-            {
-              "atom": "add"
-            },
-            {
-              "atom": "5"
+              "kind": "symbol",
+              "text": "b"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "symbol",
+          "text": "add5"
+        },
+        {
+          "kind": "list",
+          "children": [
             {
-              "atom": "add5"
+              "kind": "symbol",
+              "text": "add"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "5"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "add5"
+            },
+            {
+              "kind": "number",
+              "text": "3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/print_hello.scheme.json
+++ b/tests/json-ast/x/scheme/print_hello.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,26 +393,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "hello"
+              "kind": "string",
+              "text": "\"hello\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/pure_fold.scheme.json
+++ b/tests/json-ast/x/scheme/pure_fold.scheme.json
@@ -1,92 +1,124 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "triple"
+              "kind": "symbol",
+              "text": "triple"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "*"
+              "kind": "symbol",
+              "text": "*"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "triple"
+              "kind": "symbol",
+              "text": "triple"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 }
               ]
             }
@@ -95,9 +127,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/pure_global_fold.scheme.json
+++ b/tests/json-ast/x/scheme/pure_global_fold.scheme.json
@@ -1,106 +1,141 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "k"
+          "kind": "symbol",
+          "text": "k"
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "inc"
+              "kind": "symbol",
+              "text": "inc"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             },
             {
-              "atom": "k"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "display"
-        },
-        {
-          "list": [
-            {
-              "atom": "inc"
-            },
-            {
-              "atom": "3"
+              "kind": "symbol",
+              "text": "k"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "display"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "inc"
+            },
+            {
+              "kind": "number",
+              "text": "3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/query_sum_select.scheme.json
+++ b/tests/json-ast/x/scheme/query_sum_select.scheme.json
@@ -1,92 +1,125 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "nums"
+          "kind": "symbol",
+          "text": "nums"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "2"
+              "kind": "number",
+              "text": "2"
             },
             {
-              "atom": "3"
+              "kind": "number",
+              "text": "3"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res42"
+                      "kind": "symbol",
+                      "text": "res42"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -95,76 +128,102 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "n"
+                              "kind": "symbol",
+                              "text": "n"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "if"
+                              "kind": "symbol",
+                              "text": "if"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "\u003e"
+                                  "kind": "symbol",
+                                  "text": "\u003e"
                                 },
                                 {
-                                  "atom": "n"
+                                  "kind": "symbol",
+                                  "text": "n"
                                 },
                                 {
-                                  "atom": "1"
+                                  "kind": "number",
+                                  "text": "1"
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "set!"
+                                  "kind": "symbol",
+                                  "text": "set!"
                                 },
                                 {
-                                  "atom": "res42"
+                                  "kind": "symbol",
+                                  "text": "res42"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "append"
+                                      "kind": "symbol",
+                                      "text": "append"
                                     },
                                     {
-                                      "atom": "res42"
+                                      "kind": "symbol",
+                                      "text": "res42"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "list"
+                                          "kind": "symbol",
+                                          "text": "list"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "apply"
+                                              "kind": "symbol",
+                                              "text": "apply"
                                             },
                                             {
-                                              "atom": "+"
+                                              "kind": "symbol",
+                                              "text": "+"
                                             },
                                             {
-                                              "atom": "n"
+                                              "kind": "symbol",
+                                              "text": "n"
                                             }
                                           ]
                                         }
@@ -175,12 +234,15 @@
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "quote"
+                                  "kind": "symbol",
+                                  "text": "quote"
                                 },
                                 {
-                                  "atom": "nil"
+                                  "kind": "symbol",
+                                  "text": "nil"
                                 }
                               ]
                             }
@@ -189,12 +251,14 @@
                       ]
                     },
                     {
-                      "atom": "nums"
+                      "kind": "symbol",
+                      "text": "nums"
                     }
                   ]
                 },
                 {
-                  "atom": "res42"
+                  "kind": "symbol",
+                  "text": "res42"
                 }
               ]
             }
@@ -203,19 +267,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/right_join.scheme.json
+++ b/tests/json-ast/x/scheme/right_join.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "customers"
+          "kind": "symbol",
+          "text": "customers"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Alice"
+                          "kind": "string",
+                          "text": "\"Alice\""
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Bob"
+                          "kind": "string",
+                          "text": "\"Bob\""
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "3"
+                          "kind": "number",
+                          "text": "3"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Charlie"
+                          "kind": "string",
+                          "text": "\"Charlie\""
                         }
                       ]
                     }
@@ -171,214 +227,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "id"
+                          "kind": "string",
+                          "text": "\"id\""
                         },
                         {
-                          "atom": "4"
+                          "kind": "number",
+                          "text": "4"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "name"
+                          "kind": "string",
+                          "text": "\"name\""
                         },
                         {
-                          "atom": "Diana"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "atom": "orders"
-        },
-        {
-          "list": [
-            {
-              "atom": "list"
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "100"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "250"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "101"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "2"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "125"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "list": [
-                {
-                  "atom": "alist-\u003ehash-table"
-                },
-                {
-                  "list": [
-                    {
-                      "atom": "list"
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "id"
-                        },
-                        {
-                          "atom": "102"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "customerId"
-                        },
-                        {
-                          "atom": "1"
-                        }
-                      ]
-                    },
-                    {
-                      "list": [
-                        {
-                          "atom": "cons"
-                        },
-                        {
-                          "atom": "total"
-                        },
-                        {
-                          "atom": "300"
+                          "kind": "string",
+                          "text": "\"Diana\""
                         }
                       ]
                     }
@@ -391,29 +283,85 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "orders"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res43"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "100"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "250"
                         }
                       ]
                     }
@@ -422,188 +370,434 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "list": [
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "101"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "2"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "125"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "list"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"id\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "102"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"customerId\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "1"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "cons"
+                        },
+                        {
+                          "kind": "string",
+                          "text": "\"total\""
+                        },
+                        {
+                          "kind": "number",
+                          "text": "300"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "symbol",
+          "text": "result"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "let"
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "res43"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "list"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "list",
+              "children": [
+                {
+                  "kind": "symbol",
+                  "text": "begin"
+                },
+                {
+                  "kind": "list",
+                  "children": [
+                    {
+                      "kind": "symbol",
+                      "text": "for-each"
+                    },
+                    {
+                      "kind": "list",
+                      "children": [
+                        {
+                          "kind": "symbol",
+                          "text": "lambda"
+                        },
+                        {
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "o"
+                              "kind": "symbol",
+                              "text": "o"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "let"
+                              "kind": "symbol",
+                              "text": "let"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "matched44"
+                                      "kind": "symbol",
+                                      "text": "matched44"
                                     },
                                     {
-                                      "atom": "false"
+                                      "kind": "string",
+                                      "text": "\"false\""
                                     }
                                   ]
                                 }
                               ]
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "begin"
+                                  "kind": "symbol",
+                                  "text": "begin"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "for-each"
+                                      "kind": "symbol",
+                                      "text": "for-each"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "lambda"
+                                          "kind": "symbol",
+                                          "text": "lambda"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "c"
+                                              "kind": "symbol",
+                                              "text": "c"
                                             }
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "if"
+                                              "kind": "symbol",
+                                              "text": "if"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "="
+                                                  "kind": "symbol",
+                                                  "text": "="
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "o"
+                                                      "kind": "symbol",
+                                                      "text": "o"
                                                     },
                                                     {
-                                                      "atom": "customerId"
+                                                      "kind": "string",
+                                                      "text": "\"customerId\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "hash-table-ref"
+                                                      "kind": "symbol",
+                                                      "text": "hash-table-ref"
                                                     },
                                                     {
-                                                      "atom": "c"
+                                                      "kind": "symbol",
+                                                      "text": "c"
                                                     },
                                                     {
-                                                      "atom": "id"
+                                                      "kind": "string",
+                                                      "text": "\"id\""
                                                     }
                                                   ]
                                                 }
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "begin"
+                                                  "kind": "symbol",
+                                                  "text": "begin"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "set!"
+                                                      "kind": "symbol",
+                                                      "text": "set!"
                                                     },
                                                     {
-                                                      "atom": "matched44"
+                                                      "kind": "symbol",
+                                                      "text": "matched44"
                                                     },
                                                     {
-                                                      "atom": "true"
+                                                      "kind": "string",
+                                                      "text": "\"true\""
                                                     }
                                                   ]
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "set!"
+                                                      "kind": "symbol",
+                                                      "text": "set!"
                                                     },
                                                     {
-                                                      "atom": "res43"
+                                                      "kind": "symbol",
+                                                      "text": "res43"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "append"
+                                                          "kind": "symbol",
+                                                          "text": "append"
                                                         },
                                                         {
-                                                          "atom": "res43"
+                                                          "kind": "symbol",
+                                                          "text": "res43"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "alist-\u003ehash-table"
+                                                                  "kind": "symbol",
+                                                                  "text": "alist-\u003ehash-table"
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "list"
+                                                                      "kind": "symbol",
+                                                                      "text": "list"
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "cons"
+                                                                          "kind": "symbol",
+                                                                          "text": "cons"
                                                                         },
                                                                         {
-                                                                          "atom": "customerName"
+                                                                          "kind": "string",
+                                                                          "text": "\"customerName\""
                                                                         },
                                                                         {
-                                                                          "list": [
+                                                                          "kind": "list",
+                                                                          "children": [
                                                                             {
-                                                                              "atom": "hash-table-ref"
+                                                                              "kind": "symbol",
+                                                                              "text": "hash-table-ref"
                                                                             },
                                                                             {
-                                                                              "atom": "c"
+                                                                              "kind": "symbol",
+                                                                              "text": "c"
                                                                             },
                                                                             {
-                                                                              "atom": "name"
+                                                                              "kind": "string",
+                                                                              "text": "\"name\""
                                                                             }
                                                                           ]
                                                                         }
                                                                       ]
                                                                     },
                                                                     {
-                                                                      "list": [
+                                                                      "kind": "list",
+                                                                      "children": [
                                                                         {
-                                                                          "atom": "cons"
+                                                                          "kind": "symbol",
+                                                                          "text": "cons"
                                                                         },
                                                                         {
-                                                                          "atom": "order"
+                                                                          "kind": "string",
+                                                                          "text": "\"order\""
                                                                         },
                                                                         {
-                                                                          "atom": "o"
+                                                                          "kind": "symbol",
+                                                                          "text": "o"
                                                                         }
                                                                       ]
                                                                     }
@@ -620,12 +814,15 @@
                                               ]
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "quote"
+                                                  "kind": "symbol",
+                                                  "text": "quote"
                                                 },
                                                 {
-                                                  "atom": "nil"
+                                                  "kind": "symbol",
+                                                  "text": "nil"
                                                 }
                                               ]
                                             }
@@ -634,44 +831,58 @@
                                       ]
                                     },
                                     {
-                                      "atom": "customers"
+                                      "kind": "symbol",
+                                      "text": "customers"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "if"
+                                      "kind": "symbol",
+                                      "text": "if"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "not"
+                                          "kind": "symbol",
+                                          "text": "not"
                                         },
                                         {
-                                          "atom": "matched44"
+                                          "kind": "symbol",
+                                          "text": "matched44"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "let"
+                                          "kind": "symbol",
+                                          "text": "let"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "c"
+                                                  "kind": "symbol",
+                                                  "text": "c"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "quote"
+                                                      "kind": "symbol",
+                                                      "text": "quote"
                                                     },
                                                     {
-                                                      "atom": "nil"
+                                                      "kind": "symbol",
+                                                      "text": "nil"
                                                     }
                                                   ]
                                                 }
@@ -680,69 +891,92 @@
                                           ]
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "set!"
+                                              "kind": "symbol",
+                                              "text": "set!"
                                             },
                                             {
-                                              "atom": "res43"
+                                              "kind": "symbol",
+                                              "text": "res43"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "append"
+                                                  "kind": "symbol",
+                                                  "text": "append"
                                                 },
                                                 {
-                                                  "atom": "res43"
+                                                  "kind": "symbol",
+                                                  "text": "res43"
                                                 },
                                                 {
-                                                  "list": [
+                                                  "kind": "list",
+                                                  "children": [
                                                     {
-                                                      "atom": "list"
+                                                      "kind": "symbol",
+                                                      "text": "list"
                                                     },
                                                     {
-                                                      "list": [
+                                                      "kind": "list",
+                                                      "children": [
                                                         {
-                                                          "atom": "alist-\u003ehash-table"
+                                                          "kind": "symbol",
+                                                          "text": "alist-\u003ehash-table"
                                                         },
                                                         {
-                                                          "list": [
+                                                          "kind": "list",
+                                                          "children": [
                                                             {
-                                                              "atom": "list"
+                                                              "kind": "symbol",
+                                                              "text": "list"
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "cons"
+                                                                  "kind": "symbol",
+                                                                  "text": "cons"
                                                                 },
                                                                 {
-                                                                  "atom": "customerName"
+                                                                  "kind": "string",
+                                                                  "text": "\"customerName\""
                                                                 },
                                                                 {
-                                                                  "list": [
+                                                                  "kind": "list",
+                                                                  "children": [
                                                                     {
-                                                                      "atom": "hash-table-ref"
+                                                                      "kind": "symbol",
+                                                                      "text": "hash-table-ref"
                                                                     },
                                                                     {
-                                                                      "atom": "c"
+                                                                      "kind": "symbol",
+                                                                      "text": "c"
                                                                     },
                                                                     {
-                                                                      "atom": "name"
+                                                                      "kind": "string",
+                                                                      "text": "\"name\""
                                                                     }
                                                                   ]
                                                                 }
                                                               ]
                                                             },
                                                             {
-                                                              "list": [
+                                                              "kind": "list",
+                                                              "children": [
                                                                 {
-                                                                  "atom": "cons"
+                                                                  "kind": "symbol",
+                                                                  "text": "cons"
                                                                 },
                                                                 {
-                                                                  "atom": "order"
+                                                                  "kind": "string",
+                                                                  "text": "\"order\""
                                                                 },
                                                                 {
-                                                                  "atom": "o"
+                                                                  "kind": "symbol",
+                                                                  "text": "o"
                                                                 }
                                                               ]
                                                             }
@@ -759,12 +993,15 @@
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "quote"
+                                          "kind": "symbol",
+                                          "text": "quote"
                                         },
                                         {
-                                          "atom": "nil"
+                                          "kind": "symbol",
+                                          "text": "nil"
                                         }
                                       ]
                                     }
@@ -777,12 +1014,14 @@
                       ]
                     },
                     {
-                      "atom": "orders"
+                      "kind": "symbol",
+                      "text": "orders"
                     }
                   ]
                 },
                 {
-                  "atom": "res43"
+                  "kind": "symbol",
+                  "text": "res43"
                 }
               ]
             }
@@ -791,305 +1030,398 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "--- Right Join using syntax ---"
+          "kind": "string",
+          "text": "\"--- Right Join using syntax ---\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "for-each"
+          "kind": "symbol",
+          "text": "for-each"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "entry"
+                  "kind": "symbol",
+                  "text": "entry"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table-ref"
+                          "kind": "symbol",
+                          "text": "hash-table-ref"
                         },
                         {
-                          "atom": "entry"
+                          "kind": "symbol",
+                          "text": "entry"
                         },
                         {
-                          "atom": "order"
+                          "kind": "string",
+                          "text": "\"order\""
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "Customer"
+                              "kind": "string",
+                              "text": "\"Customer\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "atom": "entry"
+                                  "kind": "symbol",
+                                  "text": "entry"
                                 },
                                 {
-                                  "atom": "customerName"
+                                  "kind": "string",
+                                  "text": "\"customerName\""
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "has order"
+                              "kind": "string",
+                              "text": "\"has order\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-ref"
+                                      "kind": "symbol",
+                                      "text": "hash-table-ref"
                                     },
                                     {
-                                      "atom": "entry"
+                                      "kind": "symbol",
+                                      "text": "entry"
                                     },
                                     {
-                                      "atom": "order"
+                                      "kind": "string",
+                                      "text": "\"order\""
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "id"
+                                  "kind": "string",
+                                  "text": "\"id\""
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "- $"
+                              "kind": "string",
+                              "text": "\"- $\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "hash-table-ref"
+                                      "kind": "symbol",
+                                      "text": "hash-table-ref"
                                     },
                                     {
-                                      "atom": "entry"
+                                      "kind": "symbol",
+                                      "text": "entry"
                                     },
                                     {
-                                      "atom": "order"
+                                      "kind": "string",
+                                      "text": "\"order\""
                                     }
                                   ]
                                 },
                                 {
-                                  "atom": "total"
+                                  "kind": "string",
+                                  "text": "\"total\""
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "newline"
+                              "kind": "symbol",
+                              "text": "newline"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "begin"
+                          "kind": "symbol",
+                          "text": "begin"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "Customer"
+                              "kind": "string",
+                              "text": "\"Customer\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-ref"
+                                  "kind": "symbol",
+                                  "text": "hash-table-ref"
                                 },
                                 {
-                                  "atom": "entry"
+                                  "kind": "symbol",
+                                  "text": "entry"
                                 },
                                 {
-                                  "atom": "customerName"
+                                  "kind": "string",
+                                  "text": "\"customerName\""
                                 }
                               ]
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": " "
+                              "kind": "string",
+                              "text": "\" \""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "display"
+                              "kind": "symbol",
+                              "text": "display"
                             },
                             {
-                              "atom": "has no orders"
+                              "kind": "string",
+                              "text": "\"has no orders\""
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "newline"
+                              "kind": "symbol",
+                              "text": "newline"
                             }
                           ]
                         }
@@ -1102,7 +1434,8 @@
           ]
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/short_circuit.scheme.json
+++ b/tests/json-ast/x/scheme/short_circuit.scheme.json
@@ -1,186 +1,245 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "boom"
+              "kind": "symbol",
+              "text": "boom"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "a"
             },
             {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "b"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "display"
+                  "kind": "symbol",
+                  "text": "display"
                 },
                 {
-                  "atom": "boom"
+                  "kind": "string",
+                  "text": "\"boom\""
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "newline"
+                  "kind": "symbol",
+                  "text": "newline"
                 }
               ]
             },
             {
-              "atom": "true"
+              "kind": "string",
+              "text": "\"true\""
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "and"
+                  "kind": "symbol",
+                  "text": "and"
                 },
                 {
-                  "atom": "false"
+                  "kind": "string",
+                  "text": "\"false\""
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boom"
+                      "kind": "symbol",
+                      "text": "boom"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "or"
+                  "kind": "symbol",
+                  "text": "or"
                 },
                 {
-                  "atom": "true"
+                  "kind": "string",
+                  "text": "\"true\""
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boom"
+                      "kind": "symbol",
+                      "text": "boom"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/slice.scheme.json
+++ b/tests/json-ast/x/scheme/slice.scheme.json
@@ -1,88 +1,119 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "take"
+              "kind": "symbol",
+              "text": "take"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "drop"
+                  "kind": "symbol",
+                  "text": "drop"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "-"
+                  "kind": "symbol",
+                  "text": "-"
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 }
               ]
             }
@@ -91,58 +122,76 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "take"
+              "kind": "symbol",
+              "text": "take"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "drop"
+                  "kind": "symbol",
+                  "text": "drop"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     },
                     {
-                      "atom": "3"
+                      "kind": "number",
+                      "text": "3"
                     }
                   ]
                 },
                 {
-                  "atom": "0"
+                  "kind": "number",
+                  "text": "0"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "-"
+                  "kind": "symbol",
+                  "text": "-"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 },
                 {
-                  "atom": "0"
+                  "kind": "number",
+                  "text": "0"
                 }
               ]
             }
@@ -151,39 +200,50 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "substring"
+              "kind": "symbol",
+              "text": "substring"
             },
             {
-              "atom": "hello"
+              "kind": "string",
+              "text": "\"hello\""
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "4"
+              "kind": "number",
+              "text": "4"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/sort_stable.scheme.json
+++ b/tests/json-ast/x/scheme/sort_stable.scheme.json
@@ -1,88 +1,120 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "items"
+          "kind": "symbol",
+          "text": "items"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "list"
+              "kind": "symbol",
+              "text": "list"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "n"
+                          "kind": "string",
+                          "text": "\"n\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "v"
+                          "kind": "string",
+                          "text": "\"v\""
                         },
                         {
-                          "atom": "a"
+                          "kind": "string",
+                          "text": "\"a\""
                         }
                       ]
                     }
@@ -91,38 +123,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "n"
+                          "kind": "string",
+                          "text": "\"n\""
                         },
                         {
-                          "atom": "1"
+                          "kind": "number",
+                          "text": "1"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "v"
+                          "kind": "string",
+                          "text": "\"v\""
                         },
                         {
-                          "atom": "b"
+                          "kind": "string",
+                          "text": "\"b\""
                         }
                       ]
                     }
@@ -131,38 +175,50 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "alist-\u003ehash-table"
+                  "kind": "symbol",
+                  "text": "alist-\u003ehash-table"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list"
+                      "kind": "symbol",
+                      "text": "list"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "n"
+                          "kind": "string",
+                          "text": "\"n\""
                         },
                         {
-                          "atom": "2"
+                          "kind": "number",
+                          "text": "2"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "cons"
+                          "kind": "symbol",
+                          "text": "cons"
                         },
                         {
-                          "atom": "v"
+                          "kind": "string",
+                          "text": "\"v\""
                         },
                         {
-                          "atom": "c"
+                          "kind": "string",
+                          "text": "\"c\""
                         }
                       ]
                     }
@@ -175,29 +231,39 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "let"
+              "kind": "symbol",
+              "text": "let"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "res45"
+                      "kind": "symbol",
+                      "text": "res45"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list"
+                          "kind": "symbol",
+                          "text": "list"
                         }
                       ]
                     }
@@ -206,58 +272,78 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "begin"
+                  "kind": "symbol",
+                  "text": "begin"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "for-each"
+                      "kind": "symbol",
+                      "text": "for-each"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "lambda"
+                          "kind": "symbol",
+                          "text": "lambda"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "i"
+                              "kind": "symbol",
+                              "text": "i"
                             }
                           ]
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "set!"
+                              "kind": "symbol",
+                              "text": "set!"
                             },
                             {
-                              "atom": "res45"
+                              "kind": "symbol",
+                              "text": "res45"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "append"
+                                  "kind": "symbol",
+                                  "text": "append"
                                 },
                                 {
-                                  "atom": "res45"
+                                  "kind": "symbol",
+                                  "text": "res45"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "list"
+                                      "kind": "symbol",
+                                      "text": "list"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "hash-table-ref"
+                                          "kind": "symbol",
+                                          "text": "hash-table-ref"
                                         },
                                         {
-                                          "atom": "i"
+                                          "kind": "symbol",
+                                          "text": "i"
                                         },
                                         {
-                                          "atom": "v"
+                                          "kind": "string",
+                                          "text": "\"v\""
                                         }
                                       ]
                                     }
@@ -270,12 +356,14 @@
                       ]
                     },
                     {
-                      "atom": "items"
+                      "kind": "symbol",
+                      "text": "items"
                     }
                   ]
                 },
                 {
-                  "atom": "res45"
+                  "kind": "symbol",
+                  "text": "res45"
                 }
               ]
             }
@@ -284,19 +372,24 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "atom": "result"
+          "kind": "symbol",
+          "text": "result"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/str_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/str_builtin.scheme.json
@@ -1,63 +1,85 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "number-\u003estring"
+              "kind": "symbol",
+              "text": "number-\u003estring"
             },
             {
-              "atom": "123"
+              "kind": "number",
+              "text": "123"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_compare.scheme.json
+++ b/tests/json-ast/x/scheme/string_compare.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,38 +393,42 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string\u003c?"
+                      "kind": "symbol",
+                      "text": "string\u003c?"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -340,45 +437,51 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string\u003c=?"
+                      "kind": "symbol",
+                      "text": "string\u003c=?"
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -387,45 +490,51 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string\u003e?"
+                      "kind": "symbol",
+                      "text": "string\u003e?"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "a"
+                      "kind": "string",
+                      "text": "\"a\""
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -434,45 +543,51 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string\u003e=?"
+                      "kind": "symbol",
+                      "text": "string\u003e=?"
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     },
                     {
-                      "atom": "b"
+                      "kind": "string",
+                      "text": "\"b\""
                     }
                   ]
-                },
-                {
-                  "atom": "#t"
-                },
-                {
-                  "atom": "#f"
                 }
               ]
             }
@@ -481,9 +596,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_concat.scheme.json
+++ b/tests/json-ast/x/scheme/string_concat.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,25 +393,33 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "string-append"
+                  "kind": "symbol",
+                  "text": "string-append"
                 },
                 {
-                  "atom": "hello "
+                  "kind": "string",
+                  "text": "\"hello \""
                 },
                 {
-                  "atom": "world"
+                  "kind": "string",
+                  "text": "\"world\""
                 }
               ]
             }
@@ -327,9 +428,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_contains.scheme.json
+++ b/tests/json-ast/x/scheme/string_contains.scheme.json
@@ -1,158 +1,209 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s"
+          "kind": "symbol",
+          "text": "s"
         },
         {
-          "atom": "catch"
+          "kind": "string",
+          "text": "\"catch\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-contains"
+                      "kind": "symbol",
+                      "text": "string-contains"
                     },
                     {
-                      "atom": "s"
+                      "kind": "symbol",
+                      "text": "s"
                     },
                     {
-                      "atom": "cat"
+                      "kind": "string",
+                      "text": "\"cat\""
                     }
                   ]
                 },
                 {
-                  "atom": "true"
+                  "kind": "string",
+                  "text": "\"true\""
                 },
                 {
-                  "atom": "false"
+                  "kind": "string",
+                  "text": "\"false\""
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-contains"
+                      "kind": "symbol",
+                      "text": "string-contains"
                     },
                     {
-                      "atom": "s"
+                      "kind": "symbol",
+                      "text": "s"
                     },
                     {
-                      "atom": "dog"
+                      "kind": "string",
+                      "text": "\"dog\""
                     }
                   ]
                 },
                 {
-                  "atom": "true"
+                  "kind": "string",
+                  "text": "\"true\""
                 },
                 {
-                  "atom": "false"
+                  "kind": "string",
+                  "text": "\"false\""
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_in_operator.scheme.json
+++ b/tests/json-ast/x/scheme/string_in_operator.scheme.json
@@ -1,178 +1,237 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s"
+          "kind": "symbol",
+          "text": "s"
         },
         {
-          "atom": "catch"
+          "kind": "string",
+          "text": "\"catch\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "cat"
+                              "kind": "string",
+                              "text": "\"cat\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "cat"
+                              "kind": "string",
+                              "text": "\"cat\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "cat"
+                              "kind": "string",
+                              "text": "\"cat\""
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -181,145 +240,189 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "cond"
+                  "kind": "symbol",
+                  "text": "cond"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-contains"
+                              "kind": "symbol",
+                              "text": "string-contains"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "dog"
+                              "kind": "string",
+                              "text": "\"dog\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "hash-table?"
+                          "kind": "symbol",
+                          "text": "hash-table?"
                         },
                         {
-                          "atom": "s"
+                          "kind": "symbol",
+                          "text": "s"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "hash-table-exists?"
+                              "kind": "symbol",
+                              "text": "hash-table-exists?"
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             },
                             {
-                              "atom": "dog"
+                              "kind": "string",
+                              "text": "\"dog\""
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "else"
+                      "kind": "symbol",
+                      "text": "else"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "if"
+                          "kind": "symbol",
+                          "text": "if"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "member"
+                              "kind": "symbol",
+                              "text": "member"
                             },
                             {
-                              "atom": "dog"
+                              "kind": "string",
+                              "text": "\"dog\""
                             },
                             {
-                              "atom": "s"
+                              "kind": "symbol",
+                              "text": "s"
                             }
                           ]
                         },
                         {
-                          "atom": "true"
+                          "kind": "string",
+                          "text": "\"true\""
                         },
                         {
-                          "atom": "false"
+                          "kind": "string",
+                          "text": "\"false\""
                         }
                       ]
                     }
@@ -328,19 +431,23 @@
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_index.scheme.json
+++ b/tests/json-ast/x/scheme/string_index.scheme.json
@@ -1,79 +1,106 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s"
+          "kind": "symbol",
+          "text": "s"
         },
         {
-          "atom": "mochi"
+          "kind": "string",
+          "text": "\"mochi\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-ref"
+              "kind": "symbol",
+              "text": "string-ref"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/string_prefix_slice.scheme.json
+++ b/tests/json-ast/x/scheme/string_prefix_slice.scheme.json
@@ -1,66 +1,90 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 06:19 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "begin"
+          "kind": "symbol",
+          "text": "begin"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "current-error-port"
+              "kind": "symbol",
+              "text": "current-error-port"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "open-output-string"
+                  "kind": "symbol",
+                  "text": "open-output-string"
                 }
               ]
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "import"
+              "kind": "symbol",
+              "text": "import"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "srfi"
+                  "kind": "symbol",
+                  "text": "srfi"
                 },
                 {
-                  "atom": "69"
+                  "kind": "number",
+                  "text": "69"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "sort"
+                  "kind": "symbol",
+                  "text": "sort"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "chibi"
+                  "kind": "symbol",
+                  "text": "chibi"
                 },
                 {
-                  "atom": "string"
+                  "kind": "symbol",
+                  "text": "string"
                 }
               ]
             }
@@ -69,86 +93,114 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "and"
+                      "kind": "symbol",
+                      "text": "and"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "list?"
+                          "kind": "symbol",
+                          "text": "list?"
                         },
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "pair?"
+                          "kind": "symbol",
+                          "text": "pair?"
                         },
                         {
-                          "atom": "x"
+                          "kind": "symbol",
+                          "text": "x"
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "pair?"
+                          "kind": "symbol",
+                          "text": "pair?"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "car"
+                              "kind": "symbol",
+                              "text": "car"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         }
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string?"
+                          "kind": "symbol",
+                          "text": "string?"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "car"
+                              "kind": "symbol",
+                              "text": "car"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "car"
+                                  "kind": "symbol",
+                                  "text": "car"
                                 },
                                 {
-                                  "atom": "x"
+                                  "kind": "symbol",
+                                  "text": "x"
                                 }
                               ]
                             }
@@ -159,68 +211,83 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "{"
+                      "kind": "string",
+                      "text": "\"{\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "lambda"
+                                  "kind": "symbol",
+                                  "text": "lambda"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "kv"
+                                      "kind": "symbol",
+                                      "text": "kv"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "string-append"
+                                      "kind": "symbol",
+                                      "text": "string-append"
                                     },
                                     {
-                                      "atom": "\""
-                                    },
-                                    {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "car"
+                                          "kind": "symbol",
+                                          "text": "car"
                                         },
                                         {
-                                          "atom": "kv"
+                                          "kind": "symbol",
+                                          "text": "kv"
                                         }
                                       ]
                                     },
                                     {
-                                      "atom": "\": "
-                                    },
-                                    {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "to-str"
+                                          "kind": "symbol",
+                                          "text": "to-str"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "cdr"
+                                              "kind": "symbol",
+                                              "text": "cdr"
                                             },
                                             {
-                                              "atom": "kv"
+                                              "kind": "symbol",
+                                              "text": "kv"
                                             }
                                           ]
                                         }
@@ -231,53 +298,68 @@
                               ]
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "}"
+                      "kind": "string",
+                      "text": "\"}\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "hash-table?"
+                      "kind": "symbol",
+                      "text": "hash-table?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "let"
+                      "kind": "symbol",
+                      "text": "let"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "pairs"
+                              "kind": "symbol",
+                              "text": "pairs"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "hash-table-\u003ealist"
+                                  "kind": "symbol",
+                                  "text": "hash-table-\u003ealist"
                                 },
                                 {
-                                  "atom": "x"
+                                  "kind": "symbol",
+                                  "text": "x"
                                 }
                               ]
                             }
@@ -286,68 +368,83 @@
                       ]
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-append"
+                          "kind": "symbol",
+                          "text": "string-append"
                         },
                         {
-                          "atom": "{"
+                          "kind": "string",
+                          "text": "\"{\""
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "string-join"
+                              "kind": "symbol",
+                              "text": "string-join"
                             },
                             {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "map"
+                                  "kind": "symbol",
+                                  "text": "map"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "lambda"
+                                      "kind": "symbol",
+                                      "text": "lambda"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "kv"
+                                          "kind": "symbol",
+                                          "text": "kv"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "string-append"
+                                          "kind": "symbol",
+                                          "text": "string-append"
                                         },
                                         {
-                                          "atom": "\""
-                                        },
-                                        {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "car"
+                                              "kind": "symbol",
+                                              "text": "car"
                                             },
                                             {
-                                              "atom": "kv"
+                                              "kind": "symbol",
+                                              "text": "kv"
                                             }
                                           ]
                                         },
                                         {
-                                          "atom": "\": "
-                                        },
-                                        {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "to-str"
+                                              "kind": "symbol",
+                                              "text": "to-str"
                                             },
                                             {
-                                              "list": [
+                                              "kind": "list",
+                                              "children": [
                                                 {
-                                                  "atom": "cdr"
+                                                  "kind": "symbol",
+                                                  "text": "cdr"
                                                 },
                                                 {
-                                                  "atom": "kv"
+                                                  "kind": "symbol",
+                                                  "text": "kv"
                                                 }
                                               ]
                                             }
@@ -358,17 +455,20 @@
                                   ]
                                 },
                                 {
-                                  "atom": "pairs"
+                                  "kind": "symbol",
+                                  "text": "pairs"
                                 }
                               ]
                             },
                             {
-                              "atom": ", "
+                              "kind": "string",
+                              "text": "\", \""
                             }
                           ]
                         },
                         {
-                          "atom": "}"
+                          "kind": "string",
+                          "text": "\"}\""
                         }
                       ]
                     }
@@ -377,127 +477,157 @@
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "list?"
+                      "kind": "symbol",
+                      "text": "list?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "\""
-                    },
-                    {
-                      "atom": "x"
-                    },
-                    {
-                      "atom": "\""
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "true"
+                      "kind": "string",
+                      "text": "\"true\""
                     },
                     {
-                      "atom": "false"
+                      "kind": "string",
+                      "text": "\"false\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -508,161 +638,209 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "prefix"
+          "kind": "symbol",
+          "text": "prefix"
         },
         {
-          "atom": "fore"
+          "kind": "string",
+          "text": "\"fore\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s1"
+          "kind": "symbol",
+          "text": "s1"
         },
         {
-          "atom": "forest"
+          "kind": "string",
+          "text": "\"forest\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "string=?"
+                  "kind": "symbol",
+                  "text": "string=?"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "substring"
+                      "kind": "symbol",
+                      "text": "substring"
                     },
                     {
-                      "atom": "s1"
+                      "kind": "symbol",
+                      "text": "s1"
                     },
                     {
-                      "atom": "0"
+                      "kind": "number",
+                      "text": "0"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-length"
+                          "kind": "symbol",
+                          "text": "string-length"
                         },
                         {
-                          "atom": "prefix"
+                          "kind": "symbol",
+                          "text": "prefix"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "prefix"
+                  "kind": "symbol",
+                  "text": "prefix"
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "s2"
+          "kind": "symbol",
+          "text": "s2"
         },
         {
-          "atom": "desert"
+          "kind": "string",
+          "text": "\"desert\""
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "if"
+              "kind": "symbol",
+              "text": "if"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "string=?"
+                  "kind": "symbol",
+                  "text": "string=?"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "substring"
+                      "kind": "symbol",
+                      "text": "substring"
                     },
                     {
-                      "atom": "s2"
+                      "kind": "symbol",
+                      "text": "s2"
                     },
                     {
-                      "atom": "0"
+                      "kind": "number",
+                      "text": "0"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-length"
+                          "kind": "symbol",
+                          "text": "string-length"
                         },
                         {
-                          "atom": "prefix"
+                          "kind": "symbol",
+                          "text": "prefix"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "prefix"
+                  "kind": "symbol",
+                  "text": "prefix"
                 }
               ]
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/substring_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/substring_builtin.scheme.json
@@ -1,69 +1,93 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "substring"
+              "kind": "symbol",
+              "text": "substring"
             },
             {
-              "atom": "mochi"
+              "kind": "string",
+              "text": "\"mochi\""
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             },
             {
-              "atom": "4"
+              "kind": "number",
+              "text": "4"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/sum_builtin.scheme.json
+++ b/tests/json-ast/x/scheme/sum_builtin.scheme.json
@@ -1,68 +1,93 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "apply"
+              "kind": "symbol",
+              "text": "apply"
             },
             {
-              "atom": "+"
+              "kind": "symbol",
+              "text": "+"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "list"
+                  "kind": "symbol",
+                  "text": "list"
                 },
                 {
-                  "atom": "1"
+                  "kind": "number",
+                  "text": "1"
                 },
                 {
-                  "atom": "2"
+                  "kind": "number",
+                  "text": "2"
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 }
               ]
             }
@@ -71,9 +96,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/tail_recursion.scheme.json
+++ b/tests/json-ast/x/scheme/tail_recursion.scheme.json
@@ -1,133 +1,178 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-21 17:26 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "1"
+              "kind": "number",
+              "text": "1"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "srfi"
+              "kind": "symbol",
+              "text": "srfi"
             },
             {
-              "atom": "69"
+              "kind": "number",
+              "text": "69"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "sum_rec"
+              "kind": "symbol",
+              "text": "sum_rec"
             },
             {
-              "atom": "n"
+              "kind": "symbol",
+              "text": "n"
             },
             {
-              "atom": "acc"
+              "kind": "symbol",
+              "text": "acc"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "begin"
+              "kind": "symbol",
+              "text": "begin"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "if"
+                  "kind": "symbol",
+                  "text": "if"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "="
+                      "kind": "symbol",
+                      "text": "="
                     },
                     {
-                      "atom": "n"
+                      "kind": "symbol",
+                      "text": "n"
                     },
                     {
-                      "atom": "0"
+                      "kind": "number",
+                      "text": "0"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "begin"
+                      "kind": "symbol",
+                      "text": "begin"
                     },
                     {
-                      "atom": "acc"
+                      "kind": "symbol",
+                      "text": "acc"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "quote"
+                      "kind": "symbol",
+                      "text": "quote"
                     },
                     {
-                      "atom": "nil"
+                      "kind": "symbol",
+                      "text": "nil"
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "sum_rec"
+                  "kind": "symbol",
+                  "text": "sum_rec"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "-"
+                      "kind": "symbol",
+                      "text": "-"
                     },
                     {
-                      "atom": "n"
+                      "kind": "symbol",
+                      "text": "n"
                     },
                     {
-                      "atom": "1"
+                      "kind": "number",
+                      "text": "1"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "+"
+                      "kind": "symbol",
+                      "text": "+"
                     },
                     {
-                      "atom": "acc"
+                      "kind": "symbol",
+                      "text": "acc"
                     },
                     {
-                      "atom": "n"
+                      "kind": "symbol",
+                      "text": "n"
                     }
                   ]
                 }
@@ -138,29 +183,37 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "sum_rec"
+              "kind": "symbol",
+              "text": "sum_rec"
             },
             {
-              "atom": "10"
+              "kind": "number",
+              "text": "10"
             },
             {
-              "atom": "0"
+              "kind": "number",
+              "text": "0"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/typed_let.scheme.json
+++ b/tests/json-ast/x/scheme/typed_let.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,39 +393,50 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "y"
+          "kind": "symbol",
+          "text": "y"
         },
         {
-          "atom": "0"
+          "kind": "number",
+          "text": "0"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "y"
+              "kind": "symbol",
+              "text": "y"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/typed_var.scheme.json
+++ b/tests/json-ast/x/scheme/typed_var.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,39 +393,50 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "0"
+          "kind": "number",
+          "text": "0"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/unary_neg.scheme.json
+++ b/tests/json-ast/x/scheme/unary_neg.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,22 +393,29 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "-"
+                  "kind": "symbol",
+                  "text": "-"
                 },
                 {
-                  "atom": "3"
+                  "kind": "number",
+                  "text": "3"
                 }
               ]
             }
@@ -324,37 +424,49 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "+"
+                  "kind": "symbol",
+                  "text": "+"
                 },
                 {
-                  "atom": "5"
+                  "kind": "number",
+                  "text": "5"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "-"
+                      "kind": "symbol",
+                      "text": "-"
                     },
                     {
-                      "atom": "2"
+                      "kind": "number",
+                      "text": "2"
                     }
                   ]
                 }
@@ -365,9 +477,11 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/var_assignment.scheme.json
+++ b/tests/json-ast/x/scheme/var_assignment.scheme.json
@@ -1,181 +1,240 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-25 08:58 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "chibi"
+              "kind": "symbol",
+              "text": "chibi"
             },
             {
-              "atom": "string"
+              "kind": "symbol",
+              "text": "string"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "char"
+                  "kind": "symbol",
+                  "text": "char"
                 }
               ]
             },
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "string-downcase"
+              "kind": "symbol",
+              "text": "string-downcase"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -186,112 +245,146 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "upper"
+              "kind": "symbol",
+              "text": "upper"
             },
             {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "string-upcase"
+              "kind": "symbol",
+              "text": "string-upcase"
             },
             {
-              "atom": "s"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "list": [
-        {
-          "atom": "define"
-        },
-        {
-          "list": [
-            {
-              "atom": "lower"
-            },
-            {
-              "atom": "s"
-            }
-          ]
-        },
-        {
-          "list": [
-            {
-              "atom": "string-downcase"
-            },
-            {
-              "atom": "s"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "fmod"
+              "kind": "symbol",
+              "text": "lower"
             },
             {
-              "atom": "a"
-            },
-            {
-              "atom": "b"
+              "kind": "symbol",
+              "text": "s"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "-"
+              "kind": "symbol",
+              "text": "string-downcase"
             },
             {
-              "atom": "a"
+              "kind": "symbol",
+              "text": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "list",
+      "children": [
+        {
+          "kind": "symbol",
+          "text": "define"
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "fmod"
             },
             {
-              "list": [
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "symbol",
+              "text": "b"
+            }
+          ]
+        },
+        {
+          "kind": "list",
+          "children": [
+            {
+              "kind": "symbol",
+              "text": "-"
+            },
+            {
+              "kind": "symbol",
+              "text": "a"
+            },
+            {
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "*"
+                  "kind": "symbol",
+                  "text": "*"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "floor"
+                      "kind": "symbol",
+                      "text": "floor"
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "/"
+                          "kind": "symbol",
+                          "text": "/"
                         },
                         {
-                          "atom": "a"
+                          "kind": "symbol",
+                          "text": "a"
                         },
                         {
-                          "atom": "b"
+                          "kind": "symbol",
+                          "text": "b"
                         }
                       ]
                     }
                   ]
                 },
                 {
-                  "atom": "b"
+                  "kind": "symbol",
+                  "text": "b"
                 }
               ]
             }
@@ -300,52 +393,67 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "1"
+          "kind": "number",
+          "text": "1"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "set!"
+          "kind": "symbol",
+          "text": "set!"
         },
         {
-          "atom": "x"
+          "kind": "symbol",
+          "text": "x"
         },
         {
-          "atom": "2"
+          "kind": "number",
+          "text": "2"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "display"
+          "kind": "symbol",
+          "text": "display"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "newline"
+          "kind": "symbol",
+          "text": "newline"
         }
       ]
     }

--- a/tests/json-ast/x/scheme/while_loop.scheme.json
+++ b/tests/json-ast/x/scheme/while_loop.scheme.json
@@ -1,161 +1,214 @@
 {
   "forms": [
     {
-      "list": [
+      "kind": "comment",
+      "text": ";; Generated on 2025-07-22 10:01 +0700"
+    },
+    {
+      "kind": "list",
+      "children": [
         {
-          "atom": "import"
+          "kind": "symbol",
+          "text": "import"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "only"
+              "kind": "symbol",
+              "text": "only"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "scheme"
+                  "kind": "symbol",
+                  "text": "scheme"
                 },
                 {
-                  "atom": "base"
+                  "kind": "symbol",
+                  "text": "base"
                 }
               ]
             },
             {
-              "atom": "call/cc"
+              "kind": "symbol",
+              "text": "call/cc"
             }
           ]
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "to-str"
+              "kind": "symbol",
+              "text": "to-str"
             },
             {
-              "atom": "x"
+              "kind": "symbol",
+              "text": "x"
             }
           ]
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "cond"
+              "kind": "symbol",
+              "text": "cond"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "pair?"
+                      "kind": "symbol",
+                      "text": "pair?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string-append"
+                      "kind": "symbol",
+                      "text": "string-append"
                     },
                     {
-                      "atom": "["
+                      "kind": "string",
+                      "text": "\"[\""
                     },
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "string-join"
+                          "kind": "symbol",
+                          "text": "string-join"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "map"
+                              "kind": "symbol",
+                              "text": "map"
                             },
                             {
-                              "atom": "to-str"
+                              "kind": "symbol",
+                              "text": "to-str"
                             },
                             {
-                              "atom": "x"
+                              "kind": "symbol",
+                              "text": "x"
                             }
                           ]
                         },
                         {
-                          "atom": ", "
+                          "kind": "string",
+                          "text": "\", \""
                         }
                       ]
                     },
                     {
-                      "atom": "]"
+                      "kind": "string",
+                      "text": "\"]\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "string?"
+                      "kind": "symbol",
+                      "text": "string?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "atom": "x"
+                  "kind": "symbol",
+                  "text": "x"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "boolean?"
+                      "kind": "symbol",
+                      "text": "boolean?"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "if"
+                      "kind": "symbol",
+                      "text": "if"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     },
                     {
-                      "atom": "1"
+                      "kind": "string",
+                      "text": "\"1\""
                     },
                     {
-                      "atom": "0"
+                      "kind": "string",
+                      "text": "\"0\""
                     }
                   ]
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "else"
+                  "kind": "symbol",
+                  "text": "else"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "number-\u003estring"
+                      "kind": "symbol",
+                      "text": "number-\u003estring"
                     },
                     {
-                      "atom": "x"
+                      "kind": "symbol",
+                      "text": "x"
                     }
                   ]
                 }
@@ -166,141 +219,182 @@
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "define"
+          "kind": "symbol",
+          "text": "define"
         },
         {
-          "atom": "i"
+          "kind": "symbol",
+          "text": "i"
         },
         {
-          "atom": "0"
+          "kind": "number",
+          "text": "0"
         }
       ]
     },
     {
-      "list": [
+      "kind": "list",
+      "children": [
         {
-          "atom": "call/cc"
+          "kind": "symbol",
+          "text": "call/cc"
         },
         {
-          "list": [
+          "kind": "list",
+          "children": [
             {
-              "atom": "lambda"
+              "kind": "symbol",
+              "text": "lambda"
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "break2"
+                  "kind": "symbol",
+                  "text": "break2"
                 }
               ]
             },
             {
-              "list": [
+              "kind": "list",
+              "children": [
                 {
-                  "atom": "letrec"
+                  "kind": "symbol",
+                  "text": "letrec"
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "list": [
+                      "kind": "list",
+                      "children": [
                         {
-                          "atom": "loop1"
+                          "kind": "symbol",
+                          "text": "loop1"
                         },
                         {
-                          "list": [
+                          "kind": "list",
+                          "children": [
                             {
-                              "atom": "lambda"
+                              "kind": "symbol",
+                              "text": "lambda"
                             },
                             {
-                              "atom": "()"
-                            },
-                            {
-                              "list": [
+                              "kind": "list",
+                              "children": [
                                 {
-                                  "atom": "if"
+                                  "kind": "symbol",
+                                  "text": "if"
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "\u003c"
+                                      "kind": "symbol",
+                                      "text": "\u003c"
                                     },
                                     {
-                                      "atom": "i"
+                                      "kind": "symbol",
+                                      "text": "i"
                                     },
                                     {
-                                      "atom": "3"
+                                      "kind": "number",
+                                      "text": "3"
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "begin"
+                                      "kind": "symbol",
+                                      "text": "begin"
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "display"
+                                          "kind": "symbol",
+                                          "text": "display"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "to-str"
+                                              "kind": "symbol",
+                                              "text": "to-str"
                                             },
                                             {
-                                              "atom": "i"
+                                              "kind": "symbol",
+                                              "text": "i"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "newline"
+                                          "kind": "symbol",
+                                          "text": "newline"
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "set!"
+                                          "kind": "symbol",
+                                          "text": "set!"
                                         },
                                         {
-                                          "atom": "i"
+                                          "kind": "symbol",
+                                          "text": "i"
                                         },
                                         {
-                                          "list": [
+                                          "kind": "list",
+                                          "children": [
                                             {
-                                              "atom": "+"
+                                              "kind": "symbol",
+                                              "text": "+"
                                             },
                                             {
-                                              "atom": "i"
+                                              "kind": "symbol",
+                                              "text": "i"
                                             },
                                             {
-                                              "atom": "1"
+                                              "kind": "number",
+                                              "text": "1"
                                             }
                                           ]
                                         }
                                       ]
                                     },
                                     {
-                                      "list": [
+                                      "kind": "list",
+                                      "children": [
                                         {
-                                          "atom": "loop1"
+                                          "kind": "symbol",
+                                          "text": "loop1"
                                         }
                                       ]
                                     }
                                   ]
                                 },
                                 {
-                                  "list": [
+                                  "kind": "list",
+                                  "children": [
                                     {
-                                      "atom": "quote"
+                                      "kind": "symbol",
+                                      "text": "quote"
                                     },
                                     {
-                                      "atom": "nil"
+                                      "kind": "symbol",
+                                      "text": "nil"
                                     }
                                   ]
                                 }
@@ -313,9 +407,11 @@
                   ]
                 },
                 {
-                  "list": [
+                  "kind": "list",
+                  "children": [
                     {
-                      "atom": "loop1"
+                      "kind": "symbol",
+                      "text": "loop1"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- update Scheme AST representation to use Text field and typed node aliases
- keep only semantic leaves when converting tree-sitter nodes
- regenerate Scheme JSON AST golden files

## Testing
- `go test ./tools/json-ast/x/scheme -tags slow -run TestInspect_Golden`


------
https://chatgpt.com/codex/tasks/task_e_6889dca441348320944bb9a4fa3376e0