### PR TITLE
Refine Zig AST structs

### DIFF
--- a/tools/json-ast/x/zig/inspect.go
+++ b/tools/json-ast/x/zig/inspect.go
@@ -29,7 +29,7 @@ func Inspect(src string, opts ...Options) (*Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
-	node, ok := convertNode(tree.RootNode(), []byte(src), opt.Positions)
+	node, ok := convert(tree.RootNode(), []byte(src), opt.Positions)
 	if !ok {
 		return &Program{Root: SourceFile{}}, nil
 	}


### PR DESCRIPTION
## Summary
- expand Zig AST node types for richer structure
- rename converter helper and update inspector
- keep generated JSON files unchanged

## Testing
- `go test ./tools/json-ast/x/zig -run TestInspect_Golden -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6889dd3243208320b317892f08176f13