### PR TITLE
Update Erlang json-ast structs

### DIFF
--- a/tools/json-ast/x/erlang/ast.go
+++ b/tools/json-ast/x/erlang/ast.go
@@ -22,7 +22,42 @@ type Node struct {
 }
 
 // SourceFile is the root of an Erlang program.
-type SourceFile struct{ Node }
+// SourceFile is the root node for an Erlang source file.
+type SourceFile Node
+
+// The following aliases provide a slightly typed representation mirroring
+// tree-sitter's node kinds that appear in the golden tests.  Only nodes that
+// can carry a value are represented here to keep the structure minimal.
+type (
+	Error             Node
+	AnonymousFun      Node
+	Arity             Node
+	Atom              Node
+	BinaryOpExpr      Node
+	Call              Node
+	ClauseBody        Node
+	Comment           Node
+	ExportAttribute   Node
+	ExprArgs          Node
+	Fa                Node
+	FunClause         Node
+	FunDecl           Node
+	FunctionClause    Node
+	Generator         Node
+	Integer           Node
+	LcExprs           Node
+	List              Node
+	ListComprehension Node
+	MapExpr           Node
+	MapField          Node
+	MatchExpr         Node
+	ModuleAttribute   Node
+	ParenExpr         Node
+	Remote            Node
+	RemoteModule      Node
+	String            Node
+	Var               Node
+)
 
 // Option controls how the AST is generated.
 type Option struct {

--- a/tools/json-ast/x/erlang/inspect.go
+++ b/tools/json-ast/x/erlang/inspect.go
@@ -26,7 +26,7 @@ func InspectWithOption(src string, opt Option) (*Program, error) {
 	if root == nil {
 		return &Program{}, nil
 	}
-	return &Program{Root: &SourceFile{Node: *root}}, nil
+	return &Program{Root: (*SourceFile)(root)}, nil
 }
 
 // Inspect parses Erlang source code using tree-sitter and returns a Program.


### PR DESCRIPTION
## Summary
- add typed aliases for Erlang AST nodes
- adjust conversion to cast to `SourceFile` alias

## Testing
- `go test ./tools/json-ast/x/erlang -run TestInspectGolden -tags slow` *(fails: missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_6889deff0ed48320ac0d234ad5bb8641