### PR TITLE
Refactor Haskell json-ast to use option

### DIFF
--- a/tools/json-ast/x/haskell/ast.go
+++ b/tools/json-ast/x/haskell/ast.go
@@ -20,6 +20,12 @@ type Node struct {
 	Children []Node `json:"children,omitempty"`
 }
 
+// Option controls how the AST is generated.
+type Option struct {
+	// Positions requests inclusion of positional information when true.
+	Positions bool
+}
+
 // Typed aliases for the node kinds that appear in the generated JSON.  These
 // give a slightly more structured view of the AST while still using Node under
 // the hood.
@@ -68,13 +74,14 @@ type (
 )
 
 // convert transforms a tree-sitter node into the Node structure defined above.
-// Only named children are traversed to keep the result compact.
-func convert(n *sitter.Node, src []byte, pos bool) *Node {
+// Only named children are traversed to keep the result compact. Position
+// information is recorded when opt.Positions is true.
+func convert(n *sitter.Node, src []byte, opt Option) *Node {
 	if n == nil {
 		return nil
 	}
 	node := &Node{Kind: n.Type()}
-	if pos {
+	if opt.Positions {
 		start := n.StartPoint()
 		end := n.EndPoint()
 		node.Start = int(start.Row) + 1
@@ -93,7 +100,7 @@ func convert(n *sitter.Node, src []byte, pos bool) *Node {
 	}
 
 	for i := 0; i < int(n.NamedChildCount()); i++ {
-		child := convert(n.NamedChild(i), src, pos)
+		child := convert(n.NamedChild(i), src, opt)
 		if child != nil {
 			node.Children = append(node.Children, *child)
 		}

--- a/tools/json-ast/x/haskell/inspect.go
+++ b/tools/json-ast/x/haskell/inspect.go
@@ -12,22 +12,23 @@ type Program struct {
 	Root *Haskell `json:"root"`
 }
 
-// Inspect parses the provided Haskell source code using tree-sitter and
-// returns its Program representation.
-func Inspect(src string, includePos ...bool) (*Program, error) {
+// InspectWithOption parses Haskell source code using tree-sitter and returns a Program.
+func InspectWithOption(src string, opt Option) (*Program, error) {
 	parser := sitter.NewParser()
 	parser.SetLanguage(sitter.NewLanguage(tsHaskell.Language()))
 	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
 	if err != nil {
 		return nil, err
 	}
-	pos := false
-	if len(includePos) > 0 && includePos[0] {
-		pos = true
-	}
-	root := convert(tree.RootNode(), []byte(src), pos)
+	root := convert(tree.RootNode(), []byte(src), opt)
 	if root == nil {
 		root = &Node{}
 	}
 	return &Program{Root: (*Haskell)(root)}, nil
+}
+
+// Inspect parses the provided Haskell source code using tree-sitter and
+// returns its Program representation without positional information by default.
+func Inspect(src string) (*Program, error) {
+	return InspectWithOption(src, Option{})
 }


### PR DESCRIPTION
## Summary
- add `Option` to control whether positions are included
- refactor `convert` and `Inspect` functions to accept `Option`
- keep JSON output minimal by skipping syntax-only leaves

## Testing
- `go test ./tools/json-ast/x/haskell`

------
https://chatgpt.com/codex/tasks/task_e_6889e96fb4608320957a8e27c0743e38