### PR TITLE
Add typed wrappers for Ruby JSON AST

### DIFF
--- a/tools/json-ast/x/ruby/ast.go
+++ b/tools/json-ast/x/ruby/ast.go
@@ -30,6 +30,34 @@ type Node struct {
 	Children []Node `json:"children,omitempty"`
 }
 
+// A small set of concrete node types used in the golden example. They simply
+// embed Node so the JSON representation keeps the same shape while giving the
+// Go compiler a richer type hierarchy.
+type (
+	ProgramNode             struct{ Node }
+	Comment                 struct{ Node }
+	Assignment              struct{ Node }
+	Call                    struct{ Node }
+	ArgumentList            struct{ Node }
+	Array                   struct{ Node }
+	Pair                    struct{ Node }
+	Identifier              struct{ Node }
+	Constant                struct{ Node }
+	Integer                 struct{ Node }
+	String                  struct{ Node }
+	StringContent           struct{ Node }
+	SimpleSymbol            struct{ Node }
+	HashKeySymbol           struct{ Node }
+	True                    struct{ Node }
+	Binary                  struct{ Node }
+	Begin                   struct{ Node }
+	DoBlock                 struct{ Node }
+	BlockParameters         struct{ Node }
+	BodyStatement           struct{ Node }
+	ElementReference        struct{ Node }
+	ParenthesizedStatements struct{ Node }
+)
+
 // Parse converts Ruby source code into a Node tree using tree-sitter.
 // Parse converts Ruby source code into a Node tree using tree-sitter.
 func Parse(src string) (*Node, error) {

--- a/tools/json-ast/x/ruby/inspect.go
+++ b/tools/json-ast/x/ruby/inspect.go
@@ -3,7 +3,7 @@ package ruby
 // Program represents a parsed Ruby source file.
 // Program is the JSON representation returned by Inspect.
 type Program struct {
-	Root *Node `json:"root"`
+	Root *ProgramNode `json:"root"`
 }
 
 // Inspect parses the given Ruby source code and returns a Program describing
@@ -13,5 +13,9 @@ func Inspect(src string) (*Program, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Program{Root: node}, nil
+	if node == nil {
+		return &Program{Root: nil}, nil
+	}
+	root := &ProgramNode{Node: *node}
+	return &Program{Root: root}, nil
 }


### PR DESCRIPTION
## Summary
- define concrete Ruby AST node types to enrich the Go type hierarchy
- wrap program root in the new `ProgramNode` type

## Testing
- `go test ./tools/json-ast/x/ruby -run TestInspect_Golden -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6889dbe7d4748320ba2f5cfe43503e7f