### PR TITLE
Refine Haskell json-ast nodes

### DIFF
--- a/tools/json-ast/x/haskell/ast.go
+++ b/tools/json-ast/x/haskell/ast.go
@@ -20,6 +20,53 @@ type Node struct {
 	Children []Node `json:"children,omitempty"`
 }
 
+// Typed aliases for the node kinds that appear in the generated JSON.  These
+// give a slightly more structured view of the AST while still using Node under
+// the hood.
+type (
+	Haskell           Node
+	Pragma            Node
+	Imports           Node
+	Import            Node
+	Module            Node
+	ModuleID          Node
+	ImportList        Node
+	ImportName        Node
+	Comment           Node
+	Declarations      Node
+	DataType          Node
+	DataConstructors  Node
+	DataConstructor   Node
+	Record            Node
+	Constructor       Node
+	Fields            Node
+	Field             Node
+	FieldName         Node
+	FieldUpdate       Node
+	Name              Node
+	Variable          Node
+	Integer           Node
+	String            Node
+	Operator          Node
+	Unit              Node
+	Literal           Node
+	List              Node
+	ListComprehension Node
+	Match             Node
+	Bind              Node
+	Generator         Node
+	Patterns          Node
+	Apply             Node
+	Projection        Node
+	Exp               Node
+	Infix             Node
+	Lambda            Node
+	Do                Node
+	Signature         Node
+	Parens            Node
+	Qualifiers        Node
+)
+
 // convert transforms a tree-sitter node into the Node structure defined above.
 // Only named children are traversed to keep the result compact.
 func convert(n *sitter.Node, src []byte, pos bool) *Node {

--- a/tools/json-ast/x/haskell/inspect.go
+++ b/tools/json-ast/x/haskell/inspect.go
@@ -9,7 +9,7 @@ import (
 
 // Program represents a parsed Haskell module.
 type Program struct {
-	Root *Node `json:"root"`
+	Root *Haskell `json:"root"`
 }
 
 // Inspect parses the provided Haskell source code using tree-sitter and
@@ -29,5 +29,5 @@ func Inspect(src string, includePos ...bool) (*Program, error) {
 	if root == nil {
 		root = &Node{}
 	}
-	return &Program{Root: root}, nil
+	return &Program{Root: (*Haskell)(root)}, nil
 }


### PR DESCRIPTION
## Summary
- enrich Haskell json-ast node types with explicit struct aliases
- return typed root node in Program

## Testing
- `go test ./tools/json-ast/x/haskell -tags=slow -run TestInspect_Golden -args -update` *(failed: missing golden files)*
- `go test ./tools/json-ast/x/...`


------
https://chatgpt.com/codex/tasks/task_e_6889df59d17c8320b5a0567d14078be6